### PR TITLE
feat: implement database foundation (Phase 1)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,119 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *DB {
+	// Use in-memory database for tests
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	instance := &DB{db}
+	if err := instance.migrate(); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
+	return instance
+}
+
+func TestUpsertAndGetNotification(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	now := time.Now().Truncate(time.Second)
+	n := Notification{
+		GitHubID:           "123",
+		SubjectTitle:       "Test PR",
+		SubjectType:        "PullRequest",
+		Reason:             "author",
+		RepositoryFullName: "user/repo",
+		HTMLURL:            "https://github.com/user/repo/pull/1",
+		IsEnriched:         false,
+		UpdatedAt:          now,
+	}
+
+	// Test Insert
+	if err := db.UpsertNotification(n); err != nil {
+		t.Fatalf("UpsertNotification failed: %v", err)
+	}
+
+	// Test Retrieve
+	ns, err := db.GetNotification("123")
+	if err != nil {
+		t.Fatalf("GetNotification failed: %v", err)
+	}
+	if ns == nil {
+		t.Fatal("Notification not found")
+	}
+
+	if ns.GitHubID != n.GitHubID || ns.SubjectType != n.SubjectType {
+		t.Errorf("Expected %v, got %v", n, ns.Notification)
+	}
+
+	// Verify orbit_state was automatically created
+	if ns.Priority != 0 || ns.Status != "entry" {
+		t.Errorf("Unexpected orbit state: %+v", ns.OrbitState)
+	}
+
+	// Test Update Orbit State
+	newState := OrbitState{
+		NotificationID: "123",
+		Priority:       2,
+		Status:         "tracking",
+		IsReadLocally:  true,
+	}
+	if err := db.UpdateOrbitState(newState); err != nil {
+		t.Fatalf("UpdateOrbitState failed: %v", err)
+	}
+
+	ns2, _ := db.GetNotification("123")
+	if ns2.Priority != 2 || ns2.Status != "tracking" || !ns2.IsReadLocally {
+		t.Errorf("Orbit state not updated correctly: %+v", ns2.OrbitState)
+	}
+
+	// Test Upsert (Update)
+	n.SubjectTitle = "Updated PR Title"
+	if err := db.UpsertNotification(n); err != nil {
+		t.Fatalf("Upsert (Update) failed: %v", err)
+	}
+
+	ns3, _ := db.GetNotification("123")
+	if ns3.SubjectTitle != "Updated PR Title" {
+		t.Errorf("Title not updated: %s", ns3.SubjectTitle)
+	}
+	// Verify orbit state was preserved
+	if ns3.Priority != 2 {
+		t.Errorf("Orbit state lost during notification update")
+	}
+}
+
+func TestListNotifications(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	n1 := Notification{GitHubID: "1", SubjectTitle: "N1", SubjectType: "Issue", UpdatedAt: time.Now()}
+	n2 := Notification{GitHubID: "2", SubjectTitle: "N2", SubjectType: "PullRequest", UpdatedAt: time.Now().Add(time.Hour)}
+
+	_ = db.UpsertNotification(n1)
+	_ = db.UpsertNotification(n2)
+
+	list, err := db.ListNotifications()
+	if err != nil {
+		t.Fatalf("ListNotifications failed: %v", err)
+	}
+
+	if len(list) != 2 {
+		t.Errorf("Expected 2 notifications, got %d", len(list))
+	}
+
+	// Should be ordered by updated_at DESC
+	if list[0].GitHubID != "2" {
+		t.Errorf("Expected notification '2' first due to sorting")
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// migrate applies versioned schema updates.
+func (db *DB) migrate() error {
+	// 1. Create schema_version if not exists
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)`)
+	if err != nil {
+		return fmt.Errorf("failed to create schema_version table: %w", err)
+	}
+
+	// 2. Get current version
+	var currentVersion int
+	err = db.QueryRow("SELECT version FROM schema_version").Scan(&currentVersion)
+	if err == sql.ErrNoRows {
+		currentVersion = 0
+	} else if err != nil {
+		return fmt.Errorf("failed to get current schema version: %w", err)
+	}
+
+	// 3. Apply missing migrations
+	for i := currentVersion; i < len(migrations); i++ {
+		version := i + 1
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+
+		if _, err := tx.Exec(migrations[i]); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("migration to version %d failed: %w", version, err)
+		}
+
+		if currentVersion == 0 {
+			_, err = tx.Exec("INSERT INTO schema_version (version) VALUES (?)", version)
+		} else {
+			_, err = tx.Exec("UPDATE schema_version SET version = ?", version)
+		}
+
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to update schema version to %d: %w", version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -1,0 +1,115 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// UpsertNotification inserts or updates a notification and ensures orbit state exists.
+func (db *DB) UpsertNotification(n Notification) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// 1. Upsert notification
+	_, err = tx.Exec(`
+		INSERT INTO notifications (
+			github_id, subject_title, subject_type, reason, repository_full_name, html_url, is_enriched, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(github_id) DO UPDATE SET
+			subject_title = excluded.subject_title,
+			subject_type = excluded.subject_type,
+			reason = excluded.reason,
+			repository_full_name = excluded.repository_full_name,
+			html_url = excluded.html_url,
+			is_enriched = excluded.is_enriched,
+			updated_at = excluded.updated_at
+	`, n.GitHubID, n.SubjectTitle, n.SubjectType, n.Reason, n.RepositoryFullName, n.HTMLURL, n.IsEnriched, n.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("failed to upsert notification: %w", err)
+	}
+
+	// 2. Ensure orbit_state exists (do nothing if it does)
+	_, err = tx.Exec(`
+		INSERT INTO orbit_state (notification_id)
+		VALUES (?)
+		ON CONFLICT(notification_id) DO NOTHING
+	`, n.GitHubID)
+	if err != nil {
+		return fmt.Errorf("failed to ensure orbit state: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// GetNotification retrieves a notification and its local state.
+type NotificationWithState struct {
+	Notification
+	OrbitState
+}
+
+func (db *DB) GetNotification(id string) (*NotificationWithState, error) {
+	row := db.QueryRow(`
+		SELECT
+			n.github_id, n.subject_title, n.subject_type, n.reason, n.repository_full_name, n.html_url, n.is_enriched, n.updated_at,
+			s.priority, s.status, s.is_read_locally
+		FROM notifications n
+		JOIN orbit_state s ON n.github_id = s.notification_id
+		WHERE n.github_id = ?
+	`, id)
+
+	var ns NotificationWithState
+	err := row.Scan(
+		&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.IsEnriched, &ns.UpdatedAt,
+		&ns.Priority, &ns.Status, &ns.IsReadLocally,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ns, nil
+}
+
+// ListNotifications returns all notifications with their state.
+func (db *DB) ListNotifications() ([]NotificationWithState, error) {
+	rows, err := db.Query(`
+		SELECT
+			n.github_id, n.subject_title, n.subject_type, n.reason, n.repository_full_name, n.html_url, n.is_enriched, n.updated_at,
+			s.priority, s.status, s.is_read_locally
+		FROM notifications n
+		JOIN orbit_state s ON n.github_id = s.notification_id
+		ORDER BY n.updated_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []NotificationWithState
+	for rows.Next() {
+		var ns NotificationWithState
+		err := rows.Scan(
+			&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.IsEnriched, &ns.UpdatedAt,
+			&ns.Priority, &ns.Status, &ns.IsReadLocally,
+		)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, ns)
+	}
+	return results, nil
+}
+
+// UpdateOrbitState updates the local triage state.
+func (db *DB) UpdateOrbitState(state OrbitState) error {
+	_, err := db.Exec(`
+		UPDATE orbit_state
+		SET priority = ?, status = ?, is_read_locally = ?
+		WHERE notification_id = ?
+	`, state.Priority, state.Status, state.IsReadLocally, state.NotificationID)
+	return err
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -1,0 +1,26 @@
+package db
+
+// migrations define the versioned schema updates.
+var migrations = []string{
+	// Version 1: Initial schema
+	`CREATE TABLE IF NOT EXISTS schema_version (
+		version INTEGER PRIMARY KEY
+	);
+	CREATE TABLE IF NOT EXISTS notifications (
+		github_id TEXT PRIMARY KEY,
+		subject_title TEXT NOT NULL,
+		subject_type TEXT NOT NULL,
+		reason TEXT NOT NULL,
+		repository_full_name TEXT NOT NULL,
+		html_url TEXT,
+		is_enriched BOOLEAN DEFAULT FALSE,
+		updated_at DATETIME NOT NULL
+	);
+	CREATE TABLE IF NOT EXISTS orbit_state (
+		notification_id TEXT PRIMARY KEY,
+		priority INTEGER DEFAULT 0,
+		status TEXT DEFAULT 'entry',
+		is_read_locally BOOLEAN DEFAULT FALSE,
+		FOREIGN KEY (notification_id) REFERENCES notifications(github_id) ON DELETE CASCADE
+	);`,
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "modernc.org/sqlite"
+)
+
+// DB represents the database connection pool.
+type DB struct {
+	*sql.DB
+}
+
+// Open opens a connection to the SQLite database.
+func Open() (*DB, error) {
+	dbPath, err := resolveDBPath()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create parent directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create db directory: %w", err)
+	}
+
+	// modernc.org/sqlite driver
+	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)", dbPath)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	instance := &DB{db}
+	if err := instance.migrate(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return instance, nil
+}
+
+// resolveDBPath follows the XDG Base Directory specification.
+func resolveDBPath() (string, error) {
+	// Respect XDG_DATA_HOME if set, otherwise use os.UserConfigDir as a reliable base
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		// On macOS: ~/Library/Application Support/gh-orbit/
+		// On Linux: ~/.local/share/gh-orbit/
+		if os.Getenv("XDG_DATA_HOME") == "" {
+			// Fallback to platform-specific data dir
+			dataHome = filepath.Join(home, ".local", "share")
+		}
+	}
+
+	return filepath.Join(dataHome, "gh-orbit", "orbit.db"), nil
+}
+
+// Close closes the database connection.
+func (db *DB) Close() error {
+	return db.DB.Close()
+}

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1,0 +1,23 @@
+package db
+
+import "time"
+
+// Notification represents a GitHub notification record.
+type Notification struct {
+	GitHubID           string    `json:"id"`
+	SubjectTitle       string    `json:"subject_title"`
+	SubjectType        string    `json:"subject_type"`
+	Reason             string    `json:"reason"`
+	RepositoryFullName string    `json:"repository_full_name"`
+	HTMLURL            string    `json:"html_url"`
+	IsEnriched         bool      `json:"is_enriched"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+// OrbitState represents the local-first triage state for a notification.
+type OrbitState struct {
+	NotificationID string `json:"notification_id"`
+	Priority       int    `json:"priority"` // 0 to 3
+	Status         string `json:"status"`   // 'entry', 'tracking', 'archived'
+	IsReadLocally  bool   `json:"is_read_locally"`
+}


### PR DESCRIPTION
## Summary
Implementation of the core persistence layer for Phase 1.

## Changes
- CGO-free SQLite using `modernc.org/sqlite`
- Versioned migration engine in `internal/db/migrations.go`
- WAL mode and Foreign Keys enabled for concurrency
- Repository pattern in `internal/db/repository.go`
- Automated unit tests with in-memory SQLite
- XDG Base Directory specification compliance

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>