### PR TITLE
fix: update database path to XDG state directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Zero-Config**: Use `go-gh/v2` for auth; no manual PATs.
 - **Platform Native**: Follow XDG spec for persistence:
     - **Config**: `~/.config/gh/extensions/gh-orbit/`
-    - **Data/DB**: `~/.local/share/gh/extensions/gh-orbit/`
+    - **Data/DB/Logs**: `~/.local/state/gh-orbit/`
 - **Secure**: NEVER commit secrets/tokens. Redact sensitive data from logs.
 
 ## 2. Development Workflow

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -48,12 +48,17 @@ func Open(logger *slog.Logger) (*DB, error) {
 
 // resolveDBPath follows the XDG Base Directory specification.
 func resolveDBPath() (string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		// On macOS/Linux fallback to ~/.local/state
+		stateHome = filepath.Join(home, ".local", "state")
 	}
 
-	return filepath.Join(configDir, "gh-orbit", "orbit.db"), nil
+	return filepath.Join(stateHome, "gh-orbit", "orbit.db"), nil
 }
 
 // Close closes the database connection.


### PR DESCRIPTION
This PR moves the SQLite database from `os.UserConfigDir` to `~/.local/state/gh-orbit/` to unify storage with application logs and simplify troubleshooting.