### PR TITLE
chore: setup GEMINI.md for tool-specific mandates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 1. **Sync**: `git pull origin main`.
 2. **Plan**: Mandatory [Strategy Review](.agent/workflows/strategy-review/WORKFLOW.md). **SIGN-OFF** required before `internal/` or `cmd/` changes.
 3. **Branch**: `feat/` or `fix/`.
-4. **Code**: Conventional commits. Include "Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>".
+4. **Code**: Conventional commits. Include appropriate co-author attribution for the AI tool being used.
 5. **Validate**: MANDATORY local check: `make fmt lint build test`. Run `go mod tidy` on dependency changes.
 6. **PR**: `gh pr create --base main`. Address feedback.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,18 @@
+# Gemini CLI Mandates
+
+These instructions are foundational mandates and take absolute precedence.
+
+## 1. General Principles
+Refer to [AGENTS.md](AGENTS.md) for core project principles, tech stack, and development workflows.
+
+## 2. Gemini Specific Guidelines
+
+### 2.1 Commit Attribution
+Always include the following co-authored-by footer in commit messages:
+`Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>`
+
+### 2.2 Shell Safety
+Strictly follow the shell safety protocols defined in [.agent/rules/shell-safety.md](.agent/rules/shell-safety.md).
+
+### 2.3 Strategy Review
+Mandatory adherence to the [Strategy Review Workflow](.agent/workflows/strategy-review/WORKFLOW.md) before any changes to `internal/` or `cmd/`.


### PR DESCRIPTION
Moved Gemini-specific co-author attribution and mandates to GEMINI.md.
Generalize AGENTS.md for all AI tools.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>
Entire-Checkpoint: b1aaf98b0243
