### PR TITLE
feat: semantic indicators (Phase 4.9)

### DIFF
--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/dustin/go-humanize"
 	"github.com/hirakiuc/gh-orbit/internal/db"
 )
@@ -33,6 +34,24 @@ func (d itemDelegate) Height() int                               { return 2 }
 func (d itemDelegate) Spacing() int                              { return 0 }
 func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
 
+type semanticIcon struct {
+	icon     string
+	fallback string
+	style    func(s Styles) lipgloss.Style
+}
+
+var reasonIcons = map[string]semanticIcon{
+	"mention":          {"", "@", func(s Styles) lipgloss.Style { return s.Mention }},
+	"review_requested": {"", "R", func(s Styles) lipgloss.Style { return s.ReviewRequested }},
+	"author":           {"", "A", func(s Styles) lipgloss.Style { return s.Member }},
+	"assign":           {"", "G", func(s Styles) lipgloss.Style { return s.Assign }},
+	"security_alert":   {"", "!", func(s Styles) lipgloss.Style { return s.ActionRequired }},
+	"comment":          {"", "C", func(s Styles) lipgloss.Style { return s.Subscribed }},
+	"manual":           {"", "M", func(s Styles) lipgloss.Style { return s.Subscribed }},
+	"subscribed":       {"", "S", func(s Styles) lipgloss.Style { return s.Subscribed }},
+	"state_change":     {"", "X", func(s Styles) lipgloss.Style { return s.Subscribed }},
+}
+
 func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
 	i, ok := listItem.(item)
 	if !ok {
@@ -41,32 +60,49 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 	isSelected := index == m.Index()
 
-	// Indicator
+	// 1. Selection Indicator
 	indicator := "  "
 	if isSelected {
 		indicator = d.styles.Cursor.Render("▌ ")
 	}
 
-	// Type icon with fallback
-	icon := "•"
+	// 2. Unread Status Dot
+	statusDot := "  "
+	if !i.notification.IsReadLocally {
+		statusDot = d.styles.Unread.Render("• ")
+	}
+
+	// 3. Type Icon
+	typeIcon := "•"
 	switch i.notification.SubjectType {
 	case "PullRequest":
-		icon = "" // Nerd Font
+		typeIcon = ""
 	case "Issue":
-		icon = "" // Nerd Font
+		typeIcon = ""
 	case "Discussion":
-		icon = "" // Nerd Font
+		typeIcon = ""
 	}
 	// Fallback if Nerd Font is not available (common Unicode)
-	if !strings.ContainsAny(icon, "") {
+	if !strings.ContainsAny(typeIcon, "") {
 		switch i.notification.SubjectType {
 		case "PullRequest":
-			icon = "PR"
+			typeIcon = "PR"
 		case "Issue":
-			icon = "#"
+			typeIcon = "#"
 		case "Discussion":
-			icon = "D"
+			typeIcon = "D"
 		}
+	}
+	typeIconStr := d.styles.IconContainer.Render(typeIcon)
+
+	// 4. Reason Icon
+	reasonIcon := "  "
+	if si, ok := reasonIcons[i.notification.Reason]; ok {
+		icon := si.icon
+		if !strings.ContainsAny(icon, "") {
+			icon = si.fallback
+		}
+		reasonIcon = si.style(d.styles).Inherit(d.styles.IconContainer).Render(icon)
 	}
 
 	title := i.notification.SubjectTitle
@@ -74,7 +110,8 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		title = d.styles.SelectedTitle.Render(title)
 	}
 
-	str := fmt.Sprintf("%s %s %d. %s", indicator, icon, index+1, title)
+	// Stable Layout: [Selection] [Status] [Type] [Reason] [Index] [Title]
+	str := fmt.Sprintf("%s%s%s%s%d. %s", indicator, statusDot, typeIconStr, reasonIcon, index+1, title)
 
 	// Add priority indicator
 	priority := ""

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -16,6 +16,16 @@ type Styles struct {
 	Cursor              lipgloss.Style
 	SelectedTitle       lipgloss.Style
 	SelectedDescription lipgloss.Style
+
+	// Semantic colors for indicators
+	Mention         lipgloss.Style
+	ReviewRequested lipgloss.Style
+	ActionRequired  lipgloss.Style
+	Assign          lipgloss.Style
+	Member          lipgloss.Style
+	Subscribed      lipgloss.Style
+	Unread          lipgloss.Style
+	IconContainer   lipgloss.Style
 }
 
 // DefaultStyles returns the default styles for the application.
@@ -67,6 +77,27 @@ func DefaultStyles(isDark bool) Styles {
 
 	s.SelectedDescription = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#A0A0A0"))
+
+	// Semantic Indicators
+	if isDark {
+		s.Mention = lipgloss.NewStyle().Foreground(lipgloss.Color("#A371F7"))
+		s.ReviewRequested = lipgloss.NewStyle().Foreground(lipgloss.Color("#D29922"))
+		s.ActionRequired = lipgloss.NewStyle().Foreground(lipgloss.Color("#F85149"))
+		s.Assign = lipgloss.NewStyle().Foreground(lipgloss.Color("#3FB950"))
+		s.Member = lipgloss.NewStyle().Foreground(lipgloss.Color("#2F81F7"))
+		s.Subscribed = lipgloss.NewStyle().Foreground(lipgloss.Color("#8B949E"))
+		s.Unread = lipgloss.NewStyle().Foreground(lipgloss.Color("#58A6FF"))
+	} else {
+		s.Mention = lipgloss.NewStyle().Foreground(lipgloss.Color("#8957E5"))
+		s.ReviewRequested = lipgloss.NewStyle().Foreground(lipgloss.Color("#9E6A03"))
+		s.ActionRequired = lipgloss.NewStyle().Foreground(lipgloss.Color("#CF222E"))
+		s.Assign = lipgloss.NewStyle().Foreground(lipgloss.Color("#1A7F37"))
+		s.Member = lipgloss.NewStyle().Foreground(lipgloss.Color("#0969DA"))
+		s.Subscribed = lipgloss.NewStyle().Foreground(lipgloss.Color("#6E7781"))
+		s.Unread = lipgloss.NewStyle().Foreground(lipgloss.Color("#0969DA"))
+	}
+
+	s.IconContainer = lipgloss.NewStyle().Width(2)
 
 	return s
 }


### PR DESCRIPTION
This PR implements Phase 4.9 of the implementation plan:

- **Semantic Colors**: Added a new adaptive palette to `internal/tui/styles.go` to represent GitHub notification reasons (e.g., Purple for Mentions, Yellow for Review Requests).
- **Reason-to-Icon Mapping**: Implemented an efficient map-based lookup in `internal/tui/delegate.go` that maps notification reasons to Nerd Font icons with safe Unicode fallbacks.
- **Stable Horizontal Layout**: Introduced a fixed-width `IconContainer` to ensure that notification titles remain perfectly aligned regardless of the icons used.
- **Unread Status**: Added a colored status dot (`•`) to visually distinguish unread notifications in the list.
- **High Signal Triage**: The combination of Type Icon, Reason Icon, and Status Dot provides high-signal feedback, allowing users to triage their inbox at a glance.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>