### PR TITLE
feat: help menu enhancement (discoverable keybindings)

### DIFF
--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -24,15 +25,24 @@ func (i item) FilterValue() string {
 
 type itemDelegate struct {
 	styles Styles
+	keys   KeyMap
 }
 
-func newItemDelegate(s Styles) itemDelegate {
-	return itemDelegate{styles: s}
+func newItemDelegate(s Styles, k KeyMap) itemDelegate {
+	return itemDelegate{styles: s, keys: k}
 }
 
 func (d itemDelegate) Height() int                               { return 2 }
 func (d itemDelegate) Spacing() int                              { return 0 }
 func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
+
+func (d itemDelegate) ShortHelp() []key.Binding {
+	return d.keys.ShortHelp()
+}
+
+func (d itemDelegate) FullHelp() [][]key.Binding {
+	return d.keys.FullHelp()
+}
 
 type semanticIcon struct {
 	icon     string

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -1,0 +1,70 @@
+package tui
+
+import "charm.land/bubbles/v2/key"
+
+// KeyMap defines the custom keybindings for the gh-orbit TUI.
+type KeyMap struct {
+	Sync            key.Binding
+	SetPriorityLow  key.Binding
+	SetPriorityMed  key.Binding
+	SetPriorityHigh key.Binding
+	CopyURL         key.Binding
+	CheckoutPR      key.Binding
+	ViewPR          key.Binding
+	OpenBrowser     key.Binding
+}
+
+// DefaultKeyMap returns the default keybindings for the application.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Sync: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "sync"),
+		),
+		SetPriorityLow: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("1", "priority low"),
+		),
+		SetPriorityMed: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("2", "priority med"),
+		),
+		SetPriorityHigh: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("3", "priority high"),
+		),
+		CopyURL: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "copy url"),
+		),
+		CheckoutPR: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "checkout pr"),
+		),
+		ViewPR: key.NewBinding(
+			key.WithKeys("v"),
+			key.WithHelp("v", "view pr web"),
+		),
+		OpenBrowser: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "open in browser"),
+		),
+	}
+}
+
+// ShortHelp returns the keybindings to be displayed in the mini help view.
+func (k KeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		k.Sync,
+		k.OpenBrowser,
+	}
+}
+
+// FullHelp returns the keybindings to be displayed in the expanded help view.
+func (k KeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Sync, k.CopyURL, k.OpenBrowser},
+		{k.SetPriorityLow, k.SetPriorityMed, k.SetPriorityHigh},
+		{k.CheckoutPR, k.ViewPR},
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,7 @@ type Model struct {
 	logger  *slog.Logger
 	userID  string
 	styles  Styles
+	keys    KeyMap
 	err     error
 	status  string
 	spinner spinner.Model
@@ -29,7 +30,8 @@ type Model struct {
 
 func NewModel(database *db.DB, client *api.Client, userID string, cfg *config.Config, logger *slog.Logger) Model {
 	styles := DefaultStyles(true) // Default to dark theme
-	delegate := newItemDelegate(styles)
+	keys := DefaultKeyMap()
+	delegate := newItemDelegate(styles, keys)
 
 	l := list.New([]list.Item{}, delegate, 0, 0)
 	l.Title = "GitHub Orbit"
@@ -52,6 +54,7 @@ func NewModel(database *db.DB, client *api.Client, userID string, cfg *config.Co
 		logger:  logger,
 		userID:  userID,
 		styles:  styles,
+		keys:    keys,
 		spinner: s,
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -10,11 +10,13 @@ import (
 
 func TestModel_Update_SyncingState(t *testing.T) {
 	styles := DefaultStyles(true)
-	l := list.New([]list.Item{}, newItemDelegate(styles), 0, 0)
+	keys := DefaultKeyMap()
+	l := list.New([]list.Item{}, newItemDelegate(styles, keys), 0, 0)
 
 	m := &Model{
 		syncing: true,
 		list:    l,
+		keys:    keys,
 	}
 
 	// notificationsLoadedMsg should NOT reset syncing
@@ -42,11 +44,13 @@ func TestModel_Update_SyncingState(t *testing.T) {
 
 func TestModel_Update_ThemeChange(t *testing.T) {
 	styles := DefaultStyles(true)
-	l := list.New([]list.Item{}, newItemDelegate(styles), 0, 0)
+	keys := DefaultKeyMap()
+	l := list.New([]list.Item{}, newItemDelegate(styles, keys), 0, 0)
 
 	m := &Model{
 		styles: styles,
 		list:   l,
+		keys:   keys,
 	}
 
 	// Mock a light background color msg
@@ -60,10 +64,12 @@ func TestModel_Update_ThemeChange(t *testing.T) {
 
 func TestModel_Update_WindowSize(t *testing.T) {
 	styles := DefaultStyles(true)
-	l := list.New([]list.Item{}, newItemDelegate(styles), 0, 0)
+	keys := DefaultKeyMap()
+	l := list.New([]list.Item{}, newItemDelegate(styles, keys), 0, 0)
 
 	m := &Model{
 		list: l,
+		keys: keys,
 	}
 
 	// Mock window size msg

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
@@ -18,10 +19,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
+		// Only handle custom keys if the list isn't filtering
+		if m.list.FilterState() == list.Filtering {
+			break
+		}
+
+		switch {
+		case msg.String() == "ctrl+c" || msg.String() == "q":
 			return m, tea.Quit
-		case "r":
+		case key.Matches(msg, m.keys.Sync):
 			if m.syncing {
 				return m, nil
 			}
@@ -30,20 +36,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.syncNotifications(),
 				m.spinner.Tick,
 			)
-		case "y":
-			// Copy URL
+		case key.Matches(msg, m.keys.CopyURL):
 			if i, ok := m.list.SelectedItem().(item); ok && i.notification.HTMLURL != "" {
 				if isValidGitHubURL(i.notification.HTMLURL) {
 					return m, tea.SetClipboard(i.notification.HTMLURL)
 				}
 				m.err = fmt.Errorf("refusing to copy untrusted URL: %s", i.notification.HTMLURL)
 			}
-		case "enter":
+		case key.Matches(msg, m.keys.OpenBrowser):
 			if i, ok := m.list.SelectedItem().(item); ok && i.notification.HTMLURL != "" {
 				m.status = "Opening browser..."
 				return m, m.OpenBrowser(i.notification.HTMLURL)
 			}
-		case "c":
+		case key.Matches(msg, m.keys.CheckoutPR):
 			if i, ok := m.list.SelectedItem().(item); ok && i.notification.SubjectType == "PullRequest" {
 				prNumber := extractNumberFromURL(i.notification.SubjectURL)
 				if prNumber != "" {
@@ -52,7 +57,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.err = fmt.Errorf("could not extract PR number from URL: %s", i.notification.SubjectURL)
 			}
-		case "v":
+		case key.Matches(msg, m.keys.ViewPR):
 			if i, ok := m.list.SelectedItem().(item); ok && i.notification.SubjectType == "PullRequest" {
 				prNumber := extractNumberFromURL(i.notification.SubjectURL)
 				if prNumber != "" {
@@ -61,23 +66,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.err = fmt.Errorf("could not extract PR number from URL: %s", i.notification.SubjectURL)
 			}
-		case "1", "2", "3":
-			// Set priority
-			if i, ok := m.list.SelectedItem().(item); ok {
-				priority := int(msg.String()[0] - '0')
-				i.notification.Priority = priority
-				err := m.db.UpdateOrbitState(db.OrbitState{
-					NotificationID: i.notification.GitHubID,
-					Priority:       priority,
-					Status:         i.notification.Status,
-					IsReadLocally:  i.notification.IsReadLocally,
-				})
-				if err != nil {
-					m.err = err
-				}
-				// Refresh list item
-				m.list.SetItem(m.list.Index(), i)
-			}
+		case key.Matches(msg, m.keys.SetPriorityLow):
+			m.setPriority(1)
+		case key.Matches(msg, m.keys.SetPriorityMed):
+			m.setPriority(2)
+		case key.Matches(msg, m.keys.SetPriorityHigh):
+			m.setPriority(3)
 		}
 
 	case tea.WindowSizeMsg:
@@ -86,7 +80,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		m.styles = DefaultStyles(msg.IsDark())
 		m.list.Styles.Title = m.styles.Title
-		m.list.SetDelegate(newItemDelegate(m.styles))
+		m.list.SetDelegate(newItemDelegate(m.styles, m.keys))
 
 	case notificationsLoadedMsg:
 		items := make([]list.Item, len(msg))
@@ -126,6 +120,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) setPriority(priority int) {
+	if i, ok := m.list.SelectedItem().(item); ok {
+		i.notification.Priority = priority
+		err := m.db.UpdateOrbitState(db.OrbitState{
+			NotificationID: i.notification.GitHubID,
+			Priority:       priority,
+			Status:         i.notification.Status,
+			IsReadLocally:  i.notification.IsReadLocally,
+		})
+		if err != nil {
+			m.err = err
+		}
+		// Refresh list item
+		m.list.SetItem(m.list.Index(), i)
+	}
 }
 
 func isValidGitHubURL(url string) bool {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -90,12 +90,15 @@ func TestRenderFooter(t *testing.T) {
 
 func TestRenderList(t *testing.T) {
 	styles := DefaultStyles(true)
-	l := list.New([]list.Item{}, newItemDelegate(styles), 20, 10)
+	keys := DefaultKeyMap()
+	delegate := newItemDelegate(styles, keys)
+	l := list.New([]list.Item{}, delegate, 20, 10)
 	l.Title = "Test Title"
 
 	m := Model{
 		list:   l,
 		styles: styles,
+		keys:   keys,
 	}
 
 	rendered := m.renderList()
@@ -109,5 +112,13 @@ func TestRenderList(t *testing.T) {
 		if len(stripped) == 0 {
 			t.Errorf("renderList() returned empty string")
 		}
+	}
+
+	// Verify help content (short help should be at the bottom)
+	if !strings.Contains(stripped, "sync") {
+		t.Errorf("renderList() help should contain 'sync'")
+	}
+	if !strings.Contains(stripped, "open in browser") {
+		t.Errorf("renderList() help should contain 'open in browser'")
 	}
 }


### PR DESCRIPTION
This PR implements Phase 4.10 of the implementation plan:

- **Centralized KeyMap**: Introduced `internal/tui/keymap.go` to define all custom actions with semantic bindings and descriptive help text.
- **Discoverability**: Registered custom help with the list model via the `itemDelegate`, making triage (`r`, `1-3`, `y`) and integration (`Enter`, `c`, `v`) keys visible in the `?` menu.
- **Robust Input Handling**: Refactored the `Update()` loop to use `key.Matches`, ensuring consistent behavior between the UI and its documentation.
- **Verified Documentation**: Added automated tests to `view_test.go` to ensure that the custom help labels are correctly rendered.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>