### PR TITLE
feat: comprehensive status message management (Phase 4.12)

### DIFF
--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -66,7 +66,7 @@ func (m *Model) OpenBrowser(url string) tea.Cmd {
 			m.logger.Error("failed to open browser", "error", err)
 			return errMsg{err: err}
 		}
-		return nil
+		return actionCompleteMsg{}
 	}
 }
 
@@ -92,7 +92,7 @@ func (m *Model) CheckoutPR(repo, number string) tea.Cmd {
 			return errMsg{err: err}
 		}
 		m.logger.Info("checkout successful", "repo", repo, "number", number)
-		return nil
+		return actionCompleteMsg{}
 	})
 }
 
@@ -134,7 +134,7 @@ func (m *Model) ghViewCmd(ghCmd, repo, arg string) tea.Cmd {
 			m.logger.Error("gh view command failed", "command", ghCmd, "error", err)
 			return errMsg{err: err}
 		}
-		return nil
+		return actionCompleteMsg{}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -75,6 +75,8 @@ func (m *Model) Init() tea.Cmd {
 type (
 	notificationsLoadedMsg []db.NotificationWithState
 	syncCompleteMsg        []db.NotificationWithState
+	actionCompleteMsg      struct{}
+	clearStatusMsg         struct{}
 	errMsg                 struct{ err error }
 )
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"image/color"
 	"testing"
 
@@ -86,5 +87,38 @@ func TestModel_Update_WindowSize(t *testing.T) {
 
 	if newModel.list.Width() != width {
 		t.Errorf("expected list width %d, got %d", width, newModel.list.Width())
+	}
+}
+
+func TestModel_Update_StatusClearing(t *testing.T) {
+	styles := DefaultStyles(true)
+	keys := DefaultKeyMap()
+	l := list.New([]list.Item{}, newItemDelegate(styles, keys), 0, 0)
+
+	m := &Model{
+		status: "some status",
+		err:    fmt.Errorf("some error"),
+		list:   l,
+		keys:   keys,
+	}
+
+	// Test actionCompleteMsg
+	msgAction := actionCompleteMsg{}
+	updatedModel, _ := m.Update(msgAction)
+	newModel := updatedModel.(*Model)
+	if newModel.status != "" {
+		t.Error("expected status to be cleared after actionCompleteMsg")
+	}
+	if newModel.err != nil {
+		t.Error("expected err to be cleared after actionCompleteMsg")
+	}
+
+	// Test clearStatusMsg
+	m.status = "temporary status"
+	msgClear := clearStatusMsg{}
+	updatedModel, _ = m.Update(msgClear)
+	newModel = updatedModel.(*Model)
+	if newModel.status != "" {
+		t.Error("expected status to be cleared after clearStatusMsg")
 	}
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
@@ -37,7 +38,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.CopyURL):
 			if i, ok := m.list.SelectedItem().(item); ok && i.notification.HTMLURL != "" {
 				if isValidGitHubURL(i.notification.HTMLURL) {
-					return m, tea.SetClipboard(i.notification.HTMLURL)
+					m.status = "Copied URL to clipboard"
+					return m, tea.Batch(
+						tea.SetClipboard(i.notification.HTMLURL),
+						m.clearStatusAfter(3*time.Second),
+					)
 				}
 				m.err = fmt.Errorf("refusing to copy untrusted URL: %s", i.notification.HTMLURL)
 			}
@@ -96,6 +101,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case actionCompleteMsg:
+		m.status = ""
+		m.err = nil
+
+	case clearStatusMsg:
+		m.status = ""
+
 	case errMsg:
 		m.syncing = false
 		m.err = msg.err
@@ -130,6 +142,12 @@ func (m *Model) setPriority(priority int) {
 		// Refresh list item
 		m.list.SetItem(m.list.Index(), i)
 	}
+}
+
+func (m *Model) clearStatusAfter(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(_ time.Time) tea.Msg {
+		return clearStatusMsg{}
+	})
 }
 
 func isValidGitHubURL(url string) bool {


### PR DESCRIPTION
This PR implements Phase 4.12 of the implementation plan:

- **Robust Action Feedback**: External actions like `v` (View) and `Enter` (Open) now correctly clear their 'Opening...' status messages once the external process has successfully launched.
- **Timed Status Clearing**: Introduced a `clearStatusAfter` helper that uses `tea.Tick` to automatically remove temporary messages after a short delay.
- **Clipboard Polish**: The `y` key now provides immediate feedback ('Copied URL to clipboard') which is automatically cleared after 3 seconds.
- **Cleaner UI**: Successful completion of any action now automatically clears the previous error state (`m.err`), reducing visual clutter and user confusion.
- **Verified Stability**: Added unit tests to ensure that status and error fields are correctly reset by the new message handlers.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>