### PR TITLE
feat: triage undo and reset logic (Phase 4.15)

### DIFF
--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -8,6 +8,7 @@ type KeyMap struct {
 	SetPriorityLow  key.Binding
 	SetPriorityMed  key.Binding
 	SetPriorityHigh key.Binding
+	ClearPriority   key.Binding
 	CopyURL         key.Binding
 	ToggleRead      key.Binding
 	NextTab         key.Binding
@@ -35,6 +36,10 @@ func DefaultKeyMap() KeyMap {
 		SetPriorityHigh: key.NewBinding(
 			key.WithKeys("3"),
 			key.WithHelp("3", "priority high"),
+		),
+		ClearPriority: key.NewBinding(
+			key.WithKeys("0"),
+			key.WithHelp("0", "clear priority"),
 		),
 		CopyURL: key.NewBinding(
 			key.WithKeys("y"),
@@ -81,7 +86,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Sync, k.CopyURL, k.OpenBrowser, k.ViewContextual},
-		{k.SetPriorityLow, k.SetPriorityMed, k.SetPriorityHigh},
+		{k.SetPriorityLow, k.SetPriorityMed, k.SetPriorityHigh, k.ClearPriority},
 		{k.ToggleRead, k.NextTab, k.PrevTab, k.CheckoutPR},
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -171,6 +171,51 @@ func TestModel_MarkRead(t *testing.T) {
 	}
 }
 
+func TestModel_SetPriority(t *testing.T) {
+	styles := DefaultStyles(true)
+	keys := DefaultKeyMap()
+	testDB := setupTestDB(t)
+	defer func() { _ = testDB.Close() }()
+
+	l := list.New([]list.Item{
+		item{notification: db.NotificationWithState{
+			Notification: db.Notification{GitHubID: "test-id"},
+			OrbitState:   db.OrbitState{Priority: 0},
+		}},
+	}, newItemDelegate(styles, keys), 0, 0)
+
+	m := &Model{
+		list:             l,
+		db:               testDB,
+		logger:           slog.Default(),
+		allNotifications: []db.NotificationWithState{{Notification: db.Notification{GitHubID: "test-id"}, OrbitState: db.OrbitState{Priority: 0}}},
+	}
+
+	// 1. Set priority to 1
+	m.setPriority(1)
+	if m.allNotifications[0].Priority != 1 {
+		t.Errorf("expected priority 1, got %d", m.allNotifications[0].Priority)
+	}
+
+	// 2. Toggle priority 1 -> 0
+	m.setPriority(1)
+	if m.allNotifications[0].Priority != 0 {
+		t.Errorf("expected priority 0 after toggle, got %d", m.allNotifications[0].Priority)
+	}
+
+	// 3. Set priority to 3
+	m.setPriority(3)
+	if m.allNotifications[0].Priority != 3 {
+		t.Errorf("expected priority 3, got %d", m.allNotifications[0].Priority)
+	}
+
+	// 4. Explicit reset with 0
+	m.setPriority(0)
+	if m.allNotifications[0].Priority != 0 {
+		t.Errorf("expected priority 0 after explicit reset, got %d", m.allNotifications[0].Priority)
+	}
+}
+
 func TestModel_TabFiltering(t *testing.T) {
 	styles := DefaultStyles(true)
 	keys := DefaultKeyMap()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -77,11 +77,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.ViewItem(i)
 			}
 		case key.Matches(msg, m.keys.SetPriorityLow):
-			m.setPriority(1)
+			return m, m.setPriority(1)
 		case key.Matches(msg, m.keys.SetPriorityMed):
-			m.setPriority(2)
+			return m, m.setPriority(2)
 		case key.Matches(msg, m.keys.SetPriorityHigh):
-			m.setPriority(3)
+			return m, m.setPriority(3)
+		case key.Matches(msg, m.keys.ClearPriority):
+			return m, m.setPriority(0)
 		}
 
 	case tea.WindowSizeMsg:
@@ -133,8 +135,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-func (m *Model) setPriority(priority int) {
+func (m *Model) setPriority(priority int) tea.Cmd {
 	if i, ok := m.list.SelectedItem().(item); ok {
+		// Toggle logic: if already at this priority, reset to 0
+		if i.notification.Priority == priority {
+			priority = 0
+		}
+
 		i.notification.Priority = priority
 		err := m.db.UpdateOrbitState(db.OrbitState{
 			NotificationID: i.notification.GitHubID,
@@ -145,6 +152,19 @@ func (m *Model) setPriority(priority int) {
 		if err != nil {
 			m.err = err
 		}
+
+		// Update feedback
+		msg := "Priority cleared"
+		switch priority {
+		case 1:
+			msg = "Priority set to Low"
+		case 2:
+			msg = "Priority set to Medium"
+		case 3:
+			msg = "Priority set to High"
+		}
+		m.status = msg
+
 		// Update allNotifications master copy
 		for idx, n := range m.allNotifications {
 			if n.GitHubID == i.notification.GitHubID {
@@ -153,7 +173,10 @@ func (m *Model) setPriority(priority int) {
 			}
 		}
 		m.applyFilters()
+
+		return m.clearStatusAfter(3 * time.Second)
 	}
+	return nil
 }
 
 func (m *Model) applyFilters() {


### PR DESCRIPTION
This PR implements Phase 4.15 of the implementation plan:

- **Priority Reset**: Added the `0` key to allow users to explicitly clear any assigned priority from a notification.
- **Smart Toggle**: Pressing the same priority key (`1`, `2`, or `3`) on an already prioritized item now toggles it back to `0`. This follows common TUI idioms and reduces the number of keys to remember.
- **Immediate Feedback**: Users now get immediate confirmation in the status bar (e.g., 'Priority set to High' or 'Priority cleared'), which is automatically removed after 3 seconds.
- **Reactive Tabs**: Clearing or setting a priority immediately triggers a re-filter of the current tab (e.g., removing an item from 'Triaged' when its priority is cleared).
- **Verified Logic**: Comprehensive unit tests verify both explicit resets and the toggle behavior.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>