### PR TITLE
feat: fix read-state toggle inconsistency (Phase 4.16)

### DIFF
--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/cli/go-gh/v2/pkg/browser"
@@ -119,11 +120,19 @@ func (m *Model) MarkRead(i item) tea.Cmd {
 		return nil
 	}
 
-	// 1. Optimistic UI update
+	// 1. Update master copy
+	for idx, n := range m.allNotifications {
+		if n.GitHubID == i.notification.GitHubID {
+			m.allNotifications[idx].IsReadLocally = true
+			break
+		}
+	}
+
+	// 2. Optimistic UI update
 	i.notification.IsReadLocally = true
 	m.list.SetItem(m.list.Index(), i)
 
-	// 2. Persistent Local Update
+	// 3. Persistent Local Update
 	err := m.db.UpdateOrbitState(db.OrbitState{
 		NotificationID: i.notification.GitHubID,
 		Priority:       i.notification.Priority,
@@ -134,7 +143,9 @@ func (m *Model) MarkRead(i item) tea.Cmd {
 		m.logger.Error("failed to update local read state", "error", err)
 	}
 
-	// 3. Asynchronous Remote Sync
+	m.applyFilters()
+
+	// 4. Asynchronous Remote Sync
 	return func() tea.Msg {
 		err := m.client.MarkThreadAsRead(i.notification.GitHubID)
 		if err != nil {
@@ -150,11 +161,19 @@ func (m *Model) MarkRead(i item) tea.Cmd {
 func (m *Model) ToggleRead(i item) tea.Cmd {
 	newState := !i.notification.IsReadLocally
 
-	// 1. Update UI
+	// 1. Update master copy
+	for idx, n := range m.allNotifications {
+		if n.GitHubID == i.notification.GitHubID {
+			m.allNotifications[idx].IsReadLocally = newState
+			break
+		}
+	}
+
+	// 2. Update UI
 	i.notification.IsReadLocally = newState
 	m.list.SetItem(m.list.Index(), i)
 
-	// 2. Update DB
+	// 3. Update DB
 	err := m.db.UpdateOrbitState(db.OrbitState{
 		NotificationID: i.notification.GitHubID,
 		Priority:       i.notification.Priority,
@@ -165,15 +184,25 @@ func (m *Model) ToggleRead(i item) tea.Cmd {
 		m.err = err
 	}
 
-	// 3. Remote Sync (only if marking as read)
+	// 4. Status Feedback
+	m.status = "Marked as unread"
 	if newState {
-		return func() tea.Msg {
-			_ = m.client.MarkThreadAsRead(i.notification.GitHubID)
-			return nil
-		}
+		m.status = "Marked as read"
 	}
 
-	return nil
+	m.applyFilters()
+
+	// 5. Remote Sync + Timed Clear
+	var cmds []tea.Cmd
+	cmds = append(cmds, m.clearStatusAfter(3*time.Second))
+	if newState {
+		cmds = append(cmds, func() tea.Msg {
+			_ = m.client.MarkThreadAsRead(i.notification.GitHubID)
+			return nil
+		})
+	}
+
+	return tea.Batch(cmds...)
 }
 
 // ViewPRWeb executes 'gh pr view --web' for the given repo and PR number.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -150,10 +150,15 @@ func TestModel_MarkRead(t *testing.T) {
 	defer func() { _ = testDB.Close() }()
 
 	m := &Model{
-		list:   l,
-		db:     testDB,
-		logger: slog.Default(),
+		list:             l,
+		db:               testDB,
+		logger:           slog.Default(),
+		allNotifications: []db.NotificationWithState{{Notification: db.Notification{GitHubID: "test-id"}, OrbitState: db.OrbitState{IsReadLocally: false}}},
+		activeTab:        TabAll,
 	}
+
+	// Populate the list
+	m.applyFilters()
 
 	// Initial state
 	i := m.list.Items()[0].(item)
@@ -164,10 +169,15 @@ func TestModel_MarkRead(t *testing.T) {
 	// Mark as read
 	m.MarkRead(i)
 
-	// Verify optimistic update
+	// Verify optimistic update in list
 	updatedItem := m.list.Items()[0].(item)
 	if !updatedItem.notification.IsReadLocally {
-		t.Error("expected notification to be marked as read optimistically")
+		t.Error("expected notification to be marked as read optimistically in list")
+	}
+
+	// Verify synchronization in allNotifications
+	if !m.allNotifications[0].IsReadLocally {
+		t.Error("expected allNotifications[0] to be marked as read")
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -48,9 +48,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, m.keys.ToggleRead):
 			if i, ok := m.list.SelectedItem().(item); ok {
-				cmd := m.ToggleRead(i)
-				m.applyFilters()
-				return m, cmd
+				cmds = append(cmds, m.ToggleRead(i))
 			}
 		case key.Matches(msg, m.keys.NextTab):
 			m.activeTab = (m.activeTab + 1) % 4


### PR DESCRIPTION
This PR implements Phase 4.16 of the implementation plan:

- **State Persistence**: Resolved a bug where read-state changes were lost when switching tabs or re-filtering. Actions now correctly update the `allNotifications` master copy.
- **Immediate Toggling**: Toggling an item as read/unread now immediately re-filters the current view, ensuring the 'Inbox' and 'Unread' tabs are always accurate.
- **Visual Feedback**: Added immediate status bar confirmation (e.g., 'Marked as read'), which is automatically cleared after 3 seconds.
- **Code Quality**: Standardized the `Update` loop to use a consistent command collection pattern and improved unit test robustness to prevent regressions in state management.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>