### PR TITLE
feat: Phase 5.10 - Live Resource Status

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -12,9 +12,10 @@ import (
 
 // EnrichmentResult holds the fetched details for a notification.
 type EnrichmentResult struct {
-	Body    string
-	HTMLURL string
-	Author  string
+	Body          string
+	HTMLURL       string
+	Author        string
+	ResourceState string
 }
 
 // EnrichmentEngine handles fetching and caching of notification details.
@@ -51,6 +52,9 @@ func (e *EnrichmentEngine) FetchDetail(u string, subjectType string) (Enrichment
 	path := strings.TrimPrefix(u, e.client.BaseURL())
 
 	var data struct {
+		State   string `json:"state"`
+		Merged  bool   `json:"merged"`
+		Draft   bool   `json:"draft"`
 		Body    string `json:"body"`
 		HTMLURL string `json:"html_url"`
 		User    struct {
@@ -73,6 +77,20 @@ func (e *EnrichmentEngine) FetchDetail(u string, subjectType string) (Enrichment
 		Body:    data.Body,
 		Author:  data.User.Login,
 		HTMLURL: data.HTMLURL,
+	}
+
+	// Calculate Resource State
+	if data.State != "" {
+		if data.Merged {
+			res.ResourceState = "Merged"
+		} else if data.Draft {
+			res.ResourceState = "Draft"
+		} else {
+			// Title case the state (open -> Open, closed -> Closed)
+			if len(data.State) > 0 {
+				res.ResourceState = strings.ToUpper(data.State[:1]) + strings.ToLower(data.State[1:])
+			}
+		}
 	}
 
 	// Handle specific types
@@ -103,7 +121,7 @@ func (e *EnrichmentEngine) GetEnrichmentCmd(id, u, subjectType string, successMs
 		}
 
 		// Persist to DB
-		err = e.db.EnrichNotification(id, res.Body, res.Author, res.HTMLURL)
+		err = e.db.EnrichNotification(id, res.Body, res.Author, res.HTMLURL, res.ResourceState)
 		if err != nil {
 			return errorMsg(err)
 		}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -168,3 +168,35 @@ func TestListNotifications(t *testing.T) {
 		t.Errorf("Expected notification '2' first due to sorting")
 	}
 }
+
+func TestEnrichNotification(t *testing.T) {
+	db := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	id := "enrich-test"
+	n := Notification{
+		GitHubID:     id,
+		SubjectTitle: "PR",
+		UpdatedAt:    time.Now(),
+	}
+	_ = db.UpsertNotification(n)
+
+	// Enrich
+	err := db.EnrichNotification(id, "Body Content", "author-1", "https://github.com/url", "Merged")
+	if err != nil {
+		t.Fatalf("EnrichNotification failed: %v", err)
+	}
+
+	// Verify
+	ns, err := db.GetNotification(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ns.Body != "Body Content" || ns.AuthorLogin != "author-1" || ns.ResourceState != "Merged" {
+		t.Errorf("Enrichment failed to persist correctly: %+v", ns)
+	}
+	if !ns.IsEnriched {
+		t.Error("expected IsEnriched to be true")
+	}
+}

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -45,15 +45,16 @@ func (db *DB) UpsertMetadata(n Notification) error {
 }
 
 // EnrichNotification updates a notification with detailed content (body, author).
-func (db *DB) EnrichNotification(id, body, author, htmlURL string) error {
+func (db *DB) EnrichNotification(id, body, author, htmlURL, resourceState string) error {
 	_, err := db.Exec(`
 		UPDATE notifications
 		SET body = ?,
 		    author_login = ?,
 		    html_url = COALESCE(NULLIF(?, ''), html_url),
+		    resource_state = ?,
 		    is_enriched = TRUE
 		WHERE github_id = ?
-	`, body, author, htmlURL, id)
+	`, body, author, htmlURL, resourceState, id)
 	if err != nil {
 		return fmt.Errorf("failed to enrich notification: %w", err)
 	}
@@ -74,7 +75,7 @@ type NotificationWithState struct {
 func (db *DB) GetNotification(id string) (*NotificationWithState, error) {
 	row := db.QueryRow(`
 		SELECT
-			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url, COALESCE(n.body, ''), COALESCE(n.author_login, ''), n.is_enriched, n.updated_at,
+			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url, COALESCE(n.body, ''), COALESCE(n.author_login, ''), COALESCE(n.resource_state, ''), n.is_enriched, n.updated_at,
 			s.priority, s.status, s.is_read_locally
 		FROM notifications n
 		JOIN orbit_state s ON n.github_id = s.notification_id
@@ -83,7 +84,7 @@ func (db *DB) GetNotification(id string) (*NotificationWithState, error) {
 
 	var ns NotificationWithState
 	err := row.Scan(
-		&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.Body, &ns.AuthorLogin, &ns.IsEnriched, &ns.UpdatedAt,
+		&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.IsEnriched, &ns.UpdatedAt,
 		&ns.Priority, &ns.Status, &ns.IsReadLocally,
 	)
 	if err == sql.ErrNoRows {
@@ -99,7 +100,7 @@ func (db *DB) GetNotification(id string) (*NotificationWithState, error) {
 func (db *DB) ListNotifications() ([]NotificationWithState, error) {
 	rows, err := db.Query(`
 		SELECT
-			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url, COALESCE(n.body, ''), COALESCE(n.author_login, ''), n.is_enriched, n.updated_at,
+			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url, COALESCE(n.body, ''), COALESCE(n.author_login, ''), COALESCE(n.resource_state, ''), n.is_enriched, n.updated_at,
 			s.priority, s.status, s.is_read_locally
 		FROM notifications n
 		JOIN orbit_state s ON n.github_id = s.notification_id
@@ -114,7 +115,7 @@ func (db *DB) ListNotifications() ([]NotificationWithState, error) {
 	for rows.Next() {
 		var ns NotificationWithState
 		err := rows.Scan(
-			&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.Body, &ns.AuthorLogin, &ns.IsEnriched, &ns.UpdatedAt,
+			&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL, &ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.IsEnriched, &ns.UpdatedAt,
 			&ns.Priority, &ns.Status, &ns.IsReadLocally,
 		)
 		if err != nil {

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -40,4 +40,6 @@ var migrations = []string{
 	// Version 4: Add body and author_login for detail view
 	`ALTER TABLE notifications ADD COLUMN body TEXT DEFAULT '';
 	 ALTER TABLE notifications ADD COLUMN author_login TEXT DEFAULT '';`,
+	// Version 5: Add resource_state for live status (Open, Merged, etc.)
+	`ALTER TABLE notifications ADD COLUMN resource_state TEXT DEFAULT '';`,
 }

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -16,6 +16,7 @@ type Notification struct {
 	HTMLURL            string    `json:"html_url"`
 	Body               string    `json:"body"`
 	AuthorLogin        string    `json:"author_login"`
+	ResourceState      string    `json:"resource_state"`
 	IsEnriched         bool      `json:"is_enriched"`
 	UpdatedAt          time.Time `json:"updated_at"`
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -257,16 +257,17 @@ func (m *Model) FetchDetailCmd(id, u, subjectType string) tea.Cmd {
 		}
 
 		// Update database with granular enrich method
-		err = m.db.EnrichNotification(id, res.Body, res.Author, res.HTMLURL)
+		err = m.db.EnrichNotification(id, res.Body, res.Author, res.HTMLURL, res.ResourceState)
 		if err != nil {
 			return errMsg{err: err}
 		}
 
 		return detailLoadedMsg{
-			GitHubID: id,
-			Body:     res.Body,
-			Author:   res.Author,
-			HTMLURL:  res.HTMLURL,
+			GitHubID:      id,
+			Body:          res.Body,
+			Author:        res.Author,
+			HTMLURL:       res.HTMLURL,
+			ResourceState: res.ResourceState,
 		}
 	}
 }

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -83,7 +83,35 @@ func RenderTargetHeader(ctx RenderContext, n db.NotificationWithState, filter st
 		title = ctx.Styles.SelectedTitle.Render(title)
 	}
 
-	// 4. Reason Badge
+	// 4. Resource Status Badge (Draft, Open, Merged, etc.)
+	statusBadge := ""
+	if n.ResourceState != "" {
+		style := ctx.Styles.StateDraft
+		icon := ""
+		switch n.ResourceState {
+		case "Open":
+			style = ctx.Styles.StateOpen
+			icon = " "
+		case "Merged":
+			style = ctx.Styles.StateMerged
+			icon = " "
+		case "Closed":
+			style = ctx.Styles.StateClosed
+			icon = " "
+		case "Draft":
+			style = ctx.Styles.StateDraft
+			icon = " "
+		}
+		
+		// Fixed-width container (width: 12) to prevent title jumping
+		badgeText := fmt.Sprintf("%s[%s]", icon, n.ResourceState)
+		statusBadge = style.Width(12).Align(lipgloss.Left).Render(badgeText)
+	} else {
+		// Empty space to maintain layout stability
+		statusBadge = lipgloss.NewStyle().Width(12).Render("")
+	}
+
+	// 5. Reason Badge
 	badge := ""
 	if si, ok := reasonIcons[n.Reason]; ok {
 		style := si.style(ctx.Styles)
@@ -93,7 +121,7 @@ func RenderTargetHeader(ctx RenderContext, n db.NotificationWithState, filter st
 			Render(badgeText)
 	}
 
-	return fmt.Sprintf("%s%s %s  %s", iconStr, statusDot, title, badge)
+	return fmt.Sprintf("%s%s %s %s %s", iconStr, statusDot, statusBadge, title, badge)
 }
 
 func highlightMatches(ctx RenderContext, text, filter string) string {

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -18,7 +18,7 @@ type item struct {
 func (i item) Title() string       { return i.notification.SubjectTitle }
 func (i item) Description() string { return i.notification.RepositoryFullName }
 func (i item) FilterValue() string {
-	return i.notification.SubjectTitle + " " + i.notification.RepositoryFullName
+	return i.notification.SubjectTitle + " " + i.notification.RepositoryFullName + " " + i.notification.ResourceState
 }
 
 type itemDelegate struct {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -101,10 +101,11 @@ type (
 	actionCompleteMsg      struct{}
 	clearStatusMsg         struct{}
 	detailLoadedMsg        struct {
-		GitHubID string
-		Body     string
-		Author   string
-		HTMLURL  string
+		GitHubID      string
+		Body          string
+		Author        string
+		HTMLURL       string
+		ResourceState string
 	}
 	errMsg struct{ err error }
 )

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -43,6 +43,12 @@ type Styles struct {
 	ScrollbarThumb lipgloss.Style
 	FilterChip     lipgloss.Style
 
+	// Resource States
+	StateOpen   lipgloss.Style
+	StateMerged lipgloss.Style
+	StateClosed lipgloss.Style
+	StateDraft  lipgloss.Style
+
 	// Search
 	FuzzyMatch lipgloss.Style
 }
@@ -173,6 +179,24 @@ func DefaultStyles(isDark bool) Styles {
 		Foreground(accent).
 		Bold(true).
 		Underline(true)
+
+	// Resource States (Desaturated Professional Palette)
+	openColor := lipgloss.Color("#2EA043")   // Dark
+	mergedColor := lipgloss.Color("#8957E5") // Dark
+	closedColor := lipgloss.Color("#F85149") // Dark
+	draftColor := lipgloss.Color("#8B949E")  // Dark
+
+	if !isDark {
+		openColor = lipgloss.Color("#1A7F37")
+		mergedColor = lipgloss.Color("#6E39D1")
+		closedColor = lipgloss.Color("#D1242F")
+		draftColor = lipgloss.Color("#6E7781")
+	}
+
+	s.StateOpen = lipgloss.NewStyle().Padding(0, 1).Foreground(openColor)
+	s.StateMerged = lipgloss.NewStyle().Padding(0, 1).Foreground(mergedColor)
+	s.StateClosed = lipgloss.NewStyle().Padding(0, 1).Foreground(closedColor)
+	s.StateDraft = lipgloss.NewStyle().Padding(0, 1).Foreground(draftColor)
 
 	return s
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -59,6 +59,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.allNotifications[idx].Body = msg.Body
 				m.allNotifications[idx].AuthorLogin = msg.Author
 				m.allNotifications[idx].HTMLURL = msg.HTMLURL
+				m.allNotifications[idx].ResourceState = msg.ResourceState
 				m.allNotifications[idx].IsEnriched = true
 				break
 			}
@@ -150,12 +151,14 @@ func (m *Model) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {
 							i.notification.SubjectType,
 							func(res api.EnrichmentResult) tea.Msg {
 								return detailLoadedMsg{
-									GitHubID: i.notification.GitHubID,
-									Body:     res.Body,
-									Author:   res.Author,
-									HTMLURL:  res.HTMLURL,
+									GitHubID:      i.notification.GitHubID,
+									Body:          res.Body,
+									Author:        res.Author,
+									HTMLURL:       res.HTMLURL,
+									ResourceState: res.ResourceState,
 								}
 							},
+
 							func(err error) tea.Msg { return errMsg{err: err} },
 						),
 					)


### PR DESCRIPTION
This PR implements Phase 5.10 of the roadmap, significantly improving triaging intelligence by displaying the live status of PRs and Issues directly in the TUI.

### **Core Changes:**
- **Local Persistence**: Added a `resource_state` column to the database (Migration v5) to ensure statuses are rendered instantly after the first enrichment.
- **API Enrichment**: The `EnrichmentEngine` now correctly calculates the composite state (taking into account `merged` and `draft` flags) whenever a notification is peeked.
- **Professional TUI Badges**: 
    - Added color-coded, desaturated badges for `Open` (Green), `Merged` (Purple), `Closed` (Red), and `Draft` (Grey).
    - Included Nerd Font icons for better visual scanning and accessibility.
    - Used fixed-width containers to prevent 'UI Jitter' during asynchronous updates.
- **Status Search**: You can now type 'merged' or 'draft' in the list filter (`/`) to instantly find specific resources.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>