### PR TITLE
feat: Phase 5.11 - TUI Visual Polish

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -11,8 +11,9 @@ import (
 
 // RenderContext holds shared configuration for component rendering.
 type RenderContext struct {
-	Styles Styles
-	Width  int
+	Styles     Styles
+	Width      int
+	IsFetching bool
 }
 
 type semanticIcon struct {
@@ -69,23 +70,17 @@ func RenderTargetHeader(ctx RenderContext, n db.NotificationWithState, filter st
 		statusDot = ctx.Styles.Unread.Render("•")
 	}
 
-	// 3. Title + #ID
-	title := n.SubjectTitle
-	number := extractNumberFromURL(n.SubjectURL)
-	if number != "" {
-		title = fmt.Sprintf("%s #%s", title, number)
-	}
-
-	// Highlight matches
-	if filter != "" {
-		title = highlightMatches(ctx, title, filter)
-	} else if isSelected {
-		title = ctx.Styles.SelectedTitle.Render(title)
-	}
-
-	// 4. Resource Status Badge (Draft, Open, Merged, etc.)
+	// 3. Status Badge (Smooth Transition Layout)
+	badgeWidth := 12
 	statusBadge := ""
-	if n.ResourceState != "" {
+	hasBadge := false
+
+	if ctx.IsFetching {
+		// State 1: Fetching (Skeleton)
+		statusBadge = ctx.Styles.StateSkeleton.Width(badgeWidth).Align(lipgloss.Left).Render(" [LOADING] ")
+		hasBadge = true
+	} else if n.ResourceState != "" {
+		// State 2: Enriched
 		style := ctx.Styles.StateDraft
 		icon := ""
 		switch n.ResourceState {
@@ -102,26 +97,51 @@ func RenderTargetHeader(ctx RenderContext, n db.NotificationWithState, filter st
 			style = ctx.Styles.StateDraft
 			icon = " "
 		}
-		
-		// Fixed-width container (width: 12) to prevent title jumping
 		badgeText := fmt.Sprintf("%s[%s]", icon, n.ResourceState)
-		statusBadge = style.Width(12).Align(lipgloss.Left).Render(badgeText)
-	} else {
-		// Empty space to maintain layout stability
-		statusBadge = lipgloss.NewStyle().Width(12).Render("")
+		statusBadge = style.Width(badgeWidth).Align(lipgloss.Left).Render(badgeText)
+		hasBadge = true
+	}
+
+	// 4. Title + #ID (with Adaptive Truncation)
+	title := n.SubjectTitle
+	number := extractNumberFromURL(n.SubjectURL)
+	if number != "" {
+		title = fmt.Sprintf("%s #%s", title, number)
+	}
+
+	// Calculate available width for title
+	// 4 (icon+dot) + (12 if badge) + extra padding
+	occupied := 6
+	if hasBadge {
+		occupied += badgeWidth + 1
+	}
+	avail := ctx.Width - occupied
+	if avail < 10 {
+		avail = 10
+	}
+	title = truncateString(title, avail)
+
+	// Highlight matches
+	if filter != "" {
+		title = highlightMatches(ctx, title, filter)
+	} else if isSelected {
+		title = ctx.Styles.SelectedTitle.Render(title)
 	}
 
 	// 5. Reason Badge
-	badge := ""
+	reasonBadge := ""
 	if si, ok := reasonIcons[n.Reason]; ok {
 		style := si.style(ctx.Styles)
 		badgeText := strings.ToUpper(strings.ReplaceAll(n.Reason, "_", " "))
-		badge = style.
+		reasonBadge = style.
 			Padding(0, 1).
 			Render(badgeText)
 	}
 
-	return fmt.Sprintf("%s%s %s %s %s", iconStr, statusDot, statusBadge, title, badge)
+	if hasBadge {
+		return fmt.Sprintf("%s%s %s %s %s", iconStr, statusDot, statusBadge, title, reasonBadge)
+	}
+	return fmt.Sprintf("%s%s %s %s", iconStr, statusDot, title, reasonBadge)
 }
 
 func highlightMatches(ctx RenderContext, text, filter string) string {
@@ -132,4 +152,14 @@ func highlightMatches(ctx RenderContext, text, filter string) string {
 
 	// sahilm/fuzzy returns indices for the first match
 	return lipgloss.StyleRunes(text, matches[0].MatchedIndexes, ctx.Styles.FuzzyMatch, ctx.Styles.SelectedTitle)
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen < 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
 }

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -22,8 +22,9 @@ func (i item) FilterValue() string {
 }
 
 type itemDelegate struct {
-	styles Styles
-	keys   KeyMap
+	styles     Styles
+	keys       KeyMap
+	IsFetching bool
 }
 
 func newItemDelegate(s Styles, k KeyMap) itemDelegate {
@@ -58,8 +59,9 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 	// 2. Target Identity Header (Icon + Title + #ID + Badge)
 	ctx := RenderContext{
-		Styles: d.styles,
-		Width:  m.Width(),
+		Styles:     d.styles,
+		Width:      m.Width(),
+		IsFetching: isSelected && d.IsFetching,
 	}
 	header := RenderTargetHeader(ctx, i.notification, m.FilterValue(), isSelected)
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -38,6 +38,7 @@ type Model struct {
 	userID           string
 	styles           Styles
 	keys             KeyMap
+	delegate         itemDelegate
 	activeTab        int
 	allNotifications []db.NotificationWithState
 	err              error
@@ -77,6 +78,7 @@ func NewModel(database *db.DB, client *api.Client, userID string, cfg *config.Co
 		userID:   userID,
 		styles:   styles,
 		keys:     keys,
+		delegate: delegate,
 		viewport: vp,
 		isDark:   true,
 		state:    StateList,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/hirakiuc/gh-orbit/internal/db"
 	_ "modernc.org/sqlite"
 )
@@ -143,5 +144,43 @@ func TestModel_Navigation(t *testing.T) {
 	_, cmd := m.Update(msgQ)
 	if cmd == nil {
 		t.Fatal("expected quit command, got nil")
+	}
+}
+
+func TestRenderTargetHeader_Geometry(t *testing.T) {
+	styles := DefaultStyles(true)
+	ctx := RenderContext{
+		Styles: styles,
+		Width:  80,
+	}
+	notif := db.NotificationWithState{
+		Notification: db.Notification{
+			SubjectTitle: "A very long title that should be truncated when a badge is present",
+			SubjectType:  "PullRequest",
+		},
+	}
+
+	// 1. Un-enriched (No badge, maximum density)
+	h1 := RenderTargetHeader(ctx, notif, "", false)
+	w1 := lipgloss.Width(h1)
+
+	// 2. Fetching (Skeleton badge)
+	ctx.IsFetching = true
+	h2 := RenderTargetHeader(ctx, notif, "", false)
+	w2 := lipgloss.Width(h2)
+
+	// 3. Enriched (Status badge)
+	ctx.IsFetching = false
+	notif.ResourceState = "Merged"
+	h3 := RenderTargetHeader(ctx, notif, "", false)
+	w3 := lipgloss.Width(h3)
+
+	if w1 >= w2 {
+		t.Errorf("expected un-enriched header width %d to be less than skeleton header width %d", w1, w2)
+	}
+
+	// Skeleton and Enriched should have stable geometry
+	if w2 != w3 {
+		t.Errorf("expected skeleton width %d and enriched width %d to be same", w2, w3)
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -44,10 +44,11 @@ type Styles struct {
 	FilterChip     lipgloss.Style
 
 	// Resource States
-	StateOpen   lipgloss.Style
-	StateMerged lipgloss.Style
-	StateClosed lipgloss.Style
-	StateDraft  lipgloss.Style
+	StateOpen     lipgloss.Style
+	StateMerged   lipgloss.Style
+	StateClosed   lipgloss.Style
+	StateDraft    lipgloss.Style
+	StateSkeleton lipgloss.Style
 
 	// Search
 	FuzzyMatch lipgloss.Style
@@ -181,22 +182,45 @@ func DefaultStyles(isDark bool) Styles {
 		Underline(true)
 
 	// Resource States (Desaturated Professional Palette)
-	openColor := lipgloss.Color("#2EA043")   // Dark
-	mergedColor := lipgloss.Color("#8957E5") // Dark
-	closedColor := lipgloss.Color("#F85149") // Dark
-	draftColor := lipgloss.Color("#8B949E")  // Dark
+	openBG := lipgloss.Color("#1B3A24")
+	openFG := lipgloss.Color("#3FB950")
+
+	mergedBG := lipgloss.Color("#2D1F4D")
+	mergedFG := lipgloss.Color("#A371F7")
+
+	closedBG := lipgloss.Color("#351D22")
+	closedFG := lipgloss.Color("#F85149")
+
+	draftBG := lipgloss.Color("#21262D")
+	draftFG := lipgloss.Color("#8B949E")
+
+	skeletonBG := lipgloss.Color("#21262D")
+	skeletonFG := lipgloss.Color("#484F58")
 
 	if !isDark {
-		openColor = lipgloss.Color("#1A7F37")
-		mergedColor = lipgloss.Color("#6E39D1")
-		closedColor = lipgloss.Color("#D1242F")
-		draftColor = lipgloss.Color("#6E7781")
+		openBG = lipgloss.Color("#DAFBE1")
+		openFG = lipgloss.Color("#1A7F37")
+
+		mergedBG = lipgloss.Color("#FBEFFF")
+		mergedFG = lipgloss.Color("#6E39D1")
+
+		closedBG = lipgloss.Color("#FFEBE9")
+		closedFG = lipgloss.Color("#D1242F")
+
+		draftBG = lipgloss.Color("#F6F8FA")
+		draftFG = lipgloss.Color("#6E7781")
+
+		skeletonBG = lipgloss.Color("#F6F8FA")
+		skeletonFG = lipgloss.Color("#AFB8C1")
 	}
 
-	s.StateOpen = lipgloss.NewStyle().Padding(0, 1).Foreground(openColor)
-	s.StateMerged = lipgloss.NewStyle().Padding(0, 1).Foreground(mergedColor)
-	s.StateClosed = lipgloss.NewStyle().Padding(0, 1).Foreground(closedColor)
-	s.StateDraft = lipgloss.NewStyle().Padding(0, 1).Foreground(draftColor)
+	pill := lipgloss.NewStyle().Padding(0, 1).Bold(true)
+
+	s.StateOpen = pill.Background(openBG).Foreground(openFG)
+	s.StateMerged = pill.Background(mergedBG).Foreground(mergedFG)
+	s.StateClosed = pill.Background(closedBG).Foreground(closedFG)
+	s.StateDraft = pill.Background(draftBG).Foreground(draftFG)
+	s.StateSkeleton = pill.Background(skeletonBG).Foreground(skeletonFG).Blink(true)
 
 	return s
 }

--- a/internal/tui/test_utils.go
+++ b/internal/tui/test_utils.go
@@ -1,0 +1,23 @@
+package tui
+
+import "strings"
+
+// stripANSI is a simple utility to remove ANSI codes for content-based assertions.
+func stripANSI(s string) string {
+	var b strings.Builder
+	inANSI := false
+	for _, r := range s {
+		if r == '\x1b' {
+			inANSI = true
+			continue
+		}
+		if inANSI {
+			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+				inANSI = false
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -38,7 +38,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.isDark = msg.IsDark()
 		m.styles = DefaultStyles(m.isDark)
 		m.list.Styles.Title = m.styles.Title
-		m.list.SetDelegate(newItemDelegate(m.styles, m.keys))
+		m.delegate = newItemDelegate(m.styles, m.keys)
+		m.list.SetDelegate(m.delegate)
 		m.updateMarkdownRenderer()
 		m.ui.SetStyles(m.styles)
 
@@ -80,6 +81,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.ui.SetSyncing(false))
 		cmds = append(cmds, m.ui.SetFetching(false))
 		m.err = msg.err
+	}
+
+	// Sync fetching state to delegate for skeleton UI
+	if m.delegate.IsFetching != m.ui.fetchingDetail {
+		m.delegate.IsFetching = m.ui.fetchingDetail
+		m.list.SetDelegate(m.delegate)
 	}
 
 	// 2. Handle state-dependent messages (Router Pattern)
@@ -158,7 +165,6 @@ func (m *Model) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {
 									ResourceState: res.ResourceState,
 								}
 							},
-
 							func(err error) tea.Msg { return errMsg{err: err} },
 						),
 					)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -49,10 +49,6 @@ func (m *Model) View() tea.View {
 }
 
 func (m *Model) renderDetailView() string {
-	if m.ui.fetchingDetail {
-		return m.ui.RenderSpinner() + " Fetching detail..."
-	}
-
 	i, ok := m.list.SelectedItem().(item)
 	if !ok {
 		return "No item selected"
@@ -60,17 +56,21 @@ func (m *Model) renderDetailView() string {
 
 	// 1. Unified Header using shared component
 	headerCtx := RenderContext{
-		Styles: m.styles,
-		Width:  m.width,
+		Styles:     m.styles,
+		Width:      m.width,
+		IsFetching: m.ui.fetchingDetail,
 	}
 	header := RenderTargetHeader(headerCtx, i.notification, "", true)
 	
 	meta := fmt.Sprintf("Author: %s | Repo: %s", i.notification.AuthorLogin, i.notification.RepositoryFullName)
 	
-	// Content inside the viewport
-	vpView := m.viewport.View()
+	// Content inside the viewport or loading indicator
+	body := m.viewport.View()
+	if m.ui.fetchingDetail {
+		body = "\n\n  " + m.ui.RenderSpinner() + " Fetching detail..."
+	}
 	
-	content := header + "\n" + meta + "\n\n" + vpView
+	content := header + "\n" + meta + "\n\n" + body
 
 	// If we have dimensions, ensure the style doesn't clip
 	style := m.styles.Viewport

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -8,26 +8,6 @@ import (
 	"charm.land/bubbles/v2/list"
 )
 
-// stripANSI is a simple utility to remove ANSI codes for content-based assertions.
-func stripANSI(s string) string {
-	var b strings.Builder
-	inANSI := false
-	for _, r := range s {
-		if r == '\x1b' {
-			inANSI = true
-			continue
-		}
-		if inANSI {
-			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
-				inANSI = false
-			}
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
-}
-
 func TestRenderFooter(t *testing.T) {
 	styles := DefaultStyles(true)
 


### PR DESCRIPTION
This PR implements Phase 5.11 of the roadmap, fixing visibility issues and adding professional visual polish to the TUI.

### **Core Changes:**
- **Pill Style Badges**: Status indicators (`Open`, `Merged`, etc.) now use full background/foreground styling with desaturated adaptive tints for high visibility without visual fatigue.
- **Skeleton UI**: Added a pulsing `[ LOADING ]` placeholder during the enrichment cycle to provide immediate visual feedback and prevent 'Title Jumping'.
- **Adaptive Density**: The list now intelligently removes the status gap for non-enriched items, keeping the 'un-peeked' rows compact.
- **Smart Geometry**: Implemented adaptive truncation for titles to ensure they fit perfectly alongside the 12-character status badges.
- **Clean Tests**: Refactored test utilities to share ANSI-stripping logic and added geometry verification tests.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>