### PR TITLE
feat: Phase 5.16 - Sync Reliability & Forced Refresh

### DIFF
--- a/internal/api/fetcher.go
+++ b/internal/api/fetcher.go
@@ -30,17 +30,27 @@ func (f *NotificationFetcher) FetchNotifications(meta *db.SyncMeta) ([]GHNotific
 	newMeta := *meta
 	remainingRateLimit := 5000 // Default assume healthy
 
-	path := "notifications?per_page=100"
+	path := "notifications?per_page=100&all=true"
 
-	// Only fetch all notifications on first sync
+	// Use conditional requests if metadata is available
 	if meta.LastModified != "" || meta.ETag != "" {
-		path = "notifications"
+		path = "notifications?all=true"
 	}
 
 	for path != "" {
 		url := path
 		if !strings.HasPrefix(url, "http") {
 			url = f.client.BaseURL() + path
+		}
+
+		// Ensure all=true is present even if the 'next' URL from GitHub might omit it 
+		// (though usually GitHub preserves params in Link headers)
+		if !strings.Contains(url, "all=true") {
+			if strings.Contains(url, "?") {
+				url += "&all=true"
+			} else {
+				url += "?all=true"
+			}
 		}
 
 		req, err := http.NewRequest(http.MethodGet, url, nil) // #nosec G704: Trusted GitHub API URLs

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -33,9 +33,10 @@ func (s *SyncEngine) Fetcher() Fetcher {
 }
 
 // Sync performs a full synchronization cycle for notifications.
+// If force is true, it bypasses the PollInterval check.
 // It returns the remaining rate limit if known.
-func (s *SyncEngine) Sync(userID string) (int, error) {
-	s.logger.Info("starting notification sync", "user_id", userID)
+func (s *SyncEngine) Sync(userID string, force bool) (int, error) {
+	s.logger.Info("starting notification sync", "user_id", userID, "force", force)
 	metaKey := "notifications"
 	remaining := 5000 // Default
 
@@ -54,7 +55,7 @@ func (s *SyncEngine) Sync(userID string) (int, error) {
 	}
 
 	// Check if we should poll based on LastSyncAt and PollInterval
-	if time.Since(meta.LastSyncAt).Seconds() < float64(meta.PollInterval) {
+	if !force && time.Since(meta.LastSyncAt).Seconds() < float64(meta.PollInterval) {
 		s.logger.Debug("skipping sync, poll interval not reached", "interval", meta.PollInterval)
 		return remaining, nil // Too soon to poll
 	}

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -28,9 +28,11 @@ type mockFetcher struct {
 	notifs []GHNotification
 	meta   *db.SyncMeta
 	err    error
+	called bool
 }
 
 func (m *mockFetcher) FetchNotifications(meta *db.SyncMeta) ([]GHNotification, *db.SyncMeta, int, error) {
+	m.called = true
 	return m.notifs, m.meta, 5000, m.err
 }
 
@@ -65,8 +67,8 @@ func TestSyncEngine_Sync(t *testing.T) {
 
 	engine := NewSyncEngine(fetcher, database, nil, logger)
 
-	// 1. Initial Sync
-	if _, err := engine.Sync(userID); err != nil {
+	// 1. Initial Sync (Force=true)
+	if _, err := engine.Sync(userID, true); err != nil {
 		t.Fatalf("Initial sync failed: %v", err)
 	}
 
@@ -76,15 +78,22 @@ func TestSyncEngine_Sync(t *testing.T) {
 		t.Errorf("Expected 1 notification, got %d", len(list))
 	}
 
-	// 2. Second Sync (should poll only if interval passed, here we mock it by returning empty from fetcher if we wanted,
-	// but let's test that Sync actually calls FetchNotifications)
-	
-	// Mock If-Modified-Since behavior via a real httptest server if needed, but here we just verify
-	// the Sync logic flow.
-	
-	// Ensure we don't sync again too fast
-	if _, err := engine.Sync(userID); err != nil {
+	// 2. Automated Sync too soon (Force=false)
+	fetcher.called = false
+	if _, err := engine.Sync(userID, false); err != nil {
 		t.Fatalf("Second sync failed: %v", err)
+	}
+	if fetcher.called {
+		t.Error("Expected automated sync to be skipped due to interval")
+	}
+
+	// 3. Forced Sync (Force=true)
+	fetcher.called = false
+	if _, err := engine.Sync(userID, true); err != nil {
+		t.Fatalf("Forced sync failed: %v", err)
+	}
+	if !fetcher.called {
+		t.Error("Expected forced sync to bypass interval check")
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -156,7 +156,8 @@ func (m *Model) loadNotifications() tea.Cmd {
 
 func (m *Model) syncNotifications(priority int) tea.Cmd {
 	return m.traffic.Submit(priority, func(ctx context.Context) tea.Msg {
-		remaining, err := m.sync.Sync(m.userID)
+		force := (priority == api.PriorityUser)
+		remaining, err := m.sync.Sync(m.userID, force)
 		if err != nil {
 			return errMsg{err}
 		}


### PR DESCRIPTION
This PR implements Phase 5.16 of the roadmap, fixing the issue where new notifications were sometimes missed during manual refresh.

### **Core Changes:**
- **Manual Override**: Manual refreshes (via `r` key or startup) now bypass the `PollInterval` guard, ensuring immediate API fetching.
- **Historical Sync**: Switched to `all=true` for all fetches. This ensures notifications marked as read on other platforms are still synced locally, maintaining a consistent list across devices.
- **Pagination Safety**: Explicitly ensures the `all=true` parameter is maintained across all pages of a multi-page fetch cycle.
- **Better Observability**: Added granular logging to track whether sync events are 'Forced' or 'Automated'.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>