### PR TITLE
feat: Phase 5.19 - Sync Header Robustness

### DIFF
--- a/internal/api/fetcher.go
+++ b/internal/api/fetcher.go
@@ -128,13 +128,18 @@ func (f *NotificationFetcher) FetchNotifications(meta *db.SyncMeta) ([]GHNotific
 			})
 		}
 
-		// Update metadata from headers
-		if strings.Contains(url, "notifications") {
+		// Update metadata from headers ONLY on successful data fetch (200 OK)
+		if resp.StatusCode == http.StatusOK && strings.Contains(url, "notifications") {
 			if lm := resp.Header.Get("Last-Modified"); lm != "" {
 				newMeta.LastModified = lm
 			}
 			if et := resp.Header.Get("ETag"); et != "" {
-				newMeta.ETag = et
+				// Validate ETag: ignore empty weak ETags like W/""
+				if et != `W/""` {
+					newMeta.ETag = et
+				} else {
+					f.logger.Debug("ignoring invalid empty weak ETag", "etag", et)
+				}
 			}
 			if pi := resp.Header.Get("X-Poll-Interval"); pi != "" {
 				if interval, err := strconv.Atoi(pi); err == nil {

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -60,6 +60,14 @@ func (s *SyncEngine) Sync(userID string, force bool) (int, error) {
 		}
 	}
 
+	// 1. Self-Healing: Detect and clear corrupted ETags (e.g., W/"")
+	if meta.ETag == `W/""` {
+		if s.logger.Enabled(context.Background(), slog.LevelDebug) {
+			s.logger.Debug("sync: self-healing corrupted ETag", "sync_id", syncID, "etag", meta.ETag)
+		}
+		meta.ETag = ""
+	}
+
 	// Check if we should poll based on LastSyncAt and PollInterval
 	if !force && time.Since(meta.LastSyncAt).Seconds() < float64(meta.PollInterval) {
 		if s.logger.Enabled(context.Background(), slog.LevelDebug) {

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -121,3 +121,45 @@ func TestConditionalRequest(t *testing.T) {
 		t.Fatalf("Fetch failed: %v", err)
 	}
 }
+
+func TestETagSanitization(t *testing.T) {
+	// 1. Verify Fetcher ignores invalid ETags
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `W/""`) // Corrupted header
+		_ = json.NewEncoder(w).Encode([]GHNotification{})
+	}))
+	defer ts.Close()
+
+	client := &Client{http: ts.Client(), baseURL: ts.URL + "/"}
+	fetcher := NewNotificationFetcher(client, slog.Default())
+	
+	meta := &db.SyncMeta{ETag: "old-etag"}
+	_, newMeta, _, _ := fetcher.FetchNotifications(meta)
+	
+	if newMeta.ETag == `W/""` {
+		t.Error("Fetcher should have ignored the invalid W/\"\" ETag")
+	}
+	if newMeta.ETag != "old-etag" {
+		t.Errorf("Fetcher should have preserved the old ETag, got %s", newMeta.ETag)
+	}
+
+	// 2. Verify SyncEngine self-heals
+	logger := slog.Default()
+	database, _ := db.OpenInMemory(logger)
+	defer func() { _ = database.Close() }()
+
+	userID := "user-1"
+	_ = database.UpdateSyncMeta(db.SyncMeta{
+		UserID: userID,
+		Key:    "notifications",
+		ETag:   `W/""`, // Seed with corrupted data
+	})
+
+	engine := NewSyncEngine(fetcher, database, nil, logger)
+	_, _ = engine.Sync(userID, true)
+
+	finalMeta, _ := database.GetSyncMeta(userID, "notifications")
+	if finalMeta.ETag == `W/""` {
+		t.Error("SyncEngine failed to self-heal the corrupted ETag in database")
+	}
+}


### PR DESCRIPTION
This PR implements Phase 5.19 of the roadmap, fixing the 'Ghost ETag' bug that was causing synchronization to lock up.

### **Core Changes:**
- **Validation**: Refined the header capture logic to strictly ignore invalid/empty weak ETags like `W/""`.
- **Self-Healing**: The `SyncEngine` now automatically detects and clears corrupted metadata from the local database during the sync cycle, providing a seamless recovery path for existing users.
- **Strict Integrity**: Synchronization metadata (ETags, Last-Modified) is now only persisted upon receiving a successful `200 OK` response with valid data.
- **Reliability**: Verified that manual refreshes correctly bypass polling intervals while maintaining historical consistency via `all=true`.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>