### PR TITLE
fix(tui): ensure detail view content synchronization (Phase 7.7)

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -405,6 +405,50 @@ func TestModel_GHViewCmd_Validation(t *testing.T) {
 	require.IsType(t, errMsg{}, msg3)
 }
 
+func TestModel_DetailView_ContentSync(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	
+	// Initialize renderer
+	m.width = 100
+	m.updateMarkdownRenderer()
+	
+	notif := types.NotificationWithState{
+		Notification: types.Notification{
+			GitHubID: "1", 
+			SubjectTitle: "T1", 
+			Body: "original body", 
+			IsEnriched: true,
+		},
+	}
+	m.allNotifications = []types.NotificationWithState{notif}
+	m.applyFilters()
+	m.listView.list.Select(0)
+
+	// 1. Entering detail for pre-enriched item should show body immediately
+	m.Transition(tea.KeyPressMsg{Code: ' ', Text: " "}, 0)
+	assert.Equal(t, StateDetail, m.state)
+	assert.Contains(t, stripANSI(m.detailView.activeDetail), "original body")
+
+	// 2. Loading new details while in detail view should refresh content
+	m.Transition(detailLoadedMsg{GitHubID: "1", Body: "updated body"}, 0)
+	assert.Contains(t, stripANSI(m.detailView.activeDetail), "updated body")
+
+	// 3. Background sync while in detail view should preserve/refresh content
+	newNotifs := []types.NotificationWithState{
+		{
+			Notification: types.Notification{
+				GitHubID: "1", 
+				SubjectTitle: "T1", 
+				Body: "synced body", 
+				IsEnriched: true,
+			},
+		},
+	}
+	m.Transition(notificationsLoadedMsg{notifications: newNotifs}, 0)
+	assert.Contains(t, stripANSI(m.detailView.activeDetail), "synced body")
+}
+
 func TestModel_Actions_EdgeCases(t *testing.T) {
 	m := newTestModel(t)
 	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -81,6 +81,9 @@ func (m *Model) Transition(msg tea.Msg, oldIndex int) []Action {
 	case notificationsLoadedMsg:
 		m.allNotifications = msg.notifications
 		m.applyFilters()
+		if m.state == StateDetail {
+			m.refreshDetailView()
+		}
 		actions = append(actions, ActionEnrichItems{Notifications: m.getVisibleNotifications()})
 		actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
 
@@ -97,7 +100,7 @@ func (m *Model) Transition(msg tea.Msg, oldIndex int) []Action {
 		actions = append(actions, ActionLoadNotifications{}) // Reload after sync
 
 	case detailLoadedMsg:
-		m.ui.fetchingDetail = false
+		m.ui.SetFetching(false)
 		for idx, n := range m.allNotifications {
 			if n.GitHubID == msg.GitHubID {
 				m.allNotifications[idx].Body = msg.Body
@@ -109,12 +112,11 @@ func (m *Model) Transition(msg tea.Msg, oldIndex int) []Action {
 			}
 		}
 		if m.state == StateDetail {
-			if i, ok := m.listView.list.SelectedItem().(item); ok && i.notification.GitHubID == msg.GitHubID {
-				m.detailView.activeDetail = m.renderMarkdown(msg.Body)
-				m.detailView.viewport.SetContent(m.detailView.activeDetail)
-			}
+			m.applyFilters() // This updates the items in the list from the modified allNotifications
+			m.refreshDetailView()
+		} else {
+			m.applyFilters()
 		}
-		m.applyFilters()
 
 	case pollTickMsg:
 		if msg.ID == m.heartbeatID {
@@ -136,7 +138,7 @@ func (m *Model) Transition(msg tea.Msg, oldIndex int) []Action {
 	case errMsg:
 		m.err = msg.err
 		m.ui.SetSyncing(false)
-		m.ui.fetchingDetail = false
+		m.ui.SetFetching(false)
 	}
 
 	// State-dependent transitions
@@ -214,11 +216,10 @@ func (m *Model) transitionList(msg tea.Msg) []Action {
 			if i, ok := m.listView.list.SelectedItem().(item); ok {
 				m.state = StateDetail
 				if !i.notification.IsEnriched {
-					m.ui.fetchingDetail = true
+					m.ui.SetFetching(true)
 					actions = append(actions, ActionEnrichItems{Notifications: []types.NotificationWithState{i.notification}})
-				} else {
-					m.detailView.viewport.SetContent(m.detailView.activeDetail)
 				}
+				m.refreshDetailView()
 			}
 		case key.Matches(msg, m.keys.ToggleRead):
 			if i, ok := m.listView.list.SelectedItem().(item); ok {
@@ -326,6 +327,18 @@ func (m *Model) getVisibleNotifications() []types.NotificationWithState {
 		}
 	}
 	return items
+}
+
+func (m *Model) refreshDetailView() {
+	if i, ok := m.listView.list.SelectedItem().(item); ok {
+		if i.notification.IsEnriched {
+			m.detailView.activeDetail = m.renderMarkdown(i.notification.Body)
+			m.detailView.viewport.SetContent(m.detailView.activeDetail)
+		} else {
+			m.detailView.activeDetail = ""
+			m.detailView.viewport.SetContent("")
+		}
+	}
 }
 
 func (m *Model) applyFilters() {


### PR DESCRIPTION
## Summary
This PR addresses **Phase 7.7: Detail View Restoration**, fixing a regression where notification content was not reliably displayed in the Detail View.

### Key Changes
- **Functional Core Hardening**: Updated `Transition` logic to ensure the Detail View is refreshed whenever new notification data is loaded (`notificationsLoadedMsg`, `detailLoadedMsg`).
- **Immediate Initialization**: Pre-enriched items now display their content immediately upon entering the Detail View.
- **Robust Error Handling**: Ensured that the fetching state is correctly reset during error messages to prevent UI hangs.
- **Verification**: Added `TestModel_DetailView_ContentSync` to maintain the invariant that the viewport always reflects the latest state of the selected notification.

### Verification
- `make build test lint` passes.
- Unit tests specifically verify content synchronization in multiple scenarios.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>
