### PR TITLE
fix(tui): restore detail view scrolling (Phase 7.10)

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -447,6 +448,45 @@ func TestModel_DetailView_ContentSync(t *testing.T) {
 	}
 	m.Transition(notificationsLoadedMsg{notifications: newNotifs, IsInitial: true}, 0)
 	assert.Contains(t, stripANSI(m.detailView.activeDetail), "synced body")
+}
+
+func TestModel_DetailView_Scrolling(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	
+	// Set dimensions and initialize renderer
+	m.width = 80
+	m.height = 24
+	m.updateMarkdownRenderer()
+	
+	// Long body to ensure scrolling is possible
+	longBody := strings.Repeat("Line of text\n", 50)
+	notif := types.NotificationWithState{
+		Notification: types.Notification{
+			GitHubID: "1", 
+			SubjectTitle: "T1", 
+			Body: longBody, 
+			IsEnriched: true,
+		},
+	}
+	m.allNotifications = []types.NotificationWithState{notif}
+	m.applyFilters()
+	m.listView.list.Select(0)
+
+	// 1. Enter detail view
+	m.Transition(tea.KeyPressMsg{Code: ' ', Text: " "}, 0)
+	assert.Equal(t, StateDetail, m.state)
+	m.refreshDetailView() // Force refresh to ensure viewport is populated
+
+	initialOffset := m.detailView.viewport.YOffset()
+	assert.Equal(t, 0, initialOffset)
+
+	// 2. Simulate scroll down (j key)
+	// We call Update directly to simulate sub-model delegation
+	_, _ = m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	
+	newOffset := m.detailView.viewport.YOffset()
+	assert.Greater(t, newOffset, initialOffset, "Viewport YOffset should increase after scroll down")
 }
 
 func TestModel_Actions_EdgeCases(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -38,8 +38,10 @@ type ListModel struct {
 
 // DetailModel encapsulates viewport-specific state.
 type DetailModel struct {
-	viewport     viewport.Model
-	activeDetail string // Rendered markdown
+	viewport          viewport.Model
+	activeDetail      string // Rendered markdown
+	lastRenderedID    string
+	lastRenderedWidth int
 }
 
 // Model represents the application state.
@@ -124,6 +126,8 @@ func NewModel(
 	l.Styles.Title = styles.Title
 
 	vp := viewport.New()
+	vp.MouseWheelEnabled = true
+	vp.SoftWrap = false // We handle wrapping manually via lipgloss in refreshDetailView
 
 	m := &Model{
 		listView: ListModel{

--- a/internal/tui/test_utils.go
+++ b/internal/tui/test_utils.go
@@ -56,6 +56,11 @@ func newTestModel(t TestingT) *Model {
 	m.ui.toastTimeout = time.Millisecond
 	m.bridgeStatus = api.StatusHealthy
 	
+	// Initialize renderer
+	m.width = 80
+	m.height = 24
+	m.updateMarkdownRenderer()
+	
 	// Provision a default notification for tests
 	m.allNotifications = []types.NotificationWithState{
 		{

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -333,15 +333,49 @@ func (m *Model) getVisibleNotifications() []types.NotificationWithState {
 }
 
 func (m *Model) refreshDetailView() {
-	if i, ok := m.listView.list.SelectedItem().(item); ok {
-		if i.notification.IsEnriched {
-			m.detailView.activeDetail = m.renderMarkdown(i.notification.Body)
-			m.detailView.viewport.SetContent(m.detailView.activeDetail)
-		} else {
-			m.detailView.activeDetail = ""
-			m.detailView.viewport.SetContent("")
-		}
+	i, ok := m.listView.list.SelectedItem().(item)
+	if !ok {
+		return
 	}
+
+	currentWidth := m.width - 4
+	if currentWidth < 10 {
+		currentWidth = 10
+	}
+
+	// 1. Determine the raw content to display
+	var rawBody string
+	isReady := false
+	if m.ui.fetchingDetail {
+		rawBody = "\n  ◌ Loading content..."
+	} else if i.notification.IsEnriched {
+		rawBody = i.notification.Body
+		if rawBody == "" {
+			rawBody = "\n  (No description provided)"
+		}
+		isReady = true
+	} else {
+		rawBody = "\n  ◌ Waiting for enrichment..."
+	}
+
+	// 2. Guard: Skip if content and width are identical to last render
+	// We also check fetching state to ensure we transition from spinner to content correctly.
+	if i.notification.GitHubID == m.detailView.lastRenderedID &&
+		currentWidth == m.detailView.lastRenderedWidth &&
+		rawBody == m.detailView.activeDetail &&
+		!m.ui.fetchingDetail == isReady {
+		return
+	}
+
+	// 3. Render and Wrap
+	rendered := m.renderMarkdown(rawBody)
+	// Apply manual wrapping using Lipgloss style
+	wrapped := lipgloss.NewStyle().Width(currentWidth).Render(rendered)
+
+	m.detailView.viewport.SetContent(wrapped)
+	m.detailView.activeDetail = rawBody // Store rawBody for idempotent check
+	m.detailView.lastRenderedID = i.notification.GitHubID
+	m.detailView.lastRenderedWidth = currentWidth
 }
 
 func (m *Model) applyFilters() {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -154,23 +154,23 @@ func (m *Model) renderDetailView() string {
 	header := lipgloss.JoinVertical(lipgloss.Left, title, m.styles.SelectedDescription.Render(meta))
 
 	// 2. Viewport (Body)
+	// Dynamically calculate height based on header size
 	detailMetaHeight := lipgloss.Height(header) + 1 // +1 for the newline
 	
 	availableHeight := m.height - m.headerHeight - m.footerHeight - detailMetaHeight
-	if availableHeight < 5 { availableHeight = 5 }
-
-	body := m.detailView.activeDetail
-	if m.ui.fetchingDetail {
-		body = "\n  ◌ Loading content..."
-	} else if body == "" {
-		body = "\n  (No description provided)"
+	if availableHeight < 5 { 
+		availableHeight = 5 
 	}
+	
+	// Sync viewport dimensions dynamically
+	m.detailView.viewport.SetWidth(m.width - 4)
+	m.detailView.viewport.SetHeight(availableHeight)
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		header,
 		"\n",
-		m.styles.Viewport.Width(m.width-4).Height(availableHeight).Render(body),
+		m.detailView.viewport.View(),
 	)
 }
 

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -83,27 +83,38 @@ func TestRenderDetailView(t *testing.T) {
 	m := newTestModel(t)
 	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 	m.width = 100
-	m.height = 50
+	m.height = 20
+	m.updateMarkdownRenderer()
 	
-	notifs := []types.NotificationWithState{
-		{Notification: types.Notification{GitHubID: "1", SubjectTitle: "T1", SubjectURL: "u1"}},
+	// Establish header/footer heights for layout
+	m.headerHeight = 1
+	m.footerHeight = 1
+	
+	notif := types.NotificationWithState{
+		Notification: types.Notification{GitHubID: "1", SubjectTitle: "T1", SubjectURL: "u1"},
 	}
-	m.listView.list.SetItems([]list.Item{item{notification: notifs[0]}})
+	m.listView.list.SetItems([]list.Item{item{notification: notif}})
 	m.listView.list.Select(0)
 	
 	// 1. Loading state
 	m.ui.SetFetching(true)
+	m.refreshDetailView()
 	v1 := stripANSI(m.renderDetailView())
-	assert.Contains(t, v1, "Loading content...")
+	assert.Contains(t, v1, "Loading content")
 	
 	// 2. Empty state
 	m.ui.SetFetching(false)
-	m.detailView.activeDetail = ""
+	notif.IsEnriched = true
+	notif.Body = ""
+	m.listView.list.SetItems([]list.Item{item{notification: notif}})
+	m.refreshDetailView()
 	v2 := stripANSI(m.renderDetailView())
 	assert.Contains(t, v2, "No description provided")
 	
 	// 3. Content state
-	m.detailView.activeDetail = "Some description"
+	notif.Body = "Some description"
+	m.listView.list.SetItems([]list.Item{item{notification: notif}})
+	m.refreshDetailView()
 	v3 := stripANSI(m.renderDetailView())
 	assert.Contains(t, v3, "Some description")
 }


### PR DESCRIPTION
## Summary
This PR addresses **Phase 7.10: Detail View Scroll Restoration**, fixing a regression where the notification body was no longer scrollable.

### Key Changes
- **Viewport Delegation**: Restored the use of `viewport.View()` in the detail rendering path, enabling built-in scrolling logic.
- **Dynamic Layout**: Implemented on-the-fly height recalculation to ensure the scrollable area perfectly fills the space below variable-sized notification headers.
- **Intelligent Wrapping**: Switched to manual Lipgloss word-wrapping before content injection, preventing horizontal truncation.
- **Performance Optimization**: Added idempotency tracking (`lastRenderedID`, `lastRenderedWidth`) to ensure expensive re-wrapping only occurs when data or window size changes.
- **UX Polish**: Enabled mouse wheel support for the detail view.

### Verification
- `make build test lint` passes.
- New unit test `TestModel_DetailView_Scrolling` confirms that `YOffset` increments correctly on scroll inputs.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>
