### PR TITLE
fix(tui): preserve fuzzy filter state during triage (Phase 7.11)

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -702,3 +702,47 @@ func TestModel_Actions_Additional(t *testing.T) {
 	// 4. MarkRead (via method)
 	_ = m.MarkRead(i)
 }
+
+func TestModel_FilterPreservation(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	
+	// 0. Switch to TabAll to ensure items stay visible regardless of read state
+	m.listView.activeTab = TabAll
+
+	// 1. Setup multiple notifications
+	m.allNotifications = []types.NotificationWithState{
+		{Notification: types.Notification{GitHubID: "1", SubjectTitle: "Match Apple"}},
+		{Notification: types.Notification{GitHubID: "2", SubjectTitle: "Match Banana"}},
+		{Notification: types.Notification{GitHubID: "3", SubjectTitle: "Other Cherry"}},
+	}
+	m.applyFilters()
+	require.Len(t, m.listView.list.Items(), 3)
+
+	// 2. Apply fuzzy filter "Match"
+	m.listView.list.SetFilterText("Match")
+	// Note: We might need to manually trigger the filter logic in the test 
+	// because bubbles/list handles filtering in its Update loop usually.
+	// But our applyFilters now does it explicitly.
+	require.Len(t, m.listView.list.VisibleItems(), 2)
+
+	// 3. Trigger state change (Toggle Read)
+	// This calls applyFilters() internally
+	m.listView.list.Select(0)
+	target := m.listView.list.SelectedItem().(item)
+	
+	mockTraffic := m.traffic.(*mocks.MockTrafficController)
+	mockTraffic.EXPECT().Submit(mock.Anything, mock.Anything).Return(func() tea.Msg { return nil }).Maybe()
+
+	_ = m.ToggleRead(target)
+	
+	// 4. Verify filter is preserved and list is still filtered
+	assert.Equal(t, "Match", m.listView.list.FilterValue())
+	assert.Len(t, m.listView.list.VisibleItems(), 2)
+
+	// 5. Edge Case: Filter results in empty list
+	m.listView.list.SetFilterText("NonExistent")
+	m.applyFilters()
+	assert.Equal(t, "NonExistent", m.listView.list.FilterValue())
+	assert.Len(t, m.listView.list.VisibleItems(), 0)
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -404,12 +404,23 @@ func (m *Model) applyFilters() {
 			}
 		}
 
-		if keep {
+	if keep {
 			filtered = append(filtered, item{notification: n})
 		}
 	}
 
+	// Preserve existing fuzzy filter state
+	// Maintenance Note: This manually syncs the FilterInput sub-component.
+	// Library upgrades to bubbles/v2 may change this internal structure.
+	currentFilter := m.listView.list.FilterValue()
+
 	m.listView.list.SetItems(filtered)
+
+	// Restore fuzzy filter BEFORE restoring selection to ensure index mapping is correct
+	if currentFilter != "" {
+		m.listView.list.FilterInput.SetValue(currentFilter)
+		m.listView.list.SetFilterText(currentFilter)
+	}
 
 	if selectedID != "" {
 		for index, li := range m.listView.list.Items() {


### PR DESCRIPTION
## Summary
This PR fixes the bug where the notification list incorrectly clears (or resets) after performing a triage action (like marking as read) while a fuzzy filter (`/`) is active.

### Key Changes
- **Filter State Capture**: The active filter string is now captured before calling `SetItems`.
- **Atomic Restoration**: The filter is re-applied to both the visual input field and the internal list model immediately after the data refresh.
- **Selection Stability**: By restoring the filter *before* the item selection, we ensure the cursor remains on the correct item in the filtered view.

### Verification
- Added `TestModel_FilterPreservation` which covers both basic preservation and empty-list edge cases.
- `make build test lint` passes.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>
