### PR TITLE
fix: make task workbench initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ task:
 	@if [ -z "$(ID)" ]; then echo "Usage: make task ID=<issue-number>"; exit 1; fi
 	@echo "Initializing workbench for Issue #$(ID)..."
 	@rm -f .agents/issue.md .agents/proposal.md .agents/feedback.md
-	@gh issue view "$(ID)" --comments > .agents/issue.md || (echo "Error: Issue #$(ID) not found."; exit 1)
+	@gh issue view "$(ID)" --json title,body,state,labels,milestone --template 'Title: {{.title}}\n\nBody: {{.body}}\n\nLabels: {{range .labels}}{{.name}} {{end}}\nMilestone: {{if .milestone}}{{.milestone.title}}{{else}}None{{end}}\nState: {{.state}}\n' > .agents/issue.md || (echo "Error: Issue #$(ID) not found."; exit 1)
 	@cp .agents/workflows/strategy-review/TEMPLATE.md .agents/proposal.md
 	@$(SED_INPLACE) "s/\[ID\]/$(ID)/g" .agents/proposal.md
 	@echo "Workbench ready: .agents/issue.md and .agents/proposal.md initialized."


### PR DESCRIPTION
## Description
Fixes `make task` target in the Makefile which was failing to populate `.agents/issue.md` when the target GitHub issue had no comments.

### Changes
- Updated the `task` target to use `gh issue view` with `--json` and a structured template.
- This ensures that the title and body are always captured, as the `--comments` flag only produced output for comments when redirected.

Fixes #116