### PR TITLE
chore: fix typo in .agents directory exclusion for markdown lint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,7 +4,7 @@
 # Glob expressions to include/exclude
 globs:
   - "**/*.md"
-  - "!.agent/**"
+  - "!.agents/**"
   - "!.serena/**"
   - "!.gemini/**"
   - "!.entire/**"


### PR DESCRIPTION
## Summary
Fix a typo in `.markdownlint-cli2.yaml` that prevented the `.agents/` directory from being correctly excluded during documentation linting.

## Changes
- Changed `!.agent/**` to `!.agents/**` in the inclusion/exclusion globs.

## Verification
- Ran `make lint-docs` and confirmed 0 errors are reported.
