### PR TITLE
chore: implement branch persistence mandate for agents

### DIFF
--- a/.agents/skills/worker-role/SKILL.md
+++ b/.agents/skills/worker-role/SKILL.md
@@ -10,7 +10,8 @@ You are the implementation Worker for the `gh-orbit` project. This skill is used
 
 1. **Context First**: Read `GEMINI.md`, `AGENTS.md`, and `~/.gemini/GEMINI.md` (if available) to understand the project architecture and development workflow.
 2. **Standard Operating Procedure**: You follow the **Strategy Review Workflow** located at `.agents/workflows/strategy-review/WORKFLOW.md`.
-3. **The Workbench**: You operate on the following static files:
+3. **Stay on Branch**: Do not switch away from your topic branch until the review loop is closed with a **SIGN-OFF** in `.agents/feedback.md`.
+4. **The Workbench**: You operate on the following static files:
    - **Context**: `.agents/issue.md` (Already populated by the user or `make task`).
    - **Design**: `.agents/proposal.md` (Use the `TEMPLATE.md` in the workflow directory).
    - **Feedback**: `.agents/feedback.md` (Read this when the Reviewer provides feedback).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,13 @@
   - Destructive operations (e.g., clearing local database).
   - Strategic changes that deviate from the Implementation Plan.
   - Adding new external dependencies.
-- **Attribution**: All commits must include:
+- Attribution: All commits must include:
     `Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>`
+
+### 2.3 Branch Persistence
+
+- **Stay on Branch**: NEVER switch away from a topic branch (e.g., to `main`) until you have received an explicit **SIGN-OFF** in `.agents/feedback.md` or a direct user instruction to do so. This ensures you remain in the correct context for iterating on reviewer feedback.
+- **Completion**: A task is only considered complete when the pull request is merged or the user directs you to move to a new task.
 
 ## 3. Implementation Patterns
 


### PR DESCRIPTION
## Summary
Codify a rule that agents must remain on their topic branch until a task is fully completed (indicated by SIGN-OFF or user instruction). This ensures agents maintain context for iterating on reviewer feedback.

## Changes
- **AGENTS.md**: Added Section 2.3 "Branch Persistence" as a cross-agent standard.
- **worker-role skill**: Added a mandate to reinforcement branch persistence during initialization.

## Verification
- Verified documentation updates correctly reflect the mandate.
- Ran `make check` to ensure no documentation regressions.
