### PR TITLE
chore: implement reviewer boundary mandate

### DIFF
--- a/.agents/skills/reviewer-role/SKILL.md
+++ b/.agents/skills/reviewer-role/SKILL.md
@@ -11,7 +11,8 @@ You are the architectural Reviewer for the `gh-orbit` project. This skill is use
 1. **Context Discovery**: Read the `Reviewer Hint` in `.agents/proposal.md` and read the corresponding context in `.agents/issue.md`.
 2. **Review Workflow**: You MUST follow the feedback loop logic in `.agents/workflows/feedback.md`.
 3. **The Matrix Review**: Perform a thorough analysis of the proposal's security, testability, and architectural impact.
-4. **Audit Log**: Persist your findings to the static workbench file: `.agents/feedback.md`.
+4. **Read-Only Boundary**: You are an auditor, not an implementer. You must NEVER use modification tools (`replace`, `write_file`, `insert_after_symbol`, etc.) on any file except for the specific feedback file defined in your workflow (`.agents/feedback.md`).
+5. **Audit Log**: Persist your findings to the static workbench file: `.agents/feedback.md`.
 
 ## Mandatory Skill Initialization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,12 @@
 ### 2.3 Branch Persistence
 
 - **Stay on Branch**: NEVER switch away from a topic branch (e.g., to `main`) until you have received an explicit **SIGN-OFF** in `.agents/feedback.md` or a direct user instruction to do so. This ensures you remain in the correct context for iterating on reviewer feedback.
-- **Completion**: A task is only considered complete when the pull request is merged or the user directs you to move to a new task.
+- Completion: A task is only considered complete when the pull request is merged or the user directs you to move to a new task.
+
+### 2.4 Role Boundaries
+
+- **Worker**: Responsible for implementation, testing, and modifying source files. Follows the Task Cycle and Strategy Review Workflow.
+- **Reviewer**: Responsible for auditing proposals and implementation. Must operate in **Read-Only** mode relative to source files. The only file a Reviewer should modify is `.agents/feedback.md`.
 
 ## 3. Implementation Patterns
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,3 +20,7 @@ Strictly follow the shell safety protocols defined in [.agent/rules/shell-safety
 ### 2.3 Strategy Review
 
 Mandatory adherence to the [Strategy Review Workflow](.agent/workflows/strategy-review/WORKFLOW.md) before any changes to `internal/` or `cmd/`.
+
+### 2.4 Reviewer Plan Mode
+
+When acting as a Reviewer, you should use `enter_plan_mode` for the research and analysis phase. Use this phase to read source files and perform online research (`google_web_search`, `web_fetch`) for latest best practices. Since Plan Mode prevents all file writes, you must finalize your analysis and then transition to active mode strictly to write your findings to `.agents/feedback.md`.


### PR DESCRIPTION
## Summary
Enforce a strict separation of concerns between Agent roles by ensuring the Reviewer remains in a read-only capacity regarding project source code, while leveraging Plan Mode for safety.

## Changes
- **AGENTS.md**: Added Section 2.4 "Role Boundaries" defining Worker (Implementer) and Reviewer (Auditor) roles.
- **reviewer-role skill**: Added a "Read-Only Boundary" mandate to prevent modification tool usage on source files.
- **GEMINI.md**: Added Section 2.4 "Reviewer Plan Mode" mandating analysis in Plan Mode before transitioning to active mode strictly for feedback write-back.

## Verification
- Verified documentation updates correctly reflect the boundaries.
- Ran `make check` to ensure project integrity.
