### PR TITLE
feat: introduce build-time metadata (version, commit, date)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ BINARY_NAME=gh-orbit
 CMD_PATH=./cmd/gh-orbit
 GOLANGCI_LINT_VERSION=v2.11.3
 
+# Build metadata
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+LDFLAGS=-ldflags "-X github.com/hirakiuc/gh-orbit/internal/buildinfo.Version=$(VERSION) \
+                  -X github.com/hirakiuc/gh-orbit/internal/buildinfo.Commit=$(COMMIT) \
+                  -X github.com/hirakiuc/gh-orbit/internal/buildinfo.Date=$(DATE)"
+
 # Sandbox-native development environment
 PROJECT_TMP ?= $(CURDIR)/tmp
 export GOCACHE ?= $(PROJECT_TMP)/go-cache
@@ -28,7 +37,7 @@ $(PROJECT_TMP):
 	@mkdir -p $(PROJECT_TMP)
 
 build: $(PROJECT_TMP)
-	go build -o bin/$(BINARY_NAME) $(CMD_PATH)
+	go build $(LDFLAGS) -o bin/$(BINARY_NAME) $(CMD_PATH)
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		echo "Ad-hoc signing binary for macOS..."; \
 		codesign -f -s - bin/$(BINARY_NAME); \
@@ -48,13 +57,13 @@ artifacts: $(PROJECT_TMP)
 	go test -v -artifacts ./...
 
 release-build: $(PROJECT_TMP)
-	GOOS=darwin GOARCH=amd64 go build -o bin/$(BINARY_NAME)-darwin-amd64 $(CMD_PATH)
+	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY_NAME)-darwin-amd64 $(CMD_PATH)
 	@if [ "$$(uname)" = "Darwin" ]; then codesign -f -s - bin/$(BINARY_NAME)-darwin-amd64; fi
-	GOOS=darwin GOARCH=arm64 go build -o bin/$(BINARY_NAME)-darwin-arm64 $(CMD_PATH)
+	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o bin/$(BINARY_NAME)-darwin-arm64 $(CMD_PATH)
 	@if [ "$$(uname)" = "Darwin" ]; then codesign -f -s - bin/$(BINARY_NAME)-darwin-arm64; fi
-	GOOS=linux GOARCH=amd64 go build -o bin/$(BINARY_NAME)-linux-amd64 $(CMD_PATH)
-	GOOS=linux GOARCH=arm64 go build -o bin/$(BINARY_NAME)-linux-arm64 $(CMD_PATH)
-	GOOS=windows GOARCH=amd64 go build -o bin/$(BINARY_NAME)-windows-amd64.exe $(CMD_PATH)
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY_NAME)-linux-amd64 $(CMD_PATH)
+	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/$(BINARY_NAME)-linux-arm64 $(CMD_PATH)
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY_NAME)-windows-amd64.exe $(CMD_PATH)
 
 test: $(PROJECT_TMP)
 	go test -v ./...

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/dustin/go-humanize"
 	"github.com/hirakiuc/gh-orbit/internal/api"
+	"github.com/hirakiuc/gh-orbit/internal/buildinfo"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/db"
 	"github.com/hirakiuc/gh-orbit/internal/github"
@@ -22,7 +23,6 @@ import (
 )
 
 var (
-	version  = "dev"
 	logLevel = "info"
 	verbose  = false
 	testMode = false
@@ -30,8 +30,9 @@ var (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "gh-orbit",
-		Short: "A local-first triage tool for GitHub notifications.",
+		Use:     "gh-orbit",
+		Short:   "A local-first triage tool for GitHub notifications.",
+		Version: buildinfo.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Validate Global Flags
 			return nil
@@ -40,6 +41,8 @@ func main() {
 			return runTUI()
 		},
 	}
+
+	rootCmd.SetVersionTemplate(fmt.Sprintf("gh-orbit %%s (%s) build %s\n", buildinfo.Commit, buildinfo.Date))
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Logging level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output (OTel tracing)")
@@ -118,7 +121,12 @@ func runDoctor() error {
 		OS:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
 		KernelVersion: osVersion,
-		BridgeStatus:  types.StatusUnknown,
+		Build: types.BuildReport{
+			Version: buildinfo.Version,
+			Commit:  buildinfo.Commit,
+			Date:    buildinfo.Date,
+		},
+		BridgeStatus: types.StatusUnknown,
 	}
 
 	// 2. Persistence
@@ -189,7 +197,10 @@ func runDoctor() error {
 func printDoctorReport(r types.DoctorReport) {
 	fmt.Println("🤖 gh-orbit doctor report")
 	fmt.Println("==========================")
-	fmt.Printf("OS:     %s (%s)\n", r.OS, r.Arch)
+	fmt.Printf("Version: %s\n", r.Build.Version)
+	fmt.Printf("Commit:  %s\n", r.Build.Commit)
+	fmt.Printf("Build:   %s\n", r.Build.Date)
+	fmt.Printf("OS:      %s (%s)\n", r.OS, r.Arch)
 	fmt.Printf("Kernel: %s\n", r.KernelVersion)
 	fmt.Printf("Focus:  %s\n", r.FocusMode)
 	fmt.Printf("Status: %s\n", r.BridgeStatus)
@@ -303,7 +314,7 @@ func initEnvironment(ctx context.Context) (*environment, context.Context, error)
 	var otelCleanup func()
 	if verbose {
 		var otelErr error
-		_, otelCleanup, otelErr = config.SetupOTel(ctx, version)
+		_, otelCleanup, otelErr = config.SetupOTel(ctx, buildinfo.Version)
 		if otelErr != nil {
 			logger.WarnContext(ctx, "failed to initialize OpenTelemetry", "error", otelErr)
 		}
@@ -313,7 +324,7 @@ func initEnvironment(ctx context.Context) (*environment, context.Context, error)
 	tracer := config.GetTracer()
 	ctx, span := tracer.Start(ctx, "session",
 		trace.WithAttributes(
-			attribute.String("version", version),
+			attribute.String("version", buildinfo.Version),
 			attribute.String("os", runtime.GOOS),
 			attribute.String("arch", runtime.GOARCH),
 		),
@@ -402,7 +413,7 @@ func launchTUI(ctx context.Context, env *environment, res *appResources) error {
 		alerts,
 		tui.WithExecutor(executor),
 		tui.WithTheme(true),
-		tui.WithVersion(version),
+		tui.WithVersion(buildinfo.Version),
 	)
 
 	// Use tea.WithAltScreen() correctly if available in v2 or similar option

--- a/internal/api/alert.go
+++ b/internal/api/alert.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hirakiuc/gh-orbit/internal/buildinfo"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -179,7 +180,7 @@ func (a *AlertService) RefreshBridgeHealth(ctx context.Context) (types.BridgeSta
 		Status:        string(types.StatusHealthy),
 		OSVersion:     osVersion,
 		BinaryPath:    execPath,
-		BinaryVersion: "1.0.0",
+		BinaryVersion: buildinfo.Version,
 		UpdatedAt:     time.Now(),
 	})
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,20 @@
+package buildinfo
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Version is the application version (e.g., v1.0.0).
+	Version = "dev"
+	// Commit is the git commit hash at build time.
+	Commit = "unknown"
+	// Date is the build date in ISO 8601 format.
+	Date = "unknown"
+)
+
+// FullVersion returns a formatted string containing all build metadata.
+func FullVersion() string {
+	return fmt.Sprintf("%s (%s) build %s %s/%s", Version, Commit, Date, runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,18 @@
+package buildinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFullVersion(t *testing.T) {
+	// With default values
+	Version = "dev"
+	Commit = "unknown"
+	Date = "unknown"
+
+	v := FullVersion()
+	assert.Contains(t, v, "dev")
+	assert.Contains(t, v, "unknown")
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -124,6 +124,9 @@ func (m *Model) renderFooter() string {
 		}
 	}
 
+	// 5. Version Information
+	vStr := m.styles.SelectedDescription.Render(" " + m.version + " ")
+
 	footer := lipgloss.JoinHorizontal(
 		lipgloss.Bottom,
 		statusMsg,
@@ -131,7 +134,7 @@ func (m *Model) renderFooter() string {
 		filters,
 		" ",
 		rlStatus,
-		lipgloss.PlaceHorizontal(m.width-lipgloss.Width(statusMsg)-lipgloss.Width(filters)-lipgloss.Width(rlStatus)-lipgloss.Width(bridge)-4, lipgloss.Right, health),
+		lipgloss.PlaceHorizontal(m.width-lipgloss.Width(statusMsg)-lipgloss.Width(filters)-lipgloss.Width(rlStatus)-lipgloss.Width(bridge)-lipgloss.Width(vStr)-6, lipgloss.Right, vStr+" "+health),
 	)
 
 	return footer

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -49,6 +49,13 @@ type ConfigReport struct {
 	Error   string `json:"error,omitempty"`
 }
 
+// BuildReport represents the application build metadata.
+type BuildReport struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
 // DoctorReport represents the full environment diagnostic report.
 type DoctorReport struct {
 	SchemaVersion int               `json:"schema_version"`
@@ -57,6 +64,7 @@ type DoctorReport struct {
 	Arch          string            `json:"arch"`
 	KernelVersion string            `json:"kernel_version"`
 	BinaryPath    string            `json:"binary_path"`
+	Build         BuildReport       `json:"build"`
 	ActiveTier    string            `json:"active_tier"`
 	FocusMode     string            `json:"focus_mode"`
 	BridgeStatus  BridgeStatus      `json:"bridge_status"`


### PR DESCRIPTION
# Strategy Proposal: Introduce version definition with commit hash

**GitHub Issue**: #96
**Revision**: 2

## 1. Objective

*Reviewer Hint: Read `.agents/issue.md` for the original GitHub Issue context before auditing this proposal.*

Introduce build-time metadata (version, git commit hash, build date) to the `gh-orbit` binary. This enables users and developers to precisely identify the codebase version for troubleshooting and reporting.

## 2. Technical Strategy

### Architecture
- **Centralized Metadata**: Create a new package `internal/buildinfo` to hold versioning constants populated via `-ldflags`.
- **Injection**: Update the `Makefile` to calculate `COMMIT`, `DATE`, and `VERSION` and pass them to the Go compiler.
- **OTel Compatibility**: Ensure the injected `VERSION` is compatible with OpenTelemetry's preferred semver-like format.

### Components
- **Build System**: `Makefile` will handle the git-based metadata extraction.
  - Use `date -u +%Y-%m-%dT%H:%M:%SZ` for a standardized ISO 8601 UTC build date.
  - Handle "dirty" git state by appending a `-dirty` suffix.
- **CLI**: Update `cmd/gh-orbit/main.go` to use `buildinfo` for the root command's version and OTel initialization.
- **Diagnostics**: Enhance `runDoctor` to report detailed build information.
- **Alerting**: Update `AlertService` to use `buildinfo.Version` instead of a hardcoded string.
- **TUI**: Ensure the TUI receives the correct version string via functional options and verify layout stability with longer version strings (e.g., `v1.0.0-abcdef1-dirty`).

### Files
- `Makefile`: Add ldflags logic to `build` and `release-build` targets.
- `internal/buildinfo/buildinfo.go`: New file for metadata storage.
- `cmd/gh-orbit/main.go`: Integrate `buildinfo` and configure Cobra version template.
- `internal/api/alert.go`: Replace hardcoded version in `RefreshBridgeHealth` with `buildinfo.Version`.

### Dependency
- No new external dependencies.

## 3. Risks & Mitigations

- **Risk**: Build failure on systems without `git`.
- **Mitigation**: Use fallback values (e.g., "unknown") in the `Makefile` if `git` commands fail.

- **Risk**: Dirty git state making versions ambiguous.
- **Mitigation**: Append a `-dirty` suffix to the commit hash if there are uncommitted changes.

- **Risk**: TUI layout breakage with long version strings.
- **Mitigation**: Verify the status bar or help view can accommodate strings like `v1.0.0-abcdef1-dirty`.

## 4. Verification

### Automated
- Add a test in `internal/buildinfo` to ensure default values are present.
- Verify that `gh-orbit --version` returns the expected format.

### Manual
- Run `make build` and execute `bin/gh-orbit doctor` to verify the report.
- Run `bin/gh-orbit --version` to see the injected metadata.
- Check the TUI to ensure the version is correctly propagated and displayed without layout issues.

---

## Review History (Local Loop)

### Revision 2 Updates
- Addressed [ARCH-WARN] regarding hardcoded version in `internal/api/alert.go`.
- Added OTel semver compatibility consideration.
- Standardized `DATE` format in `Makefile` to ISO 8601 UTC.
- Added TUI layout verification for long version strings.

### Final Decision

- **SIGN-OFF** (Marker required for Phase B)
