### PR TITLE
chore: move gemini plan files to project-local sandbox

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,4 +1,9 @@
 {
+  "general": {
+    "plan": {
+      "directory": "./tmp/plans"
+    }
+  },
   "mcp": {
     "allowed": ["serena"]
   },

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 # Temporary directory
 /tmp/*
 !/tmp/.gitkeep
+/tmp/plans/*
+!/tmp/plans/.gitkeep
 
 # Ignore serena files
 .serena/


### PR DESCRIPTION
# Strategy Proposal: Move Gemini plan files to project-local sandbox

**GitHub Issue**: #121
**Revision**: 1

## 1. Objective

*Reviewer Hint: Read `.agents/issue.md` for the original GitHub Issue context before auditing this proposal.*

Configure the Gemini CLI to store plan files generated during `enter_plan_mode` within the project's `./tmp/plans` directory instead of the default `~/.gemini` directory. This ensures that even in Plan Mode, the agent's file modifications are restricted to the project's sandbox.

## 2. Technical Strategy

### Architecture
- **Local Storage**: Switch from global to project-local storage for plan artifacts.
- **Git Hygiene**: Ensure the local plan directory is ignored by Git while maintaining the directory structure.

### Components
- **Configuration**: Update `.gemini/settings.json` with `general.plan.directory`.
- **Git**: Update `.gitignore` to handle the new directory.

### Files
- `.gemini/settings.json`: Add the `general.plan` configuration.
- `.gitignore`: Add `/tmp/plans/*` and `!/tmp/plans/.gitkeep`.
- `tmp/plans/.gitkeep`: Create to ensure the directory structure exists.

### Dependency
- No new external dependencies.

## 3. Risks & Mitigations

- **Risk**: Plan Mode might fail if the global policy doesn't allow writes to the new path.
- **Mitigation**: Advise the user to check their global policies (though project-local `.gemini/settings.json` and sandbox settings usually work seamlessly).

- **Risk**: Accidentally committing large plan files to Git.
- **Mitigation**: Explicitly ignore `tmp/plans/*` in `.gitignore`.

## 4. Verification

### Automated
- None (Configuration only).

### Manual
- Execute `enter_plan_mode` and verify that the plan `.md` file is created under `tmp/plans/`.
- Verify that `git status` does not show the new plan file.

---

## Review History (Local Loop)

### Final Decision

- **SIGN-OFF** (Marker required for Phase B)
