### PR TITLE
docs: document sandbox constraints and ./tmp usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ This project enforces a restricted sandbox for AI agents (e.g., via macOS Seatbe
   - For assertions of expected results in test cases, use `assert` so that the test fails if the expected result is not met, but continue to run the test.
 - Use assertions as much as possible to confirm that the test result is really expected. DON'T omit it without any explicit reason.
 
-## 4. Reliability & Precision Rules
+## 5. Reliability & Precision Rules
 
 - **API Verification**: Always run `go doc <package>.<symbol>` before implementing calls to external libraries (especially `v2+` versions) to ensure 100% signature and behavior accuracy.
 - **Surgical Refactoring**: For large controller or logic files (>200 lines, e.g., `update.go`), prioritize the use of `replace` or `insert_after_symbol` instead of `write_file` to prevent accidental feature regressions (logic erasure).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,6 +21,10 @@ Strictly follow the shell safety protocols defined in [.agent/rules/shell-safety
 
 Mandatory adherence to the [Strategy Review Workflow](.agent/workflows/strategy-review/WORKFLOW.md) before any changes to `internal/` or `cmd/`.
 
+### 2.4 Reviewer Plan Mode
+
+When acting as a Reviewer, you should use `enter_plan_mode` for the research and analysis phase. Use this phase to read source files and perform online research (`google_web_search`, `web_fetch`) for latest best practices. Since Plan Mode prevents all file writes, you must finalize your analysis and then transition to active mode strictly to write your findings to `.agents/feedback.md`.
+
 ### 2.5 Sandbox & macOS Seatbelt
 
 This project is configured with a restricted sandbox for AI tools (macOS Seatbelt). 


### PR DESCRIPTION
This PR introduces explicit documentation for the project's sandbox environment (macOS Seatbelt) and the mandatory usage of the `./tmp` directory for all AI agent caching and transient file storage.

### Key Changes:
- **GEMINI.md**: Added a new section (#2.5) specifically for Gemini CLI, including troubleshooting tips for "Operation not permitted" errors and a list of mandatory environment variables (`GOCACHE`, `TMPDIR`, etc.).
- **AGENTS.md**: Added a general "Sandbox & Environment Constraints" section (#3) for all AI agents, explaining the rationale and redirection requirements.

### Rationale:
Ensuring all agents are aware of the restricted sandbox environment prevents common execution failures (especially during builds and tests) and maintains security by isolating agent file modifications within the project boundary.