### PR TITLE
fix: resolve SQLITE_BUSY error via batching and DSN optimization

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,7 +27,7 @@ When acting as a Reviewer, you should use `enter_plan_mode` for the research and
 
 ### 2.5 Sandbox & macOS Seatbelt
 
-This project is configured with a restricted sandbox for AI tools (macOS Seatbelt). 
+This project is configured with a restricted sandbox for AI tools (macOS Seatbelt).
 
 - **Operation not permitted**: If you encounter this error (or "Permission denied") when running shell commands, it is likely due to sandbox constraints. Do not attempt to work around these by modifying system paths.
 - **Mandatory ./tmp usage**: You MUST use the project's `./tmp` directory for all caches and transient files.

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -145,10 +144,9 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 			"count", len(notifications))
 
 		var newlyDiscoveredIDs []string
-		var upsertErrs []error
-
+		var triageNotifications []triage.Notification
 		for _, n := range notifications {
-			err := s.db.UpsertNotification(ctx, triage.Notification{
+			triageNotifications = append(triageNotifications, triage.Notification{
 				GitHubID:           n.ID,
 				SubjectTitle:       n.Subject.Title,
 				SubjectURL:         n.Subject.URL,
@@ -159,11 +157,14 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 				HTMLURL:            "", // Will be enriched in later phases if needed
 				UpdatedAt:          n.UpdatedAt,
 			})
-			if err != nil {
-				upsertErrs = append(upsertErrs, fmt.Errorf("failed to save notification %s: %w", n.ID, err))
-				continue
-			}
+		}
 
+		if err := s.db.UpsertNotifications(ctx, triageNotifications); err != nil {
+			s.logger.ErrorContext(ctx, "sync: failed to batch upsert notifications", "error", err)
+			return rlInfo, err
+		}
+
+		for _, n := range notifications {
 			// We only trigger alerts for notifications arriving AFTER the established baseline
 			// AND that we haven't notified for yet.
 			state, err := s.db.GetNotification(ctx, n.ID)
@@ -179,10 +180,6 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 				// Mark as "processed" even if alert failed (to prevent infinite retry storm)
 				newlyDiscoveredIDs = append(newlyDiscoveredIDs, n.ID)
 			}
-		}
-
-		if len(upsertErrs) > 0 {
-			return rlInfo, errors.Join(upsertErrs...)
 		}
 
 		// Batch mark as notified to preserve baseline state

--- a/internal/api/sync_bench_test.go
+++ b/internal/api/sync_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkSyncEngine_Sync(b *testing.B) {
 		mockAlerter.EXPECT().Notify(mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockRepo.EXPECT().GetSyncMeta(mock.Anything, "user-1", "notifications").Return(nil, nil).Maybe()
 		mockFetcher.EXPECT().FetchNotifications(mock.Anything, mock.Anything, true).Return(notifs, &models.SyncMeta{}, models.RateLimitInfo{Limit: 5000, Remaining: 5000}, nil).Maybe()
-		mockRepo.EXPECT().UpsertNotification(mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockRepo.EXPECT().UpsertNotifications(mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockRepo.EXPECT().GetNotification(mock.Anything, mock.Anything).Return(&triage.NotificationWithState{}, nil).Maybe()
 		mockRepo.EXPECT().MarkNotifiedBatch(mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockRepo.EXPECT().UpdateSyncMeta(mock.Anything, mock.Anything).Return(nil).Maybe()

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -42,7 +42,7 @@ func TestSyncEngine_Sync(t *testing.T) {
 		mockRepo.EXPECT().GetSyncMeta(mock.Anything, userID, "notifications").Return(meta, nil).Once()
 		mockAlerter.EXPECT().SyncStart(mock.Anything).Return().Once()
 		mockFetcher.EXPECT().FetchNotifications(mock.Anything, meta, false).Return(notifs, meta, models.RateLimitInfo{}, nil).Once()
-		mockRepo.EXPECT().UpsertNotification(mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.EXPECT().UpsertNotifications(mock.Anything, mock.Anything).Return(nil).Once()
 		mockRepo.EXPECT().GetNotification(mock.Anything, "1").Return(&triage.NotificationWithState{
 			State: triage.State{IsNotified: false},
 		}, nil).Once()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -35,7 +35,7 @@ func TestUpsertAndGetNotification(t *testing.T) {
 		UpdatedAt:          time.Now(),
 	}
 
-	err = db.UpsertNotification(ctx, notif)
+	err = db.UpsertNotifications(ctx, []triage.Notification{notif})
 	require.NoError(t, err)
 
 	// Verify retrieval
@@ -47,6 +47,43 @@ func TestUpsertAndGetNotification(t *testing.T) {
 	assert.Equal(t, 0, ns.Priority)
 	assert.Equal(t, "entry", ns.Status)
 	assert.False(t, ns.IsReadLocally)
+}
+
+func TestUpsertNotificationsBatch(t *testing.T) {
+	logger := slog.Default()
+	ctx := context.Background()
+	db, err := OpenInMemory(ctx, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	notifs := []triage.Notification{
+		{
+			GitHubID:           "1",
+			SubjectTitle:       "PR 1",
+			SubjectType:        "PullRequest",
+			RepositoryFullName: "owner/repo",
+			UpdatedAt:          time.Now(),
+		},
+		{
+			GitHubID:           "2",
+			SubjectTitle:       "PR 2",
+			SubjectType:        "PullRequest",
+			RepositoryFullName: "owner/repo",
+			UpdatedAt:          time.Now(),
+		},
+	}
+
+	err = db.UpsertNotifications(ctx, notifs)
+	require.NoError(t, err)
+
+	// Verify both exist
+	n1, err := db.GetNotification(ctx, "1")
+	require.NoError(t, err)
+	assert.Equal(t, "PR 1", n1.SubjectTitle)
+
+	n2, err := db.GetNotification(ctx, "2")
+	require.NoError(t, err)
+	assert.Equal(t, "PR 2", n2.SubjectTitle)
 }
 
 func TestUpsertPreservesLocalState(t *testing.T) {
@@ -62,7 +99,7 @@ func TestUpsertPreservesLocalState(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	require.NoError(t, db.UpsertNotification(ctx, notif))
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{notif}))
 
 	// Manually set some triage state
 	err = db.UpdateOrbitState(ctx, triage.State{
@@ -74,7 +111,7 @@ func TestUpsertPreservesLocalState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upsert again (as if from a new poll)
-	require.NoError(t, db.UpsertNotification(ctx, notif))
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{notif}))
 
 	// Verify triage state was NOT overwritten
 	ns, err := db.GetNotification(ctx, id)
@@ -94,12 +131,14 @@ func TestMarkNotifiedBatch(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	ids := []string{"1", "2", "3"}
+	var batch []triage.Notification
 	for _, id := range ids {
-		require.NoError(t, db.UpsertNotification(ctx, triage.Notification{
+		batch = append(batch, triage.Notification{
 			GitHubID:  id,
 			UpdatedAt: time.Now(),
-		}))
+		})
 	}
+	require.NoError(t, db.UpsertNotifications(ctx, batch))
 
 	// Batch mark
 	require.NoError(t, db.MarkNotifiedBatch(ctx, ids))
@@ -121,10 +160,10 @@ func TestRepository_Actions(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	id := "action-test"
-	require.NoError(t, db.UpsertNotification(ctx, triage.Notification{
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
 		GitHubID:  id,
 		UpdatedAt: time.Now(),
-	}))
+	}}))
 
 	// 1. Set Priority
 	require.NoError(t, db.SetPriority(ctx, id, 2))
@@ -181,10 +220,10 @@ func TestRepository_MetadataAndEnrichment(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	id := "enrich-test"
-	require.NoError(t, db.UpsertNotification(ctx, triage.Notification{
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
 		GitHubID:  id,
 		UpdatedAt: time.Now(),
-	}))
+	}}))
 
 	// 1. Enrich Notification (Combined body, author, etc)
 	require.NoError(t, db.EnrichNotification(ctx, id, "Some body", "author", "https://github.com/u", "OPEN"))
@@ -282,11 +321,11 @@ func TestRepository_UpdateByNodeID(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	id := "node-test"
-	require.NoError(t, db.UpsertNotification(ctx, triage.Notification{
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
 		GitHubID:      id,
 		SubjectNodeID: "node-123",
 		UpdatedAt:     time.Now(),
-	}))
+	}}))
 
 	// 1. Update Resource State by Node ID
 	require.NoError(t, db.UpdateResourceStateByNodeID(ctx, "node-123", "MERGED"))
@@ -402,8 +441,8 @@ func TestListNotifications(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	require.NoError(t, db.UpsertNotification(ctx, triage.Notification{GitHubID: "1", UpdatedAt: time.Now()}))
-	require.NoError(t, db.UpsertNotification(ctx, triage.Notification{GitHubID: "2", UpdatedAt: time.Now()}))
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{GitHubID: "1", UpdatedAt: time.Now()}}))
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{GitHubID: "2", UpdatedAt: time.Now()}}))
 
 	list, err := db.ListNotifications(ctx)
 	require.NoError(t, err)

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -11,52 +11,18 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 )
 
-// UpsertMetadata inserts or updates core notification metadata from API polling.
-func (db *DB) UpsertMetadata(ctx context.Context, n triage.Notification) error {
+// EnrichNotification updates a notification with detailed content (body, author).
+// It also propagates the state to all notifications sharing the same subject_node_id for consistency.
+func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// 1. Upsert notification metadata (API fields only)
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO notifications (
-			github_id, subject_title, subject_url, subject_type, reason, repository_full_name, html_url, subject_node_id, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(github_id) DO UPDATE SET
-			subject_title = excluded.subject_title,
-			subject_url = excluded.subject_url,
-			subject_type = excluded.subject_type,
-			reason = excluded.reason,
-			repository_full_name = excluded.repository_full_name,
-			html_url = excluded.html_url,
-			subject_node_id = COALESCE(NULLIF(excluded.subject_node_id, ''), notifications.subject_node_id),
-			updated_at = excluded.updated_at
-	`, n.GitHubID, n.SubjectTitle, n.SubjectURL, n.SubjectType, n.Reason, n.RepositoryFullName, n.HTMLURL, n.SubjectNodeID, n.UpdatedAt)
-	if err != nil {
-		return fmt.Errorf("failed to upsert metadata: %w", err)
-	}
-
-	// 2. Ensure orbit_state exists
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO orbit_state (notification_id, priority, status, is_read_locally)
-		VALUES (?, 0, 'entry', FALSE)
-		ON CONFLICT(notification_id) DO NOTHING
-	`, n.GitHubID)
-	if err != nil {
-		return fmt.Errorf("failed to ensure orbit state: %w", err)
-	}
-
-	return tx.Commit()
-}
-
-// EnrichNotification updates a notification with detailed content (body, author).
-// It also propagates the state to all notifications sharing the same subject_node_id for consistency.
-func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error {
 	// 1. Get the subject_node_id for this notification
 	var nodeID string
-	err := db.QueryRowContext(ctx, "SELECT subject_node_id FROM notifications WHERE github_id = ?", id).Scan(&nodeID)
+	err = tx.QueryRowContext(ctx, "SELECT subject_node_id FROM notifications WHERE github_id = ?", id).Scan(&nodeID)
 	if err != nil && err != sql.ErrNoRows {
 		return fmt.Errorf("failed to fetch node_id during enrichment: %w", err)
 	}
@@ -64,7 +30,7 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 	now := time.Now()
 
 	// 2. Update the primary target
-	_, err = db.ExecContext(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		UPDATE notifications
 		SET body = ?,
 		    author_login = ?,
@@ -80,7 +46,7 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 
 	// 3. Propagate to peers sharing the same subject (visual continuity win!)
 	if nodeID != "" {
-		_, err = db.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 			UPDATE notifications
 			SET resource_state = ?,
 			    body = CASE WHEN body = '' THEN ? ELSE body END,
@@ -94,7 +60,7 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 		}
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 // UpdateResourceStateByNodeID updates the live status of all resources sharing a GraphQL ID.
@@ -122,9 +88,61 @@ func (db *DB) UpdateSubjectNodeID(ctx context.Context, id, nodeID string) error 
 	return err
 }
 
-// UpsertNotification is a compatibility helper that performs a metadata upsert.
-func (db *DB) UpsertNotification(ctx context.Context, n triage.Notification) error {
-	return db.UpsertMetadata(ctx, n)
+// UpsertNotifications performs batch upsert of notifications in a single transaction.
+func (db *DB) UpsertNotifications(ctx context.Context, notifications []triage.Notification) error {
+	if len(notifications) == 0 {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmtNotifications, err := tx.PrepareContext(ctx, `
+		INSERT INTO notifications (
+			github_id, subject_title, subject_url, subject_type, reason, repository_full_name, html_url, subject_node_id, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(github_id) DO UPDATE SET
+			subject_title = excluded.subject_title,
+			subject_url = excluded.subject_url,
+			subject_type = excluded.subject_type,
+			reason = excluded.reason,
+			repository_full_name = excluded.repository_full_name,
+			html_url = excluded.html_url,
+			subject_node_id = COALESCE(NULLIF(excluded.subject_node_id, ''), notifications.subject_node_id),
+			updated_at = excluded.updated_at
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare notifications stmt: %w", err)
+	}
+	defer func() { _ = stmtNotifications.Close() }()
+
+	stmtState, err := tx.PrepareContext(ctx, `
+		INSERT INTO orbit_state (notification_id, priority, status, is_read_locally)
+		VALUES (?, 0, 'entry', FALSE)
+		ON CONFLICT(notification_id) DO NOTHING
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare orbit_state stmt: %w", err)
+	}
+	defer func() { _ = stmtState.Close() }()
+
+	for _, n := range notifications {
+		if _, err := stmtNotifications.ExecContext(ctx,
+			n.GitHubID, n.SubjectTitle, n.SubjectURL, n.SubjectType, n.Reason,
+			n.RepositoryFullName, n.HTMLURL, n.SubjectNodeID, n.UpdatedAt,
+		); err != nil {
+			return fmt.Errorf("failed to upsert metadata for %s: %w", n.GitHubID, err)
+		}
+
+		if _, err := stmtState.ExecContext(ctx, n.GitHubID); err != nil {
+			return fmt.Errorf("failed to ensure orbit state for %s: %w", n.GitHubID, err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 func baseNotificationSelect() string {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -47,7 +47,7 @@ func Open(ctx context.Context, logger *slog.Logger) (*DB, error) {
 	logger.InfoContext(ctx, "opening database", "path", primaryPath)
 
 	// modernc.org/sqlite driver
-	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)", primaryPath)
+	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_txlock=immediate", primaryPath)
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
@@ -281,7 +281,7 @@ var userHome = func() (string, error) {
 
 // OpenInMemory opens an in-memory SQLite database for testing.
 func OpenInMemory(ctx context.Context, logger *slog.Logger) (*DB, error) {
-	dsn := "file::memory:?cache=shared&_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)"
+	dsn := "file::memory:?cache=shared&_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_txlock=immediate"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open in-memory database: %w", err)

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -783,17 +783,17 @@ func (_c *MockRepository_UpdateSyncMeta_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// UpsertNotification provides a mock function with given fields: ctx, n
-func (_m *MockRepository) UpsertNotification(ctx context.Context, n triage.Notification) error {
-	ret := _m.Called(ctx, n)
+// UpsertNotifications provides a mock function with given fields: ctx, notifications
+func (_m *MockRepository) UpsertNotifications(ctx context.Context, notifications []triage.Notification) error {
+	ret := _m.Called(ctx, notifications)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpsertNotification")
+		panic("no return value specified for UpsertNotifications")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, triage.Notification) error); ok {
-		r0 = rf(ctx, n)
+	if rf, ok := ret.Get(0).(func(context.Context, []triage.Notification) error); ok {
+		r0 = rf(ctx, notifications)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -801,31 +801,31 @@ func (_m *MockRepository) UpsertNotification(ctx context.Context, n triage.Notif
 	return r0
 }
 
-// MockRepository_UpsertNotification_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertNotification'
-type MockRepository_UpsertNotification_Call struct {
+// MockRepository_UpsertNotifications_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertNotifications'
+type MockRepository_UpsertNotifications_Call struct {
 	*mock.Call
 }
 
-// UpsertNotification is a helper method to define mock.On call
+// UpsertNotifications is a helper method to define mock.On call
 //   - ctx context.Context
-//   - n triage.Notification
-func (_e *MockRepository_Expecter) UpsertNotification(ctx interface{}, n interface{}) *MockRepository_UpsertNotification_Call {
-	return &MockRepository_UpsertNotification_Call{Call: _e.mock.On("UpsertNotification", ctx, n)}
+//   - notifications []triage.Notification
+func (_e *MockRepository_Expecter) UpsertNotifications(ctx interface{}, notifications interface{}) *MockRepository_UpsertNotifications_Call {
+	return &MockRepository_UpsertNotifications_Call{Call: _e.mock.On("UpsertNotifications", ctx, notifications)}
 }
 
-func (_c *MockRepository_UpsertNotification_Call) Run(run func(ctx context.Context, n triage.Notification)) *MockRepository_UpsertNotification_Call {
+func (_c *MockRepository_UpsertNotifications_Call) Run(run func(ctx context.Context, notifications []triage.Notification)) *MockRepository_UpsertNotifications_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(triage.Notification))
+		run(args[0].(context.Context), args[1].([]triage.Notification))
 	})
 	return _c
 }
 
-func (_c *MockRepository_UpsertNotification_Call) Return(_a0 error) *MockRepository_UpsertNotification_Call {
+func (_c *MockRepository_UpsertNotifications_Call) Return(_a0 error) *MockRepository_UpsertNotifications_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockRepository_UpsertNotification_Call) RunAndReturn(run func(context.Context, triage.Notification) error) *MockRepository_UpsertNotification_Call {
+func (_c *MockRepository_UpsertNotifications_Call) RunAndReturn(run func(context.Context, []triage.Notification) error) *MockRepository_UpsertNotifications_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/mock_sync_repository.go
+++ b/internal/mocks/mock_sync_repository.go
@@ -237,17 +237,17 @@ func (_c *MockSyncRepository_UpdateSyncMeta_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// UpsertNotification provides a mock function with given fields: ctx, n
-func (_m *MockSyncRepository) UpsertNotification(ctx context.Context, n triage.Notification) error {
-	ret := _m.Called(ctx, n)
+// UpsertNotifications provides a mock function with given fields: ctx, notifications
+func (_m *MockSyncRepository) UpsertNotifications(ctx context.Context, notifications []triage.Notification) error {
+	ret := _m.Called(ctx, notifications)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpsertNotification")
+		panic("no return value specified for UpsertNotifications")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, triage.Notification) error); ok {
-		r0 = rf(ctx, n)
+	if rf, ok := ret.Get(0).(func(context.Context, []triage.Notification) error); ok {
+		r0 = rf(ctx, notifications)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -255,31 +255,31 @@ func (_m *MockSyncRepository) UpsertNotification(ctx context.Context, n triage.N
 	return r0
 }
 
-// MockSyncRepository_UpsertNotification_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertNotification'
-type MockSyncRepository_UpsertNotification_Call struct {
+// MockSyncRepository_UpsertNotifications_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertNotifications'
+type MockSyncRepository_UpsertNotifications_Call struct {
 	*mock.Call
 }
 
-// UpsertNotification is a helper method to define mock.On call
+// UpsertNotifications is a helper method to define mock.On call
 //   - ctx context.Context
-//   - n triage.Notification
-func (_e *MockSyncRepository_Expecter) UpsertNotification(ctx interface{}, n interface{}) *MockSyncRepository_UpsertNotification_Call {
-	return &MockSyncRepository_UpsertNotification_Call{Call: _e.mock.On("UpsertNotification", ctx, n)}
+//   - notifications []triage.Notification
+func (_e *MockSyncRepository_Expecter) UpsertNotifications(ctx interface{}, notifications interface{}) *MockSyncRepository_UpsertNotifications_Call {
+	return &MockSyncRepository_UpsertNotifications_Call{Call: _e.mock.On("UpsertNotifications", ctx, notifications)}
 }
 
-func (_c *MockSyncRepository_UpsertNotification_Call) Run(run func(ctx context.Context, n triage.Notification)) *MockSyncRepository_UpsertNotification_Call {
+func (_c *MockSyncRepository_UpsertNotifications_Call) Run(run func(ctx context.Context, notifications []triage.Notification)) *MockSyncRepository_UpsertNotifications_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(triage.Notification))
+		run(args[0].(context.Context), args[1].([]triage.Notification))
 	})
 	return _c
 }
 
-func (_c *MockSyncRepository_UpsertNotification_Call) Return(_a0 error) *MockSyncRepository_UpsertNotification_Call {
+func (_c *MockSyncRepository_UpsertNotifications_Call) Return(_a0 error) *MockSyncRepository_UpsertNotifications_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockSyncRepository_UpsertNotification_Call) RunAndReturn(run func(context.Context, triage.Notification) error) *MockSyncRepository_UpsertNotification_Call {
+func (_c *MockSyncRepository_UpsertNotifications_Call) RunAndReturn(run func(context.Context, []triage.Notification) error) *MockSyncRepository_UpsertNotifications_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -123,7 +123,7 @@ type ErrMsg struct{ Err error }
 type SyncRepository interface {
 	GetSyncMeta(ctx context.Context, userID, key string) (*models.SyncMeta, error)
 	UpdateSyncMeta(ctx context.Context, s models.SyncMeta) error
-	UpsertNotification(ctx context.Context, n triage.Notification) error
+	UpsertNotifications(ctx context.Context, notifications []triage.Notification) error
 	GetNotification(ctx context.Context, id string) (*triage.NotificationWithState, error)
 	MarkNotifiedBatch(ctx context.Context, ids []string) error
 }


### PR DESCRIPTION
## Overview
This PR addresses the `SQLITE_BUSY` error reported when saving notifications. The fix involves optimizing SQLite's concurrency handling and introducing batch upserts to minimize lock contention.

## Key Changes
- **SQLite Optimization**: Updated the connection DSN to include `busy_timeout(5000)`, `_txlock=immediate`, and `synchronous(NORMAL)`. This prevents deadlocks during lock escalation and provides a retry mechanism when the database is busy.
- **Batch Upsert**: Introduced `UpsertNotifications` in the `SyncRepository` interface and its implementation to perform notification upserts in a single transaction. This significantly reduces the number of write transactions during API synchronization.
- **Atomic Enrichment**: Wrapped the multiple SQL operations in `EnrichNotification` (fetching node ID, updating primary notification, and propagating to peers) within a single transaction to ensure data consistency.
- **Cleanup**: Removed the deprecated and unused `UpsertNotification` and `UpsertMetadata` methods.
- **Infrastructure**: Regenerated mocks and updated all existing tests and benchmarks to support the new batching interface.

## Related Issue
Fixes #86

## Verification
### Automated Tests
- Added `TestUpsertNotificationsBatch` in `internal/db/db_test.go` to verify the batch upsert functionality.
- Successfully ran all tests with `make test`.
- Verified build and linting with `make check`.

### Manual Verification
- Verified environment health using `gh orbit doctor`.
- Triggered manual syncs in the TUI to ensure no regressions in notification processing.
