### PR TITLE
refactor: reduce tui complexity hotspots

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -19,103 +19,16 @@ type RenderContext struct {
 // Layout: [Indicator][Icon][Unread][Badge] [Title] [ID] [Priority]
 func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) string {
 	const minTitleWidth = 10
-	const selectionIndicatorWidth = 2
-	styles := ctx.Styles
+	indicator := renderSelectionIndicator(ctx.Styles, ctx.IsSelected)
+	icon := renderNotificationIcon(n.SubjectType)
+	unread := renderUnreadIndicator(ctx.Styles, n.IsReadLocally)
+	badge := renderResourceStateBadge(ctx, n.ResourceState)
+	idStr := renderResourceID(ctx.Styles, n.SubjectURL)
+	priority := renderPriorityBadge(ctx.Styles, n.Priority)
+	titleWidth := calculateAvailableTitleWidth(ctx.Width, minTitleWidth, icon, unread, badge, idStr, priority)
+	title := renderNotificationTitle(ctx, n, titleWidth)
 
-	// 1. Selection Indicator
-	indicator := "  "
-	if ctx.IsSelected {
-		indicator = styles.Cursor.Render("▌ ")
-	}
-
-	// 2. Icon Selection
-	icon := "  "
-	switch n.SubjectType {
-	case "PullRequest":
-		icon = " "
-	case "Issue":
-		icon = " "
-	case "Discussion":
-		icon = " "
-	case "Release":
-		icon = " "
-	}
-
-	// 3. Unread Indicator
-	unread := renderUnreadIndicator(styles, n.IsReadLocally)
-
-	// 4. Resource ID Extraction
-	id := ""
-	if lastIdx := strings.LastIndex(n.SubjectURL, "/"); lastIdx != -1 {
-		id = "#" + n.SubjectURL[lastIdx+1:]
-	}
-	idStr := styles.SelectedDescription.Render(id)
-
-	// 5. Status Badge Logic
-	badge := ""
-	if ctx.IsFetching {
-		badge = styles.StateSkeleton.Render(" ◌ FETCH ")
-	} else if n.ResourceState != "" {
-		s := strings.ToUpper(n.ResourceState)
-		switch s {
-		case "OPEN":
-			badge = styles.StateOpen.Render("  OPEN ")
-		case "CLOSED":
-			badge = styles.StateClosed.Render("  CLOSED ")
-		case "MERGED":
-			badge = styles.StateMerged.Render("  MERGED ")
-		case "DRAFT":
-			badge = styles.StateDraft.Render("  DRAFT ")
-		default:
-			badge = styles.StateSkeleton.UnsetBlink().Render(fmt.Sprintf(" %s ", s))
-		}
-	} else {
-		// Placeholder for empty ResourceState to maintain consistent column alignment
-		badge = styles.StateSkeleton.Render(" ◌ PEND  ")
-	}
-
-	// 6. Priority Badge
-	priorityBadge := ""
-	switch n.Priority {
-	case 3:
-		priorityBadge = styles.PriorityHigh.Render(" [!!!]")
-	case 2:
-		priorityBadge = styles.PriorityMed.Render(" [!!]")
-	case 1:
-		priorityBadge = styles.PriorityLow.Render(" [!]")
-	}
-
-	// 7. Dynamic Width Calculation (Subtract-from-Total)
-	// We sum the visual width of all fixed components.
-	// Note: We add a small safety buffer (5 cells) to account for multi-byte glyphs (Nerd Fonts)
-	// which may render as 2 cells in some environments despite lipgloss.Width() reporting 1.
-	fixedWidth := selectionIndicatorWidth + lipgloss.Width(icon) + lipgloss.Width(unread) + lipgloss.Width(idStr) + 7 // +2 for spaces, +5 safety
-	if badge != "" {
-		fixedWidth += lipgloss.Width(badge) + 1
-	}
-	if priorityBadge != "" {
-		fixedWidth += lipgloss.Width(priorityBadge)
-	}
-
-	availableTitleWidth := ctx.Width - fixedWidth
-	if availableTitleWidth < minTitleWidth {
-		availableTitleWidth = minTitleWidth
-	}
-
-	// 8. Title Styling & Truncation
-	titleStr := n.SubjectTitle
-	titleStyle := styles.Unread
-	if n.IsReadLocally {
-		titleStyle = styles.SelectedDescription
-	}
-	if ctx.IsSelected {
-		titleStyle = styles.SelectedTitle
-	}
-	title := titleStyle.Width(availableTitleWidth).MaxWidth(availableTitleWidth).Render(titleStr)
-
-	// 9. Assembly
-	// We use exact spacing to ensure width remains within ctx.Width
-	return fmt.Sprintf("%s%s%s%s%s%s%s", indicator, icon, unread, badge, title, idStr, priorityBadge)
+	return fmt.Sprintf("%s%s%s%s%s%s%s", indicator, icon, unread, badge, title, idStr, priority)
 }
 
 func renderUnreadIndicator(styles Styles, isRead bool) string {
@@ -123,4 +36,101 @@ func renderUnreadIndicator(styles Styles, isRead bool) string {
 		return "  "
 	}
 	return styles.Unread.Render("• ")
+}
+
+func renderSelectionIndicator(styles Styles, isSelected bool) string {
+	if isSelected {
+		return styles.Cursor.Render("▌ ")
+	}
+	return "  "
+}
+
+func renderNotificationIcon(subjectType string) string {
+	switch subjectType {
+	case "PullRequest":
+		return " "
+	case "Issue":
+		return " "
+	case "Discussion":
+		return " "
+	case "Release":
+		return " "
+	default:
+		return "  "
+	}
+}
+
+func renderResourceID(styles Styles, subjectURL string) string {
+	id := ""
+	if lastIdx := strings.LastIndex(subjectURL, "/"); lastIdx != -1 {
+		id = "#" + subjectURL[lastIdx+1:]
+	}
+	return styles.SelectedDescription.Render(id)
+}
+
+func renderResourceStateBadge(ctx RenderContext, resourceState string) string {
+	styles := ctx.Styles
+	if ctx.IsFetching {
+		return styles.StateSkeleton.Render(" ◌ FETCH ")
+	}
+	if resourceState == "" {
+		return styles.StateSkeleton.Render(" ◌ PEND  ")
+	}
+
+	s := strings.ToUpper(resourceState)
+	switch s {
+	case "OPEN":
+		return styles.StateOpen.Render("  OPEN ")
+	case "CLOSED":
+		return styles.StateClosed.Render("  CLOSED ")
+	case "MERGED":
+		return styles.StateMerged.Render("  MERGED ")
+	case "DRAFT":
+		return styles.StateDraft.Render("  DRAFT ")
+	default:
+		return styles.StateSkeleton.UnsetBlink().Render(fmt.Sprintf(" %s ", s))
+	}
+}
+
+func renderPriorityBadge(styles Styles, priority int) string {
+	switch priority {
+	case 3:
+		return styles.PriorityHigh.Render(" [!!!]")
+	case 2:
+		return styles.PriorityMed.Render(" [!!]")
+	case 1:
+		return styles.PriorityLow.Render(" [!]")
+	default:
+		return ""
+	}
+}
+
+func calculateAvailableTitleWidth(totalWidth, minTitleWidth int, icon, unread, badge, idStr, priority string) int {
+	const selectionIndicatorWidth = 2
+	const layoutSafetyBuffer = 7 // 2 spaces + 5 extra cells for multi-width glyphs.
+
+	fixedWidth := selectionIndicatorWidth + lipgloss.Width(icon) + lipgloss.Width(unread) + lipgloss.Width(idStr) + layoutSafetyBuffer
+	if badge != "" {
+		fixedWidth += lipgloss.Width(badge) + 1
+	}
+	if priority != "" {
+		fixedWidth += lipgloss.Width(priority)
+	}
+
+	availableTitleWidth := totalWidth - fixedWidth
+	if availableTitleWidth < minTitleWidth {
+		return minTitleWidth
+	}
+	return availableTitleWidth
+}
+
+func renderNotificationTitle(ctx RenderContext, n triage.NotificationWithState, width int) string {
+	titleStyle := ctx.Styles.Unread
+	if n.IsReadLocally {
+		titleStyle = ctx.Styles.SelectedDescription
+	}
+	if ctx.IsSelected {
+		titleStyle = ctx.Styles.SelectedTitle
+	}
+	return titleStyle.Width(width).MaxWidth(width).Render(n.SubjectTitle)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -47,6 +47,14 @@ type DetailModel struct {
 	lastRenderedWidth int
 }
 
+// notificationStore defines the notification persistence behavior the TUI needs.
+type notificationStore interface {
+	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
+	MarkReadLocally(ctx context.Context, id string, isRead bool) error
+	SetPriority(ctx context.Context, id string, priority int) error
+	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error
+}
+
 // Model represents the application state.
 type Model struct {
 	// Sub-Models
@@ -54,7 +62,7 @@ type Model struct {
 	detailView DetailModel
 
 	// Shared State & Services (Interfaces)
-	db               types.Repository
+	db               notificationStore
 	client           github.Client
 	sync             types.Syncer
 	enrich           types.Enricher
@@ -120,7 +128,7 @@ func NewModel(
 	userID string,
 	cfg *config.Config,
 	logger *slog.Logger,
-	database types.Repository,
+	database notificationStore,
 	client github.Client,
 	syncer types.Syncer,
 	enricher types.Enricher,

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// TestingT is a common interface for *testing.T and *testing.B
+// TestingT is a common interface for *testing.T and *testing.B.
 type TestingT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -52,100 +52,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) transitionGlobal(msg tea.Msg) []Action {
-	var actions []Action
-
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-		m.ui.SetSize(msg.Width, msg.Height)
-
-		m.headerHeight = lipgloss.Height(m.renderHeader())
-		m.footerHeight = lipgloss.Height(m.renderFooter())
-		availableHeight := m.height - m.headerHeight - m.footerHeight
-
-		m.listView.list.SetSize(msg.Width, availableHeight)
-
-		m.detailView.viewport.SetWidth(msg.Width - 4)
-		m.detailView.viewport.SetHeight(availableHeight - 2)
-		m.updateMarkdownRenderer()
-
+		m.handleWindowSize(msg)
 	case tea.BackgroundColorMsg:
-		m.isDark = msg.IsDark()
-		m.styles = DefaultStyles(m.isDark)
-		m.listView.list.Styles.Title = m.styles.Title
-		m.listView.delegate = newItemDelegate(m.styles, m.keys)
-		m.listView.list.SetDelegate(m.listView.delegate)
-		m.updateMarkdownRenderer()
-		m.ui.SetStyles(m.styles)
-
+		m.handleBackgroundColor(msg)
 	case notificationsLoadedMsg:
-		m.allNotifications = msg.notifications
-		m.applyFilters()
-		if m.state == StateDetail {
-			m.refreshDetailView()
-		}
-		if msg.IsInitial {
-			actions = append(actions, ActionEnrichItems{Notifications: m.getVisibleNotifications()})
-			actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
-		}
-
+		return m.handleNotificationsLoaded(msg)
 	case priorityUpdatedMsg:
-		m.allNotifications = msg.notifications
-		m.applyFilters()
-		actions = append(actions, ActionShowToast{Message: msg.toast})
-
+		return m.handlePriorityUpdated(msg)
 	case syncCompleteMsg:
-		m.ui.SetSyncing(false)
-		// Rate limit update is an imperative effect, but tracked in model
-		m.LastSyncAt = time.Now()
-		m.RateLimit = msg.rateLimit
-		actions = append(actions, ActionUpdateRateLimit{Info: msg.rateLimit})
-		actions = append(actions, ActionLoadNotifications{}) // Reload after sync
-
+		return m.handleSyncComplete(msg)
 	case detailLoadedMsg:
-		m.ui.SetFetching(false)
-		for idx, n := range m.allNotifications {
-			if n.GitHubID == msg.GitHubID {
-				m.allNotifications[idx].Body = msg.Body
-				m.allNotifications[idx].AuthorLogin = msg.Author
-				m.allNotifications[idx].HTMLURL = msg.HTMLURL
-				m.allNotifications[idx].ResourceState = msg.ResourceState
-				m.allNotifications[idx].IsEnriched = true
-				break
-			}
-		}
-		if m.state == StateDetail {
-			m.applyFilters() // This updates the items in the list from the modified allNotifications
-			m.refreshDetailView()
-		} else {
-			m.applyFilters()
-		}
-
+		m.handleDetailLoaded(msg)
 	case pollTickMsg:
-		if msg.ID == m.heartbeatID {
-			if time.Since(m.LastSyncAt).Seconds() >= float64(m.PollInterval) {
-				actions = append(actions, ActionSyncNotifications{Force: false})
-				m.ui.SetSyncing(true)
-			}
-			actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
-		}
-
+		return m.handlePollTick(msg)
 	case clockTickMsg:
-		if msg.ID == m.clockID {
-			actions = append(actions, ActionScheduleTick{TickType: TickClock, Interval: m.clockInterval})
-		}
-
+		return m.handleClockTick(msg)
 	case viewportEnrichMsg:
-		actions = append(actions, ActionEnrichItems{Notifications: m.getVisibleNotifications()})
-
+		return []Action{ActionEnrichItems{Notifications: m.getVisibleNotifications()}}
 	case types.ErrMsg:
-		m.err = msg.Err
-		m.ui.SetSyncing(false)
-		m.ui.SetFetching(false)
+		m.handleTransitionError(msg)
 	}
 
-	return actions
+	return nil
 }
 
 func (m *Model) Transition(msg tea.Msg, oldIndex int) []Action {
@@ -202,101 +132,12 @@ func (m *Model) handleQuitTransition() []Action {
 }
 
 func (m *Model) transitionList(msg tea.Msg) []Action {
-	var actions []Action
-
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		if m.listView.list.FilterState() == list.Filtering {
-			break
-		}
-
-		switch {
-		case msg.String() == "ctrl+c":
-			actions = append(actions, ActionQuit{})
-		case key.Matches(msg, m.keys.Quit):
-			if !m.listView.list.Help.ShowAll {
-				return m.handleQuitTransition()
-			}
-		case key.Matches(msg, m.keys.Sync):
-			if !m.ui.syncing {
-				actions = append(actions, ActionSyncNotifications{Force: true})
-				m.ui.SetSyncing(true)
-			}
-		case key.Matches(msg, m.keys.ToggleDetail):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				m.state = StateDetail
-				if !i.notification.IsEnriched {
-					m.ui.SetFetching(true)
-					actions = append(actions, ActionEnrichItems{Notifications: []triage.NotificationWithState{i.notification}})
-				}
-				m.refreshDetailView()
-			}
-		case key.Matches(msg, m.keys.ToggleRead):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				newState := !i.notification.IsReadLocally
-				actions = append(actions, ActionMarkRead{ID: i.notification.GitHubID, Read: newState})
-				toast := "Marked as unread"
-				if newState {
-					toast = "Marked as read"
-				}
-				actions = append(actions, ActionShowToast{Message: toast})
-			}
-		case key.Matches(msg, m.keys.NextTab):
-			m.listView.activeTab = (m.listView.activeTab + 1) % 4
-			m.applyFilters()
-		case key.Matches(msg, m.keys.PrevTab):
-			m.listView.activeTab = (m.listView.activeTab - 1 + 4) % 4
-			m.applyFilters()
-		case key.Matches(msg, m.keys.Tab1):
-			m.listView.activeTab = TabInbox
-			m.applyFilters()
-		case key.Matches(msg, m.keys.Tab2):
-			m.listView.activeTab = TabUnread
-			m.applyFilters()
-		case key.Matches(msg, m.keys.Tab3):
-			m.listView.activeTab = TabTriaged
-			m.applyFilters()
-		case key.Matches(msg, m.keys.Tab4):
-			m.listView.activeTab = TabAll
-			m.applyFilters()
-		case key.Matches(msg, m.keys.OpenBrowser):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				actions = append(actions, ActionViewWeb{Notification: i.notification})
-			}
-		case key.Matches(msg, m.keys.CheckoutPR):
-			if i, ok := m.listView.list.SelectedItem().(item); ok && i.notification.SubjectType == "PullRequest" {
-				number := extractNumberFromURL(i.notification.SubjectURL)
-				if number != "" {
-					actions = append(actions, ActionCheckoutPR{Repository: i.notification.RepositoryFullName, Number: number})
-				}
-			}
-		case key.Matches(msg, m.keys.FilterPR):
-			m.toggleResourceFilter("PullRequest", "PRs")
-		case key.Matches(msg, m.keys.FilterIssue):
-			m.toggleResourceFilter("Issue", "Issues")
-		case key.Matches(msg, m.keys.FilterDiscussion):
-			m.toggleResourceFilter("Discussion", "Discussions")
-		case key.Matches(msg, m.keys.PriorityUp):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				newP := (i.notification.Priority + 1) % 4
-				actions = append(actions, ActionSetPriority{ID: i.notification.GitHubID, Priority: newP})
-				actions = append(actions, ActionShowToast{Message: m.getPriorityToast(newP)})
-			}
-		case key.Matches(msg, m.keys.PriorityDown):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				newP := (i.notification.Priority - 1 + 4) % 4
-				actions = append(actions, ActionSetPriority{ID: i.notification.GitHubID, Priority: newP})
-				actions = append(actions, ActionShowToast{Message: m.getPriorityToast(newP)})
-			}
-		case key.Matches(msg, m.keys.PriorityNone):
-			if i, ok := m.listView.list.SelectedItem().(item); ok {
-				actions = append(actions, ActionSetPriority{ID: i.notification.GitHubID, Priority: 0})
-				actions = append(actions, ActionShowToast{Message: "Priority cleared"})
-			}
-		}
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok || m.listView.list.FilterState() == list.Filtering {
+		return nil
 	}
 
-	return actions
+	return m.handleListKey(keyMsg)
 }
 
 func (m *Model) getPriorityToast(p int) string {
@@ -447,5 +288,259 @@ func (m *Model) toggleResourceFilter(resType, label string) {
 		m.listView.resourceFilter = resType
 		m.ui.SetResourceFilter(label)
 	}
+	m.applyFilters()
+}
+
+func (m *Model) handleWindowSize(msg tea.WindowSizeMsg) {
+	m.width = msg.Width
+	m.height = msg.Height
+	m.ui.SetSize(msg.Width, msg.Height)
+
+	m.headerHeight = lipgloss.Height(m.renderHeader())
+	m.footerHeight = lipgloss.Height(m.renderFooter())
+	availableHeight := m.height - m.headerHeight - m.footerHeight
+
+	m.listView.list.SetSize(msg.Width, availableHeight)
+	m.detailView.viewport.SetWidth(msg.Width - 4)
+	m.detailView.viewport.SetHeight(availableHeight - 2)
+	m.updateMarkdownRenderer()
+}
+
+func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
+	m.isDark = msg.IsDark()
+	m.styles = DefaultStyles(m.isDark)
+	m.listView.list.Styles.Title = m.styles.Title
+	m.listView.delegate = newItemDelegate(m.styles, m.keys)
+	m.listView.list.SetDelegate(m.listView.delegate)
+	m.updateMarkdownRenderer()
+	m.ui.SetStyles(m.styles)
+}
+
+func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
+	m.allNotifications = msg.notifications
+	m.applyFilters()
+	if m.state == StateDetail {
+		m.refreshDetailView()
+	}
+	if !msg.IsInitial {
+		return nil
+	}
+	return []Action{
+		ActionEnrichItems{Notifications: m.getVisibleNotifications()},
+		ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval},
+	}
+}
+
+func (m *Model) handlePriorityUpdated(msg priorityUpdatedMsg) []Action {
+	m.allNotifications = msg.notifications
+	m.applyFilters()
+	return []Action{ActionShowToast{Message: msg.toast}}
+}
+
+func (m *Model) handleSyncComplete(msg syncCompleteMsg) []Action {
+	m.ui.SetSyncing(false)
+	m.LastSyncAt = time.Now()
+	m.RateLimit = msg.rateLimit
+	return []Action{
+		ActionUpdateRateLimit{Info: msg.rateLimit},
+		ActionLoadNotifications{},
+	}
+}
+
+func (m *Model) handleDetailLoaded(msg detailLoadedMsg) {
+	m.ui.SetFetching(false)
+	for idx, n := range m.allNotifications {
+		if n.GitHubID != msg.GitHubID {
+			continue
+		}
+		m.allNotifications[idx].Body = msg.Body
+		m.allNotifications[idx].AuthorLogin = msg.Author
+		m.allNotifications[idx].HTMLURL = msg.HTMLURL
+		m.allNotifications[idx].ResourceState = msg.ResourceState
+		m.allNotifications[idx].IsEnriched = true
+		break
+	}
+
+	m.applyFilters()
+	if m.state == StateDetail {
+		m.refreshDetailView()
+	}
+}
+
+func (m *Model) handlePollTick(msg pollTickMsg) []Action {
+	if msg.ID != m.heartbeatID {
+		return nil
+	}
+
+	actions := []Action{ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval}}
+	if time.Since(m.LastSyncAt).Seconds() < float64(m.PollInterval) {
+		return actions
+	}
+
+	m.ui.SetSyncing(true)
+	return append(actions, ActionSyncNotifications{Force: false})
+}
+
+func (m *Model) handleClockTick(msg clockTickMsg) []Action {
+	if msg.ID != m.clockID {
+		return nil
+	}
+	return []Action{ActionScheduleTick{TickType: TickClock, Interval: m.clockInterval}}
+}
+
+func (m *Model) handleTransitionError(msg types.ErrMsg) {
+	m.err = msg.Err
+	m.ui.SetSyncing(false)
+	m.ui.SetFetching(false)
+}
+
+func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
+	switch {
+	case msg.String() == "ctrl+c":
+		return []Action{ActionQuit{}}
+	case key.Matches(msg, m.keys.Quit):
+		if !m.listView.list.Help.ShowAll {
+			return m.handleQuitTransition()
+		}
+	case key.Matches(msg, m.keys.Sync):
+		return m.handleSyncKey()
+	case key.Matches(msg, m.keys.ToggleDetail):
+		return m.handleToggleDetailKey()
+	case key.Matches(msg, m.keys.ToggleRead):
+		return m.handleToggleReadKey()
+	case key.Matches(msg, m.keys.NextTab):
+		m.cycleTab(1)
+	case key.Matches(msg, m.keys.PrevTab):
+		m.cycleTab(-1)
+	case key.Matches(msg, m.keys.Tab1):
+		m.setActiveTab(TabInbox)
+	case key.Matches(msg, m.keys.Tab2):
+		m.setActiveTab(TabUnread)
+	case key.Matches(msg, m.keys.Tab3):
+		m.setActiveTab(TabTriaged)
+	case key.Matches(msg, m.keys.Tab4):
+		m.setActiveTab(TabAll)
+	case key.Matches(msg, m.keys.OpenBrowser):
+		return m.handleOpenBrowserKey()
+	case key.Matches(msg, m.keys.CheckoutPR):
+		return m.handleCheckoutPRKey()
+	case key.Matches(msg, m.keys.FilterPR):
+		m.toggleResourceFilter("PullRequest", "PRs")
+	case key.Matches(msg, m.keys.FilterIssue):
+		m.toggleResourceFilter("Issue", "Issues")
+	case key.Matches(msg, m.keys.FilterDiscussion):
+		m.toggleResourceFilter("Discussion", "Discussions")
+	case key.Matches(msg, m.keys.PriorityUp):
+		return m.handlePriorityKey(1)
+	case key.Matches(msg, m.keys.PriorityDown):
+		return m.handlePriorityKey(-1)
+	case key.Matches(msg, m.keys.PriorityNone):
+		return m.handleClearPriorityKey()
+	}
+	return nil
+}
+
+func (m *Model) handleSyncKey() []Action {
+	if m.ui.syncing {
+		return nil
+	}
+	m.ui.SetSyncing(true)
+	return []Action{ActionSyncNotifications{Force: true}}
+}
+
+func (m *Model) handleToggleDetailKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+
+	m.state = StateDetail
+	actions := []Action{}
+	if !n.IsEnriched {
+		m.ui.SetFetching(true)
+		actions = append(actions, ActionEnrichItems{Notifications: []triage.NotificationWithState{n}})
+	}
+	m.refreshDetailView()
+	return actions
+}
+
+func (m *Model) handleToggleReadKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+
+	newState := !n.IsReadLocally
+	toast := "Marked as unread"
+	if newState {
+		toast = "Marked as read"
+	}
+
+	return []Action{
+		ActionMarkRead{ID: n.GitHubID, Read: newState},
+		ActionShowToast{Message: toast},
+	}
+}
+
+func (m *Model) handleOpenBrowserKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+	return []Action{ActionViewWeb{Notification: n}}
+}
+
+func (m *Model) handleCheckoutPRKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok || n.SubjectType != "PullRequest" {
+		return nil
+	}
+
+	number := extractNumberFromURL(n.SubjectURL)
+	if number == "" {
+		return nil
+	}
+	return []Action{ActionCheckoutPR{Repository: n.RepositoryFullName, Number: number}}
+}
+
+func (m *Model) handlePriorityKey(delta int) []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+
+	newPriority := (n.Priority + delta + 4) % 4
+	return []Action{
+		ActionSetPriority{ID: n.GitHubID, Priority: newPriority},
+		ActionShowToast{Message: m.getPriorityToast(newPriority)},
+	}
+}
+
+func (m *Model) handleClearPriorityKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+	return []Action{
+		ActionSetPriority{ID: n.GitHubID, Priority: 0},
+		ActionShowToast{Message: "Priority cleared"},
+	}
+}
+
+func (m *Model) selectedNotification() (triage.NotificationWithState, bool) {
+	i, ok := m.listView.list.SelectedItem().(item)
+	if !ok {
+		return triage.NotificationWithState{}, false
+	}
+	return i.notification, true
+}
+
+func (m *Model) cycleTab(delta int) {
+	m.listView.activeTab = (m.listView.activeTab + delta + 4) % 4
+	m.applyFilters()
+}
+
+func (m *Model) setActiveTab(tab int) {
+	m.listView.activeTab = tab
 	m.applyFilters()
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Note: stripANSI is already defined in test_utils.go
+// Note: stripANSI is already defined in test_utils_test.go.
 
 func TestRenderNotificationRow_States(t *testing.T) {
 	ctx := RenderContext{


### PR DESCRIPTION
## Summary
- move TUI test helpers into `*_test.go` so production `internal/tui` no longer imports test mocks
- narrow the TUI notification persistence dependency to a local behavior-shaped interface
- split `internal/tui/update.go` and `RenderNotificationRow` into smaller focused handlers/helpers to reduce complexity

## Validation
- `go test ./internal/tui`
- `make generate && make check`

## Notes
- production `internal/tui` no longer imports `internal/mocks`
- the main TUI transition hotspot dropped from cyclomatic complexity 35 to 21

Refs #98
