### PR TITLE
feat: hide outdated notifications by age

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,11 +28,12 @@ type EnrichmentConfig struct {
 
 // NotificationsConfig represents the settings for system alerts.
 type NotificationsConfig struct {
-	Enabled      bool     `yaml:"enabled"`
-	Mute         bool     `yaml:"mute"`
-	SyncInterval int      `yaml:"sync_interval"`
-	Reasons      []string `yaml:"reasons"`
-	IgnoreRepos  []string `yaml:"ignore_repos"`
+	Enabled           bool     `yaml:"enabled"`
+	Mute              bool     `yaml:"mute"`
+	SyncInterval      int      `yaml:"sync_interval"`
+	MaxVisibleAgeDays int      `yaml:"max_visible_age_days"`
+	Reasons           []string `yaml:"reasons"`
+	IgnoreRepos       []string `yaml:"ignore_repos"`
 }
 
 // DefaultConfig returns the default configuration values.
@@ -40,11 +41,12 @@ func DefaultConfig() *Config {
 	return &Config{
 		Version: 1,
 		Notifications: NotificationsConfig{
-			Enabled:      true,
-			Mute:         false,
-			SyncInterval: 60,
-			Reasons:      []string{"assign", "mention", "review_requested"},
-			IgnoreRepos:  []string{},
+			Enabled:           true,
+			Mute:              false,
+			SyncInterval:      60,
+			MaxVisibleAgeDays: 365,
+			Reasons:           []string{"assign", "mention", "review_requested"},
+			IgnoreRepos:       []string{},
 		},
 		Enrichment: EnrichmentConfig{
 			DebounceMS:  250,
@@ -64,6 +66,9 @@ func (c *Config) Validate() error {
 	// 2. Notifications Validation
 	if c.Notifications.SyncInterval < 10 || c.Notifications.SyncInterval > 3600 {
 		return fmt.Errorf("notifications.sync_interval must be between 10 and 3600 seconds, got %d", c.Notifications.SyncInterval)
+	}
+	if c.Notifications.MaxVisibleAgeDays < 0 || c.Notifications.MaxVisibleAgeDays > 3650 {
+		return fmt.Errorf("notifications.max_visible_age_days must be between 0 and 3650 days, got %d", c.Notifications.MaxVisibleAgeDays)
 	}
 
 	// 3. Enrichment Validation

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,6 +33,22 @@ func TestConfig_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "notifications.sync_interval must be between 10 and 3600")
 	})
 
+	t.Run("Invalid MaxVisibleAgeDays (Too Low)", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Notifications.MaxVisibleAgeDays = -1
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notifications.max_visible_age_days must be between 0 and 3650 days")
+	})
+
+	t.Run("Invalid MaxVisibleAgeDays (Too High)", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Notifications.MaxVisibleAgeDays = 3651
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notifications.max_visible_age_days must be between 0 and 3650 days")
+	})
+
 	t.Run("Invalid DebounceMS", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Enrichment.DebounceMS = 10
@@ -99,6 +115,23 @@ notifications:
 		assert.False(t, cfg.Notifications.Enabled)
 		// Verify default was preserved for missing field
 		assert.Equal(t, 60, cfg.Notifications.SyncInterval)
+		assert.Equal(t, 365, cfg.Notifications.MaxVisibleAgeDays)
+	})
+
+	t.Run("Successful Load with Explicit MaxVisibleAgeDays", func(t *testing.T) {
+		content := `
+version: 1
+notifications:
+  enabled: true
+  max_visible_age_days: 30
+`
+		err := os.WriteFile(expectedPath, []byte(content), 0o600)
+		require.NoError(t, err)
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 30, cfg.Notifications.MaxVisibleAgeDays)
 	})
 }
 

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // keyPress is a helper to create a KeyPressMsg for tests.
@@ -113,6 +115,7 @@ func TestModel_Transition_Navigation(t *testing.T) {
 			GitHubID:    "1",
 			SubjectURL:  "https://api.github.com/repos/o/r/pulls/1",
 			SubjectType: "PullRequest",
+			UpdatedAt:   time.Now(),
 		},
 	}
 	m.allNotifications = []triage.NotificationWithState{notif}
@@ -179,8 +182,8 @@ func TestModel_Transition_Enrichment(t *testing.T) {
 	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notifs := []triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1", IsEnriched: false}},
-		{Notification: triage.Notification{GitHubID: "2", IsEnriched: false}},
+		{Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "2", IsEnriched: false, UpdatedAt: time.Now()}},
 	}
 	m.allNotifications = notifs
 	m.applyFilters()
@@ -222,6 +225,85 @@ func TestModel_Transition_Filtering(t *testing.T) {
 	// 2. Toggle off
 	_ = m.Transition(msg, 0)
 	assert.Equal(t, "", m.listView.resourceFilter)
+}
+
+func TestModel_ApplyFilters_HidesNotificationsOlderThanConfiguredDays(t *testing.T) {
+	m := newTestModel(t)
+	m.listView.activeTab = TabAll
+	m.config.Notifications.MaxVisibleAgeDays = 365
+
+	oldNotification := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "old",
+			SubjectType: "PullRequest",
+			UpdatedAt:   daysAgo(366),
+		},
+	}
+	recentNotification := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "recent",
+			SubjectType: "PullRequest",
+			UpdatedAt:   daysAgo(30),
+		},
+	}
+
+	m.allNotifications = []triage.NotificationWithState{oldNotification, recentNotification}
+	m.applyFilters()
+
+	require.Len(t, m.listView.list.Items(), 1)
+	item, ok := m.listView.list.Items()[0].(item)
+	require.True(t, ok)
+	assert.Equal(t, "recent", item.notification.GitHubID)
+}
+
+func TestModel_ApplyFilters_ZeroVisibleAgeDaysDisablesCutoff(t *testing.T) {
+	m := newTestModel(t)
+	m.listView.activeTab = TabAll
+	m.config.Notifications.MaxVisibleAgeDays = 0
+
+	m.allNotifications = []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "old", SubjectType: "PullRequest", UpdatedAt: daysAgo(900)}},
+		{Notification: triage.Notification{GitHubID: "recent", SubjectType: "PullRequest", UpdatedAt: daysAgo(30)}},
+	}
+	m.applyFilters()
+
+	assert.Len(t, m.listView.list.Items(), 2)
+}
+
+func TestModel_ApplyFilters_UsesGitHubUpdatedAtInsteadOfRecentLocalActivity(t *testing.T) {
+	m := newTestModel(t)
+	m.listView.activeTab = TabAll
+	m.config.Notifications.MaxVisibleAgeDays = 365
+
+	oldButRecentlyTouched := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:      "old",
+			SubjectType:   "PullRequest",
+			UpdatedAt:     daysAgo(500),
+			IsEnriched:    true,
+			EnrichedAt:    sql.NullTime{Time: time.Now(), Valid: true},
+			ResourceState: "OPEN",
+		},
+		State: triage.State{
+			Priority:      3,
+			IsReadLocally: true,
+		},
+	}
+	recentNotification := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "recent",
+			SubjectType: "PullRequest",
+			UpdatedAt:   daysAgo(10),
+		},
+	}
+
+	m.allNotifications = []triage.NotificationWithState{oldButRecentlyTouched, recentNotification}
+	m.applyFilters()
+
+	require.Len(t, m.listView.list.Items(), 1)
+	item, ok := m.listView.list.Items()[0].(item)
+	require.True(t, ok)
+	assert.Equal(t, "recent", item.notification.GitHubID)
 }
 
 func TestHelpers(t *testing.T) {

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -22,7 +22,7 @@ type TestingT interface {
 
 // newTestModel creates a model with basic mocks.
 func newTestModel(t TestingT) *Model {
-	cfg := &config.Config{}
+	cfg := config.DefaultConfig()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	userID := "test-user"
 
@@ -71,6 +71,7 @@ func newTestModel(t TestingT) *Model {
 				SubjectTitle:       "Default Title",
 				RepositoryFullName: "owner/repo",
 				SubjectType:        "",
+				UpdatedAt:          time.Now(),
 			},
 		},
 	}
@@ -78,6 +79,10 @@ func newTestModel(t TestingT) *Model {
 
 	m.ui.SetSize(80, 24)
 	return m
+}
+
+func daysAgo(days int) time.Time {
+	return time.Now().AddDate(0, 0, -days)
 }
 
 // stripANSI is a simple utility to remove ANSI codes for content-based assertions.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -252,6 +252,10 @@ func (m *Model) applyFilters() {
 			}
 		}
 
+		if keep && !m.isNotificationWithinVisibleAge(n, time.Now()) {
+			keep = false
+		}
+
 		if keep {
 			filtered = append(filtered, item{notification: n})
 		}
@@ -278,6 +282,23 @@ func (m *Model) applyFilters() {
 			}
 		}
 	}
+}
+
+func (m *Model) isNotificationWithinVisibleAge(n triage.NotificationWithState, now time.Time) bool {
+	maxVisibleAgeDays := m.maxVisibleNotificationAgeDays()
+	if maxVisibleAgeDays == 0 || n.UpdatedAt.IsZero() {
+		return true
+	}
+
+	cutoff := now.AddDate(0, 0, -maxVisibleAgeDays)
+	return !n.UpdatedAt.Before(cutoff)
+}
+
+func (m *Model) maxVisibleNotificationAgeDays() int {
+	if m.config == nil {
+		return 0
+	}
+	return m.config.Notifications.MaxVisibleAgeDays
 }
 
 func (m *Model) toggleResourceFilter(resType, label string) {


### PR DESCRIPTION
## Summary
- add `notifications.max_visible_age_days` with a default of `365` days and `0` meaning unlimited
- hide outdated notifications in the TUI using GitHub `UpdatedAt` rather than local enrichment or triage activity
- add focused config and TUI tests, including coverage for an old notification that was touched locally recently

## Validation
- `go test ./internal/config ./internal/tui`
- `make generate && make check`

## Notes
- the age filter remains a display-layer concern in this slice; old notifications stay stored locally
- visibility is based on GitHub/source `updated_at` semantics, not local timestamps

Refs #124
