### PR TITLE
chore: remove redundant Reviewer Plan Mode mandate

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,11 +21,7 @@ Strictly follow the shell safety protocols defined in [.agent/rules/shell-safety
 
 Mandatory adherence to the [Strategy Review Workflow](.agent/workflows/strategy-review/WORKFLOW.md) before any changes to `internal/` or `cmd/`.
 
-### 2.4 Reviewer Plan Mode
-
-When acting as a Reviewer, you should use `enter_plan_mode` for the research and analysis phase. Use this phase to read source files and perform online research (`google_web_search`, `web_fetch`) for latest best practices. Since Plan Mode prevents all file writes, you must finalize your analysis and then transition to active mode strictly to write your findings to `.agents/feedback.md`.
-
-### 2.5 Sandbox & macOS Seatbelt
+### 2.4 Sandbox & macOS Seatbelt
 
 This project is configured with a restricted sandbox for AI tools (macOS Seatbelt).
 


### PR DESCRIPTION
## Goal
Remove the redundant Reviewer Plan Mode mandate from `GEMINI.md` to eliminate the 'read-only trap' and streamline the Strategy Review Workflow.

## Changes
- Removed **Section 2.4 ("Reviewer Plan Mode")** from `GEMINI.md`.

## Rationale
Forcing the Reviewer into a technical `PLAN` lock prevents the agent from fulfilling its primary duty: writing feedback to `.agents/feedback.md`. Since the Reviewer's read-only boundary is already strictly enforced by role-based mandates in `AGENTS.md` and the `reviewer-role` skill, this tool-level lock is unnecessary and counter-productive.

## Verification
- `cat GEMINI.md`

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>