### PR TITLE
feat: implement Strategy Record Template and Publishing Workflow

### DIFF
--- a/.agents/skills/worker-role/SKILL.md
+++ b/.agents/skills/worker-role/SKILL.md
@@ -20,7 +20,8 @@ You are the implementation Worker for the `gh-orbit` project. This skill is used
 
 - **Draft Proposals**: Create surgical plans for assigned GitHub Issues.
 - **Iterate**: Refine your proposal based on agentic feedback until **SIGN-OFF** is reached.
-- **Implement**: Once approved, create a topic branch and execute the plan.
+- **Publish**: ONLY after receiving a **SIGN-OFF**, synthesize the technical context into a clean record using the `FINAL_RECORD_TEMPLATE.md` and post it to the GitHub Issue.
+- **Implement**: Once the record is published, create a topic branch and execute the plan.
 - **Research**: Actively research technical details online and **Ask the User** if information is insufficient.
 
 ## Execution

--- a/.agents/workflows/strategy-review/FINAL_RECORD_TEMPLATE.md
+++ b/.agents/workflows/strategy-review/FINAL_RECORD_TEMPLATE.md
@@ -1,0 +1,26 @@
+# 🏛️ Strategy Record: [Title from Proposal]
+
+**GitHub Issue**: # [ID]
+**Status**: ✅ SIGNED-OFF
+
+## 1. Objective
+[Content from Section 1 of Proposal: What and Why]
+
+## 2. Technical Strategy
+- **Architecture**: [Content from Section 2]
+- **Components**: [Content from Section 2]
+- **Files**: [Content from Section 2]
+- **Dependency**: [Content from Section 2]
+
+## 3. Risks & Mitigations
+- [Content from Section 3: Trade-offs and Mitigations]
+
+## 4. Proof of Correctness
+### Test Contract / Reproduction Plan
+[Content from Section 4: Behavioral expectations or reproduction steps]
+
+### Verification Commands
+[Content from Section 4: Specific commands used to verify the final state]
+
+---
+*This is a permanent technical record of the approved strategy. Procedural metadata and review history have been omitted for clarity.*

--- a/.agents/workflows/strategy-review/WORKFLOW.md
+++ b/.agents/workflows/strategy-review/WORKFLOW.md
@@ -52,8 +52,9 @@ To minimize coordination overhead and maximize token efficiency, this workflow u
 
 ### Phase B: GitHub Synchronization (The Record)
 
-1. **[Worker] Publish**: Post the *final, signed-off* content of `.agents/proposal.md` as a comment on the GitHub Issue.
-   - `gh issue comment "<ID>" --body-file .agents/proposal.md`
+1. **[Worker] Publish**: ONLY after receiving a **SIGN-OFF**, synthesize the final technical context of `.agents/proposal.md` into a clean architectural record using the `FINAL_RECORD_TEMPLATE.md`.
+   - Post this record as a comment on the GitHub Issue: `gh issue comment "<ID>" --body "<SYNTHESIZED_RECORD>"`
+   - *Note*: Ensure all procedural noise (Revision, Reviewer Hints, Review History) is omitted to maintain a professional project history.
 2. **[Worker] Branching**: Create the development branch linked to the issue.
    - `gh issue develop "<ID>"`
 3. **[Worker] Implementation**: Execute the plan on the new branch.


### PR DESCRIPTION
## Goal
Improve the clarity and longevity of the project's technical history by introducing a dedicated template and synthesis step for final, approved Strategy Records on GitHub.

## Changes
- **`FINAL_RECORD_TEMPLATE.md`**: Created a clean, technical-only template for GitHub Issue comments, omitting procedural noise (Revision numbers, Reviewer Hints, Review History).
- **`WORKFLOW.md`**: Updated 'Phase B: GitHub Synchronization' to mandate the synthesis of signed-off proposals into the new Record template.
- **`worker-role` Skill**: Added a new responsibility and explicit execution instruction for the `Worker` to synthesize and publish the record immediately after receiving a `SIGN-OFF`.

## Rationale
This transition from an internal 'Design Workbench' (`proposal.md`) to a permanent 'Technical Record' ensures that architectural context is preserved in a professional, RFC-style format that is easily digestible for both humans and future AI agents.

## Verification
- `cat .agents/workflows/strategy-review/FINAL_RECORD_TEMPLATE.md`
- `cat .agents/workflows/strategy-review/WORKFLOW.md`
- `cat .agents/skills/worker-role/SKILL.md`

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>