### PR TITLE
feat: show pull request approval status in detail view

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -84,7 +85,9 @@ func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectTyp
 		var err error
 
 		switch subjectType {
-		case "PullRequest", "Issue":
+		case "PullRequest":
+			res, err = e.fetchPullRequestGQL(ctx, u)
+		case "Issue":
 			res, err = e.fetchREST(ctx, u)
 		default:
 			// Releases and others don't have descriptions in REST API without extra calls
@@ -108,6 +111,81 @@ func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectTyp
 	}
 
 	return val.(models.EnrichmentResult), nil
+}
+
+func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (models.EnrichmentResult, error) {
+	owner, repo := github.ExtractOwnerRepoFromURL(u)
+	numberStr := github.ExtractNumberFromURL(u)
+
+	if owner == "" || repo == "" || numberStr == "" {
+		return e.fetchREST(ctx, u)
+	}
+
+	number, err := strconv.Atoi(numberStr)
+	if err != nil {
+		return e.fetchREST(ctx, u)
+	}
+
+	queryString := `
+		query($owner: String!, $repo: String!, $number: Int!) {
+			repository(owner: $owner, name: $repo) {
+				pullRequest(number: $number) {
+					body
+					url
+					author { login }
+					state
+					merged
+					isDraft
+					reviewDecision
+				}
+			}
+		}
+	`
+	variables := map[string]any{
+		"owner":  owner,
+		"repo":   repo,
+		"number": number,
+	}
+
+	var data struct {
+		Repository struct {
+			PullRequest struct {
+				Body   string `json:"body"`
+				URL    string `json:"url"`
+				Author struct {
+					Login string `json:"login"`
+				} `json:"author"`
+				State          string `json:"state"`
+				Merged         bool   `json:"merged"`
+				IsDraft        bool   `json:"isDraft"`
+				ReviewDecision string `json:"reviewDecision"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	err = e.client.GQL().DoWithContext(ctx, queryString, variables, &data)
+	if err != nil {
+		return models.EnrichmentResult{}, fmt.Errorf("GQL fetch failed: %w", err)
+	}
+
+	pr := data.Repository.PullRequest
+	state := ""
+	if pr.Merged {
+		state = "Merged"
+	} else if pr.IsDraft {
+		state = "Draft"
+	} else if pr.State != "" {
+		state = strings.ToUpper(pr.State[:1]) + strings.ToLower(pr.State[1:])
+	}
+
+	return models.EnrichmentResult{
+		Body:           pr.Body,
+		HTMLURL:        pr.URL,
+		Author:         pr.Author.Login,
+		ResourceState:  state,
+		ReviewDecision: pr.ReviewDecision,
+		FetchedAt:      time.Now(),
+	}, nil
 }
 
 func (e *EnrichmentEngine) fetchREST(ctx context.Context, u string) (models.EnrichmentResult, error) {
@@ -176,7 +254,7 @@ func (e *EnrichmentEngine) fetchByNodeIDs(ctx context.Context, ids []string, res
 	queryString := `
 		query($ids: [ID!]!) {
 			nodes(ids: $ids) {
-				... on PullRequest { id, state, merged, isDraft }
+				... on PullRequest { id, state, merged, isDraft, reviewDecision }
 				... on Issue { id, state }
 			}
 			rateLimit { cost, remaining }
@@ -186,10 +264,11 @@ func (e *EnrichmentEngine) fetchByNodeIDs(ctx context.Context, ids []string, res
 
 	var data struct {
 		Nodes []struct {
-			ID      string `json:"id"`
-			State   string `json:"state"`
-			Merged  bool   `json:"merged"`
-			IsDraft bool   `json:"isDraft"`
+			ID             string `json:"id"`
+			State          string `json:"state"`
+			Merged         bool   `json:"merged"`
+			IsDraft        bool   `json:"isDraft"`
+			ReviewDecision string `json:"reviewDecision"`
 		} `json:"nodes"`
 		RateLimit struct {
 			Cost      int `json:"cost"`
@@ -237,15 +316,16 @@ func (e *EnrichmentEngine) fetchByNodeIDs(ctx context.Context, ids []string, res
 			state = strings.ToUpper(node.State[:1]) + strings.ToLower(node.State[1:])
 		}
 
-		if state != "" {
-			if err := e.db.UpdateResourceStateByNodeID(ctx, node.ID, state); err != nil {
+		if state != "" || node.ReviewDecision != "" {
+			if err := e.db.UpdateResourceStateByNodeID(ctx, node.ID, state, node.ReviewDecision); err != nil {
 				e.logger.ErrorContext(ctx, "enrichment: failed to update resource state", "node_id", node.ID, "error", err)
 			}
 
 			// Populate results for immediate TUI refresh
 			results[node.ID] = models.EnrichmentResult{
-				ResourceState: state,
-				FetchedAt:     time.Now(),
+				ResourceState:  state,
+				ReviewDecision: node.ReviewDecision,
+				FetchedAt:      time.Now(),
 			}
 		}
 	}

--- a/internal/api/enrichment_test.go
+++ b/internal/api/enrichment_test.go
@@ -22,6 +22,39 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 
 	mockClient.EXPECT().BaseURL().Return("https://api.github.com/").Maybe()
 	mockClient.EXPECT().REST().Return(mockREST).Maybe()
+	mockGQL := mocks.NewMockGraphQLClient(t)
+	mockClient.EXPECT().GQL().Return(mockGQL).Maybe()
+
+	t.Run("Successful Fetch (PullRequest) via GQL", func(t *testing.T) {
+		mockGQL.EXPECT().DoWithContext(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, query string, variables map[string]any, response interface{}) {
+			// Simulate GQL response
+			res := response.(*struct {
+				Repository struct {
+					PullRequest struct {
+						Body   string `json:"body"`
+						URL    string `json:"url"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State          string `json:"state"`
+						Merged         bool   `json:"merged"`
+						IsDraft        bool   `json:"isDraft"`
+						ReviewDecision string `json:"reviewDecision"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			})
+			res.Repository.PullRequest.Body = "PR Body"
+			res.Repository.PullRequest.ReviewDecision = "APPROVED"
+		}).Return(nil).Once()
+
+		engine := NewEnrichmentEngine(ctx, mockClient, mockRepo, slog.Default())
+		t.Cleanup(func() { engine.Shutdown(ctx) })
+
+		res, err := engine.FetchDetail(ctx, "https://api.github.com/repos/o/r/pulls/1", "PullRequest")
+		assert.NoError(t, err)
+		assert.Equal(t, "PR Body", res.Body)
+		assert.Equal(t, "APPROVED", res.ReviewDecision)
+	})
 
 	t.Run("Successful Fetch (Issue)", func(t *testing.T) {
 		mockREST.EXPECT().DoWithContext(mock.Anything, "GET", "url", nil, mock.Anything).Return(nil).Once()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -226,7 +226,7 @@ func TestRepository_MetadataAndEnrichment(t *testing.T) {
 	}}))
 
 	// 1. Enrich Notification (Combined body, author, etc)
-	require.NoError(t, db.EnrichNotification(ctx, id, "Some body", "author", "https://github.com/u", "OPEN"))
+	require.NoError(t, db.EnrichNotification(ctx, id, "Some body", "author", "https://github.com/u", "OPEN", "APPROVED"))
 
 	// Verify
 	ns, err := db.GetNotification(ctx, id)
@@ -237,6 +237,7 @@ func TestRepository_MetadataAndEnrichment(t *testing.T) {
 	assert.Equal(t, "author", ns.AuthorLogin)
 	assert.Equal(t, "https://github.com/u", ns.HTMLURL)
 	assert.Equal(t, "OPEN", ns.ResourceState)
+	assert.Equal(t, "APPROVED", ns.ReviewDecision)
 	assert.True(t, ns.IsEnriched)
 }
 
@@ -328,11 +329,12 @@ func TestRepository_UpdateByNodeID(t *testing.T) {
 	}}))
 
 	// 1. Update Resource State by Node ID
-	require.NoError(t, db.UpdateResourceStateByNodeID(ctx, "node-123", "MERGED"))
+	require.NoError(t, db.UpdateResourceStateByNodeID(ctx, "node-123", "MERGED", "APPROVED"))
 	ns, err := db.GetNotification(ctx, id)
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.Equal(t, "MERGED", ns.ResourceState)
+	assert.Equal(t, "APPROVED", ns.ReviewDecision)
 
 	// 2. Update Subject Node ID
 	require.NoError(t, db.UpdateSubjectNodeID(ctx, id, "node-456"))

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -13,7 +13,7 @@ import (
 
 // EnrichNotification updates a notification with detailed content (body, author).
 // It also propagates the state to all notifications sharing the same subject_node_id for consistency.
-func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error {
+func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, reviewDecision string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -36,10 +36,11 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 		    author_login = ?,
 		    html_url = COALESCE(NULLIF(?, ''), html_url),
 		    resource_state = ?,
+		    review_decision = ?,
 		    is_enriched = TRUE,
 		    enriched_at = ?
 		WHERE github_id = ?
-	`, body, author, htmlURL, resourceState, now, id)
+	`, body, author, htmlURL, resourceState, reviewDecision, now, id)
 	if err != nil {
 		return fmt.Errorf("failed to enrich notification: %w", err)
 	}
@@ -49,12 +50,13 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 		_, err = tx.ExecContext(ctx, `
 			UPDATE notifications
 			SET resource_state = ?,
+			    review_decision = ?,
 			    body = CASE WHEN body = '' THEN ? ELSE body END,
 			    author_login = CASE WHEN author_login = '' THEN ? ELSE author_login END,
 			    is_enriched = CASE WHEN body != '' THEN TRUE ELSE is_enriched END,
 			    enriched_at = ?
 			WHERE subject_node_id = ? AND github_id != ?
-		`, resourceState, body, author, now, nodeID, id)
+		`, resourceState, reviewDecision, body, author, now, nodeID, id)
 		if err != nil {
 			db.logger.WarnContext(ctx, "failed to propagate enrichment to peers", "node_id", nodeID, "error", err)
 		}
@@ -64,14 +66,15 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 }
 
 // UpdateResourceStateByNodeID updates the live status of all resources sharing a GraphQL ID.
-func (db *DB) UpdateResourceStateByNodeID(ctx context.Context, nodeID, state string) error {
-	db.logger.DebugContext(ctx, "db: updating resource state by node_id", "node_id", nodeID, "state", state)
+func (db *DB) UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, reviewDecision string) error {
+	db.logger.DebugContext(ctx, "db: updating resource state by node_id", "node_id", nodeID, "state", state, "review_decision", reviewDecision)
 	_, err := db.ExecContext(ctx, `
 		UPDATE notifications
 		SET resource_state = ?,
+		    review_decision = ?,
 		    enriched_at = ?
 		WHERE subject_node_id = ?
-	`, state, time.Now(), nodeID)
+	`, state, reviewDecision, time.Now(), nodeID)
 	if err != nil {
 		return fmt.Errorf("failed to update resource state by node_id: %w", err)
 	}
@@ -149,7 +152,7 @@ func baseNotificationSelect() string {
 	return `
 		SELECT
 			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url,
-			COALESCE(n.body, ''), COALESCE(n.author_login, ''), COALESCE(n.resource_state, ''), COALESCE(n.subject_node_id, ''),
+			COALESCE(n.body, ''), COALESCE(n.author_login, ''), COALESCE(n.resource_state, ''), COALESCE(n.review_decision, ''), COALESCE(n.subject_node_id, ''),
 			n.is_enriched, n.enriched_at, n.updated_at,
 			s.priority, s.status, s.is_read_locally, s.is_notified
 		FROM notifications n
@@ -164,7 +167,7 @@ func (db *DB) GetNotification(ctx context.Context, id string) (*triage.Notificat
 	var ns triage.NotificationWithState
 	err := row.Scan(
 		&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL,
-		&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
+		&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.ReviewDecision, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
 		&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsNotified,
 	)
 	if err == sql.ErrNoRows {
@@ -190,7 +193,7 @@ func (db *DB) ListNotifications(ctx context.Context) ([]triage.NotificationWithS
 		var ns triage.NotificationWithState
 		err := rows.Scan(
 			&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL,
-			&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
+			&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.ReviewDecision, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
 			&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsNotified,
 		)
 		if err != nil {

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -58,4 +58,6 @@ var migrations = []string{
 		binary_version TEXT NOT NULL,
 		updated_at DATETIME NOT NULL
 	);`,
+	// Version 10: Add review_decision for PR approval status
+	`ALTER TABLE notifications ADD COLUMN review_decision TEXT DEFAULT '';`,
 }

--- a/internal/github/utils.go
+++ b/internal/github/utils.go
@@ -2,12 +2,80 @@ package github
 
 import (
 	"net/http"
+	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
 )
+
+var (
+	RePRNumber = regexp.MustCompile(`^[0-9]+$`)
+	ReTagName  = regexp.MustCompile(`^[a-zA-Z0-9-._/]+$`)
+	ReRepoName = regexp.MustCompile(`^[a-zA-Z0-9-._]+/[a-zA-Z0-9-._]+$`)
+)
+
+// ExtractNumberFromURL parses the last segment of a GitHub API URL as a number (Issue/PR).
+func ExtractNumberFromURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+
+	// Example: https://api.github.com/repos/owner/repo/pulls/123
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) > 0 {
+		last := segments[len(segments)-1]
+		if RePRNumber.MatchString(last) {
+			return last
+		}
+	}
+	return ""
+}
+
+// ExtractTagFromURL parses the last segment of a GitHub API URL as a tag (Release).
+func ExtractTagFromURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+
+	// Example: https://api.github.com/repos/owner/repo/releases/123
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) > 0 {
+		last := segments[len(segments)-1]
+		if ReTagName.MatchString(last) {
+			return last
+		}
+	}
+	return ""
+}
+
+// ExtractOwnerRepoFromURL extracts owner and repo from a GitHub API URL.
+func ExtractOwnerRepoFromURL(u string) (string, string) {
+	if u == "" {
+		return "", ""
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return "", ""
+	}
+
+	// Example: https://api.github.com/repos/owner/repo/pulls/123
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) >= 3 && segments[0] == "repos" {
+		return segments[1], segments[2]
+	}
+	return "", ""
+}
 
 // ParseRateLimitInfo extracts GitHub-specific rate limit headers into a standard structure.
 func ParseRateLimitInfo(h http.Header) models.RateLimitInfo {

--- a/internal/mocks/mock_enrichment_repository.go
+++ b/internal/mocks/mock_enrichment_repository.go
@@ -21,17 +21,17 @@ func (_m *MockEnrichmentRepository) EXPECT() *MockEnrichmentRepository_Expecter 
 	return &MockEnrichmentRepository_Expecter{mock: &_m.Mock}
 }
 
-// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState
-func (_m *MockEnrichmentRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string) error {
-	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState)
+// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState, reviewDecision
+func (_m *MockEnrichmentRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, reviewDecision string) error {
+	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState, reviewDecision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EnrichNotification")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
-		r0 = rf(ctx, id, body, author, htmlURL, resourceState)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, id, body, author, htmlURL, resourceState, reviewDecision)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -51,13 +51,14 @@ type MockEnrichmentRepository_EnrichNotification_Call struct {
 //   - author string
 //   - htmlURL string
 //   - resourceState string
-func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}) *MockEnrichmentRepository_EnrichNotification_Call {
-	return &MockEnrichmentRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState)}
+//   - reviewDecision string
+func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, reviewDecision interface{}) *MockEnrichmentRepository_EnrichNotification_Call {
+	return &MockEnrichmentRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState, reviewDecision)}
 }
 
-func (_c *MockEnrichmentRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string)) *MockEnrichmentRepository_EnrichNotification_Call {
+func (_c *MockEnrichmentRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, reviewDecision string)) *MockEnrichmentRepository_EnrichNotification_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string))
 	})
 	return _c
 }
@@ -67,22 +68,22 @@ func (_c *MockEnrichmentRepository_EnrichNotification_Call) Return(_a0 error) *M
 	return _c
 }
 
-func (_c *MockEnrichmentRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *MockEnrichmentRepository_EnrichNotification_Call {
+func (_c *MockEnrichmentRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string) error) *MockEnrichmentRepository_EnrichNotification_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdateResourceStateByNodeID provides a mock function with given fields: ctx, nodeID, state
-func (_m *MockEnrichmentRepository) UpdateResourceStateByNodeID(ctx context.Context, nodeID string, state string) error {
-	ret := _m.Called(ctx, nodeID, state)
+// UpdateResourceStateByNodeID provides a mock function with given fields: ctx, nodeID, state, reviewDecision
+func (_m *MockEnrichmentRepository) UpdateResourceStateByNodeID(ctx context.Context, nodeID string, state string, reviewDecision string) error {
+	ret := _m.Called(ctx, nodeID, state, reviewDecision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateResourceStateByNodeID")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, nodeID, state)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, nodeID, state, reviewDecision)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -99,13 +100,14 @@ type MockEnrichmentRepository_UpdateResourceStateByNodeID_Call struct {
 //   - ctx context.Context
 //   - nodeID string
 //   - state string
-func (_e *MockEnrichmentRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
-	return &MockEnrichmentRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state)}
+//   - reviewDecision string
+func (_e *MockEnrichmentRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}, reviewDecision interface{}) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
+	return &MockEnrichmentRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state, reviewDecision)}
 }
 
-func (_c *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call) Run(run func(ctx context.Context, nodeID string, state string)) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
+func (_c *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call) Run(run func(ctx context.Context, nodeID string, state string, reviewDecision string)) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
@@ -115,7 +117,7 @@ func (_c *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call) Return(_a0 
 	return _c
 }
 
-func (_c *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call) RunAndReturn(run func(context.Context, string, string) error) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
+func (_c *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call) RunAndReturn(run func(context.Context, string, string, string) error) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -71,17 +71,17 @@ func (_c *MockRepository_ArchiveThread_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState
-func (_m *MockRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string) error {
-	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState)
+// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState, reviewDecision
+func (_m *MockRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, reviewDecision string) error {
+	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState, reviewDecision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EnrichNotification")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
-		r0 = rf(ctx, id, body, author, htmlURL, resourceState)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, id, body, author, htmlURL, resourceState, reviewDecision)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -101,13 +101,14 @@ type MockRepository_EnrichNotification_Call struct {
 //   - author string
 //   - htmlURL string
 //   - resourceState string
-func (_e *MockRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}) *MockRepository_EnrichNotification_Call {
-	return &MockRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState)}
+//   - reviewDecision string
+func (_e *MockRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, reviewDecision interface{}) *MockRepository_EnrichNotification_Call {
+	return &MockRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState, reviewDecision)}
 }
 
-func (_c *MockRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string)) *MockRepository_EnrichNotification_Call {
+func (_c *MockRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, reviewDecision string)) *MockRepository_EnrichNotification_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string))
 	})
 	return _c
 }
@@ -117,7 +118,7 @@ func (_c *MockRepository_EnrichNotification_Call) Return(_a0 error) *MockReposit
 	return _c
 }
 
-func (_c *MockRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *MockRepository_EnrichNotification_Call {
+func (_c *MockRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string) error) *MockRepository_EnrichNotification_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -688,17 +689,17 @@ func (_c *MockRepository_UpdateBridgeHealth_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// UpdateResourceStateByNodeID provides a mock function with given fields: ctx, nodeID, state
-func (_m *MockRepository) UpdateResourceStateByNodeID(ctx context.Context, nodeID string, state string) error {
-	ret := _m.Called(ctx, nodeID, state)
+// UpdateResourceStateByNodeID provides a mock function with given fields: ctx, nodeID, state, reviewDecision
+func (_m *MockRepository) UpdateResourceStateByNodeID(ctx context.Context, nodeID string, state string, reviewDecision string) error {
+	ret := _m.Called(ctx, nodeID, state, reviewDecision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateResourceStateByNodeID")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, nodeID, state)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, nodeID, state, reviewDecision)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -715,13 +716,14 @@ type MockRepository_UpdateResourceStateByNodeID_Call struct {
 //   - ctx context.Context
 //   - nodeID string
 //   - state string
-func (_e *MockRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}) *MockRepository_UpdateResourceStateByNodeID_Call {
-	return &MockRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state)}
+//   - reviewDecision string
+func (_e *MockRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}, reviewDecision interface{}) *MockRepository_UpdateResourceStateByNodeID_Call {
+	return &MockRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state, reviewDecision)}
 }
 
-func (_c *MockRepository_UpdateResourceStateByNodeID_Call) Run(run func(ctx context.Context, nodeID string, state string)) *MockRepository_UpdateResourceStateByNodeID_Call {
+func (_c *MockRepository_UpdateResourceStateByNodeID_Call) Run(run func(ctx context.Context, nodeID string, state string, reviewDecision string)) *MockRepository_UpdateResourceStateByNodeID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
@@ -731,7 +733,7 @@ func (_c *MockRepository_UpdateResourceStateByNodeID_Call) Return(_a0 error) *Mo
 	return _c
 }
 
-func (_c *MockRepository_UpdateResourceStateByNodeID_Call) RunAndReturn(run func(context.Context, string, string) error) *MockRepository_UpdateResourceStateByNodeID_Call {
+func (_c *MockRepository_UpdateResourceStateByNodeID_Call) RunAndReturn(run func(context.Context, string, string, string) error) *MockRepository_UpdateResourceStateByNodeID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -48,9 +48,10 @@ type BridgeHealth struct {
 
 // EnrichmentResult holds the fetched details for a notification.
 type EnrichmentResult struct {
-	Body          string
-	HTMLURL       string
-	Author        string
-	ResourceState string
-	FetchedAt     time.Time
+	Body           string
+	HTMLURL        string
+	Author         string
+	ResourceState  string
+	ReviewDecision string
+	FetchedAt      time.Time
 }

--- a/internal/triage/types.go
+++ b/internal/triage/types.go
@@ -26,6 +26,7 @@ type Notification struct {
 	Body               string       `json:"body"`
 	AuthorLogin        string       `json:"author_login"`
 	ResourceState      string       `json:"resource_state"`
+	ReviewDecision     string       `json:"review_decision"`
 	SubjectNodeID      string       `json:"subject_node_id"`
 	IsEnriched         bool         `json:"is_enriched"`
 	EnrichedAt         sql.NullTime `json:"enriched_at"`

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -126,17 +126,18 @@ func (m *Model) FetchDetailCmd(id, u, subjectType string) tea.Cmd {
 		}
 
 		// Update database with granular enrich method
-		err = m.db.EnrichNotification(ctx, id, res.Body, res.Author, res.HTMLURL, res.ResourceState)
+		err = m.db.EnrichNotification(ctx, id, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ReviewDecision)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 
 		return detailLoadedMsg{
-			GitHubID:      id,
-			Body:          res.Body,
-			Author:        res.Author,
-			HTMLURL:       res.HTMLURL,
-			ResourceState: res.ResourceState,
+			GitHubID:       id,
+			Body:           res.Body,
+			Author:         res.Author,
+			HTMLURL:        res.HTMLURL,
+			ResourceState:  res.ResourceState,
+			ReviewDecision: res.ReviewDecision,
 		}
 	})
 }

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/cli/go-gh/v2/pkg/browser"
 	"github.com/hirakiuc/gh-orbit/internal/api"
+	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 )
@@ -123,7 +124,7 @@ func (i *Interpreter) executeOpenBrowser(u string) tea.Cmd {
 
 func (i *Interpreter) executeCheckoutPR(repo, number string) tea.Cmd {
 	// Validation logic moved from actions.go
-	if !reRepoName.MatchString(repo) || !rePRNumber.MatchString(number) {
+	if !github.ReRepoName.MatchString(repo) || !github.RePRNumber.MatchString(number) {
 		return func() tea.Msg {
 			return types.ErrMsg{Err: fmt.Errorf("invalid checkout parameters: %s#%s", repo, number)}
 		}
@@ -190,14 +191,14 @@ func (i *Interpreter) executeViewWeb(n triage.NotificationWithState) tea.Cmd {
 
 func (i *Interpreter) executeGHView(ghCmd, repo, arg string) tea.Cmd {
 	// Validation
-	if !reRepoName.MatchString(repo) {
+	if !github.ReRepoName.MatchString(repo) {
 		return func() tea.Msg { return types.ErrMsg{Err: fmt.Errorf("invalid repo: %s", repo)} }
 	}
 	if ghCmd == "release" {
-		if !reTagName.MatchString(arg) {
+		if !github.ReTagName.MatchString(arg) {
 			return func() tea.Msg { return types.ErrMsg{Err: fmt.Errorf("invalid tag: %s", arg)} }
 		}
-	} else if !rePRNumber.MatchString(arg) {
+	} else if !github.RePRNumber.MatchString(arg) {
 		return func() tea.Msg { return types.ErrMsg{Err: fmt.Errorf("invalid number: %s", arg)} }
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -52,7 +52,7 @@ type notificationStore interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
 	MarkReadLocally(ctx context.Context, id string, isRead bool) error
 	SetPriority(ctx context.Context, id string, priority int) error
-	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error
+	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, reviewDecision string) error
 }
 
 // Model represents the application state.
@@ -258,11 +258,12 @@ type syncCompleteMsg struct {
 }
 
 type detailLoadedMsg struct {
-	GitHubID      string
-	Body          string
-	Author        string
-	HTMLURL       string
-	ResourceState string
+	GitHubID       string
+	Body           string
+	Author         string
+	HTMLURL        string
+	ResourceState  string
+	ReviewDecision string
 }
 
 type (

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -378,6 +378,7 @@ func (m *Model) handleDetailLoaded(msg detailLoadedMsg) {
 		m.allNotifications[idx].AuthorLogin = msg.Author
 		m.allNotifications[idx].HTMLURL = msg.HTMLURL
 		m.allNotifications[idx].ResourceState = msg.ResourceState
+		m.allNotifications[idx].ReviewDecision = msg.ReviewDecision
 		m.allNotifications[idx].IsEnriched = true
 		break
 	}

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -2,54 +2,17 @@ package tui
 
 import (
 	"net/url"
-	"regexp"
 	"strings"
-)
 
-var (
-	rePRNumber = regexp.MustCompile(`^[0-9]+$`)
-	reRepoName = regexp.MustCompile(`^[a-zA-Z0-9-._]+/[a-zA-Z0-9-._]+$`)
-	reTagName  = regexp.MustCompile(`^[a-zA-Z0-9-._/]+$`)
+	"github.com/hirakiuc/gh-orbit/internal/github"
 )
 
 func extractNumberFromURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return ""
-	}
-
-	// Example: https://api.github.com/repos/owner/repo/pulls/123
-	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(segments) > 0 {
-		last := segments[len(segments)-1]
-		if rePRNumber.MatchString(last) {
-			return last
-		}
-	}
-	return ""
+	return github.ExtractNumberFromURL(u)
 }
 
 func extractTagFromURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return ""
-	}
-
-	// Example: https://api.github.com/repos/owner/repo/releases/123
-	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(segments) > 0 {
-		last := segments[len(segments)-1]
-		if reTagName.MatchString(last) {
-			return last
-		}
-	}
-	return ""
+	return github.ExtractTagFromURL(u)
 }
 
 func isValidGitHubURL(u string) bool {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -149,10 +150,23 @@ func (m *Model) renderDetailView() string {
 	// 1. Header (Title + Metadata)
 	title := m.styles.DetailHeader.Render(i.notification.SubjectTitle)
 
-	meta := fmt.Sprintf("%s • %s • %s",
+	decision := ""
+	if i.notification.ReviewDecision != "" {
+		decisionStyle := m.styles.Subscribed
+		switch i.notification.ReviewDecision {
+		case "APPROVED":
+			decisionStyle = m.styles.Assign
+		case "CHANGES_REQUESTED", "REVIEW_REQUIRED":
+			decisionStyle = m.styles.ActionRequired
+		}
+		decision = " • " + decisionStyle.Render(strings.ReplaceAll(i.notification.ReviewDecision, "_", " "))
+	}
+
+	meta := fmt.Sprintf("%s • %s • %s%s",
 		i.notification.RepositoryFullName,
 		i.notification.AuthorLogin,
-		i.notification.ResourceState)
+		i.notification.ResourceState,
+		decision)
 
 	header := lipgloss.JoinVertical(lipgloss.Left, title, m.styles.SelectedDescription.Render(meta))
 

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -130,8 +130,8 @@ type SyncRepository interface {
 
 // EnrichmentRepository defines the database interactions required by the EnrichmentEngine.
 type EnrichmentRepository interface {
-	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState string) error
-	UpdateResourceStateByNodeID(ctx context.Context, nodeID, state string) error
+	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, reviewDecision string) error
+	UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, reviewDecision string) error
 }
 
 // AlertRepository defines the database interactions required by the AlertService.


### PR DESCRIPTION
This PR implements the 'Review Decision' status for Pull Requests in the TUI Detail View, addressing Issue #88.

**Key Changes:**
- **Database**: Added Version 10 migration for the `review_decision` column in the `notifications` table.
- **Enrichment**: Updated `EnrichmentEngine` to fetch `reviewDecision` via GraphQL for Pull Request subjects, providing live approval status.
- **TUI**: Enhanced `renderDetailView` to display the `ReviewDecision` with conditional coloring (Green for APPROVED, Red for CHANGES_REQUESTED).
- **Refactoring**: Centralized GitHub URL parsing and regex utilities in the `internal/github` package to avoid circular dependencies.

Closes #88