### PR TITLE
feat: make 'mark as read on open' configurable in TUI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,12 @@ type Config struct {
 	Version       int                 `yaml:"version"`
 	Notifications NotificationsConfig `yaml:"notifications"`
 	Enrichment    EnrichmentConfig    `yaml:"enrichment"`
+	TUI           TUIConfig           `yaml:"tui"`
+}
+
+// TUIConfig represents settings for the Terminal UI.
+type TUIConfig struct {
+	AutoReadOnOpen bool `yaml:"auto_read_on_open"`
 }
 
 // EnrichmentConfig represents the settings for background metadata enrichment.
@@ -53,6 +59,9 @@ func DefaultConfig() *Config {
 			Concurrency: 1,
 			BatchSize:   20,
 		},
+		TUI: TUIConfig{
+			AutoReadOnOpen: false,
+		},
 	}
 }
 
@@ -79,6 +88,9 @@ func (c *Config) Validate() error {
 	if c.Enrichment.Concurrency < 1 || c.Enrichment.Concurrency > 10 {
 		return fmt.Errorf("enrichment.concurrency must be between 1 and 10, got %d", c.Enrichment.Concurrency)
 	}
+
+	// 4. TUI Validation
+	// Currently no range constraints for booleans, but maintains structure.
 
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,8 @@ notifications:
 		// Verify default was preserved for missing field
 		assert.Equal(t, 60, cfg.Notifications.SyncInterval)
 		assert.Equal(t, 365, cfg.Notifications.MaxVisibleAgeDays)
+		// Verify TUI defaults when section is missing
+		assert.False(t, cfg.TUI.AutoReadOnOpen)
 	})
 
 	t.Run("Successful Load with Explicit MaxVisibleAgeDays", func(t *testing.T) {

--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -36,8 +36,9 @@ type ActionSyncNotifications struct {
 func (a ActionSyncNotifications) Type() string { return "sync_notifications" }
 
 type ActionCheckoutPR struct {
-	Repository string
-	Number     string
+	NotificationID string
+	Repository     string
+	Number         string
 }
 
 func (a ActionCheckoutPR) Type() string { return "checkout_pr" }

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -56,7 +56,7 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 	}
 
 	if a, ok := action.(ActionCheckoutPR); ok {
-		return i.executeCheckoutPR(a.Repository, a.Number)
+		return i.executeCheckoutPR(a.NotificationID, a.Repository, a.Number)
 	}
 
 	if a, ok := action.(ActionEnrichItems); ok {
@@ -122,7 +122,7 @@ func (i *Interpreter) executeOpenBrowser(u string) tea.Cmd {
 	})
 }
 
-func (i *Interpreter) executeCheckoutPR(repo, number string) tea.Cmd {
+func (i *Interpreter) executeCheckoutPR(id, repo, number string) tea.Cmd {
 	// Validation logic moved from actions.go
 	if !github.ReRepoName.MatchString(repo) || !github.RePRNumber.MatchString(number) {
 		return func() tea.Msg {
@@ -142,14 +142,8 @@ func (i *Interpreter) executeCheckoutPR(repo, number string) tea.Cmd {
 		return actionCompleteMsg{}
 	}, "pr", "checkout", number, "-R", repo)
 
-	// Find the item to mark as read
-	var selectedID string
-	if item, ok := i.model.listView.list.SelectedItem().(item); ok {
-		selectedID = item.notification.GitHubID
-	}
-
-	if selectedID != "" {
-		return tea.Batch(checkoutCmd, i.model.MarkReadByID(selectedID, true))
+	if i.model.config.TUI.AutoReadOnOpen && id != "" {
+		return tea.Batch(checkoutCmd, i.model.MarkReadByID(id, true))
 	}
 	return checkoutCmd
 }
@@ -187,7 +181,12 @@ func (i *Interpreter) executeViewWeb(n triage.NotificationWithState) tea.Cmd {
 		cmd = i.executeOpenBrowser(n.HTMLURL)
 	}
 
-	return tea.Batch(cmd, i.model.ui.SetToast(toast), i.model.MarkReadByID(n.GitHubID, true))
+	batch := []tea.Cmd{cmd, i.model.ui.SetToast(toast)}
+	if i.model.config.TUI.AutoReadOnOpen {
+		batch = append(batch, i.model.MarkReadByID(n.GitHubID, true))
+	}
+
+	return tea.Batch(batch...)
 }
 
 func (i *Interpreter) executeGHView(ghCmd, repo, arg string) tea.Cmd {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -523,7 +523,12 @@ func (m *Model) handleCheckoutPRKey() []Action {
 	if number == "" {
 		return nil
 	}
-	return []Action{ActionCheckoutPR{Repository: n.RepositoryFullName, Number: number}}
+
+	return []Action{ActionCheckoutPR{
+		NotificationID: n.GitHubID,
+		Repository:     n.RepositoryFullName,
+		Number:         number,
+	}}
 }
 
 func (m *Model) handlePriorityKey(delta int) []Action {


### PR DESCRIPTION
This PR makes the "mark as read" behavior after opening a notification in the browser or checking out a PR configurable. 

By default, notifications are no longer automatically marked as read, giving users full control over their triage state.

### Changes
- **Config**: Added `tui.auto_read_on_open` (default `false`).
- **Robustness**: Refactored `ActionCheckoutPR` to use an explicit `NotificationID` instead of relying on the current selection.
- **Logic**: Updated the TUI interpreter to respect the new setting.

Closes #89