### PR TITLE
feat: toggle full multi-line help menu in TUI

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -76,7 +76,7 @@ type Model struct {
 	version          string
 	styles           Styles
 	keys             KeyMap
-	help             help.Model
+	help             *help.Model
 	showHelp         bool
 	allNotifications []triage.NotificationWithState
 	err              error
@@ -177,7 +177,7 @@ func NewModel(
 		userID:       userID,
 		styles:       styles,
 		keys:         keys,
-		help:         h,
+		help:         &h,
 		state:        StateList,
 		PollInterval: cfg.Notifications.SyncInterval,
 		// Default intervals

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -107,6 +107,7 @@ func (m *Model) transitionDetail(msg tea.Msg) []Action {
 			m.state = StateList
 		case key.Matches(msg, m.keys.Help):
 			m.showHelp = !m.showHelp
+			m.help.ShowAll = m.showHelp
 		case key.Matches(msg, m.keys.OpenBrowser):
 			if i, ok := m.listView.list.SelectedItem().(item); ok {
 				actions = append(actions, ActionViewWeb{Notification: i.notification})
@@ -319,6 +320,9 @@ func (m *Model) handleWindowSize(msg tea.WindowSizeMsg) {
 	m.width = msg.Width
 	m.height = msg.Height
 	m.ui.SetSize(msg.Width, msg.Height)
+
+	m.help.SetWidth(msg.Width)
+
 	m.updateMarkdownRenderer()
 }
 
@@ -428,6 +432,7 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 		return m.handleToggleReadKey()
 	case key.Matches(msg, m.keys.Help):
 		m.showHelp = !m.showHelp
+		m.help.ShowAll = m.showHelp
 	case key.Matches(msg, m.keys.NextTab):
 		m.cycleTab(1)
 	case key.Matches(msg, m.keys.PrevTab):


### PR DESCRIPTION
This PR fixes the issue where pressing '?' only displayed a single line of help. 

Users can now toggle between a hidden state and a full, multi-line help menu that correctly adapts to the terminal width.

### Changes
- Updated `internal/tui/update.go` to sync width and expanded state.
- Refactored help component management in the TUI model.

Closes #159