### PR TITLE
fix: correct version string output format

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -42,7 +42,7 @@ func main() {
 		},
 	}
 
-	rootCmd.SetVersionTemplate(fmt.Sprintf("gh-orbit %%s (%s) build %s\n", buildinfo.Commit, buildinfo.Date))
+	rootCmd.SetVersionTemplate(fmt.Sprintf("gh-orbit {{.Version}} (%s) build %s\n", buildinfo.Commit, buildinfo.Date))
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Logging level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output (OTel tracing)")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -109,3 +109,23 @@ func TestCLI_Sync(t *testing.T) {
 	dbPath := filepath.Join(tmpHome, ".local", "share", "gh-orbit", "orbit.db")
 	require.FileExists(t, dbPath)
 }
+
+func TestCLI_Version(t *testing.T) {
+	// Prepare Environment
+	binPath := filepath.Join("..", "..", "bin", "gh-orbit")
+
+	// Ensure binary exists
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		t.Skip("gh-orbit binary not found in bin/. Run 'make build' first.")
+	}
+
+	// Run 'gh-orbit --version'
+	cmd := exec.Command(binPath, "--version") // #nosec G204
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "version command failed")
+
+	// Verify output format
+	outStr := string(output)
+	assert.NotContains(t, outStr, "%s", "Version string still contains a raw %s placeholder")
+	assert.Contains(t, outStr, "gh-orbit", "Version output should contain the binary name")
+}


### PR DESCRIPTION
## 1. Objective
Address the issue where `./bin/gh-orbit --version` shows a raw `%s` literal instead of the actual version. The goal is to correctly use Cobra's version template system.

## 2. Technical Strategy
- **Changes**: Updated `cmd/gh-orbit/main.go` to use Cobra's `{{.Version}}` template tag instead of an incorrectly formatted `fmt.Sprintf` string.
- **Regression Testing**: Added `TestCLI_Version` to `tests/e2e/e2e_test.go` to ensure the version output remains correctly formatted in the future.

## 3. Proof of Correctness
### Behavioral Expectations
- Running `./bin/gh-orbit --version` now correctly displays the version (e.g., `ed2a5ed`).

### Verification Commands
- **Manual Verification**: Run `make build && ./bin/gh-orbit --version`.
- **Automated Tests**: `go test -v ./tests/e2e -run TestCLI_Version`.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>