### PR TITLE
feat: implement proactive batch enrichment and deduplication for live status badges

### DIFF
--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/hirakiuc/gh-orbit/internal/api"
@@ -77,6 +78,12 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState) tea.Cmd {
 		return nil
 	}
 
+	// 1. Mark as inflight
+	now := time.Now()
+	for _, n := range toEnrich {
+		m.inflightEnrichments[n.GitHubID] = now
+	}
+
 	// For a single item enrichment (Detail View), we use FetchDetail
 	if len(toEnrich) == 1 {
 		n := toEnrich[0]
@@ -95,15 +102,7 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState) tea.Cmd {
 
 		cmds = append(cmds, m.traffic.Submit(api.PriorityEnrich, func(ctx context.Context) tea.Msg {
 			results := m.enrich.FetchHybridBatch(ctx, chunk)
-			if len(results) == 0 {
-				return nil
-			}
-
-			notifs, err := m.db.ListNotifications(ctx)
-			if err != nil {
-				return types.ErrMsg{Err: err}
-			}
-			return notificationsLoadedMsg{notifications: notifs, IsInitial: false}
+			return enrichmentBatchCompleteMsg{Results: results}
 		}))
 	}
 

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -90,9 +90,7 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 				return clearStatusMsg{}
 			})
 		case TickEnrich:
-			return tea.Tick(a.Interval, func(_ time.Time) tea.Msg {
-				return viewportEnrichMsg{}
-			})
+			return i.model.tickEnrich()
 		}
 	}
 

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -194,15 +194,61 @@ func TestModel_Transition_Enrichment(t *testing.T) {
 	m.listView.list.Select(0)
 	oldIndex := 0
 
-	// 1. Viewport enrichment msg
-	actions := m.Transition(viewportEnrichMsg{}, oldIndex)
+	// 1. Viewport enrichment msg (ID check)
+	m.enrichID = 42
+	actions := m.Transition(viewportEnrichMsg{ID: 42}, oldIndex)
 	assert.Contains(t, actions, ActionEnrichItems{Notifications: []triage.NotificationWithState{notifs[0], notifs[1]}})
 
 	// 2. List index change (debounced enrichment)
 	// oldIndex is 0
 	_, cmd := m.Update(keyPress("down"))
-
 	assert.NotNil(t, cmd, "Update should return commands for enrichment tick")
+}
+
+func TestModel_Enrichment_Deduplication(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+
+	notif := triage.NotificationWithState{
+		Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()},
+	}
+	m.allNotifications = []triage.NotificationWithState{notif}
+	m.applyFilters()
+	m.listView.list.SetSize(100, 100)
+
+	// 1. Mark as inflight
+	m.inflightEnrichments["1"] = time.Now()
+
+	// 2. Trigger enrichment
+	actions := m.Transition(viewportEnrichMsg{ID: m.enrichID}, 0)
+	// Should NOT contain ActionEnrichItems because it's already inflight
+	for _, a := range actions {
+		if ae, ok := a.(ActionEnrichItems); ok {
+			assert.Empty(t, ae.Notifications, "Should not re-enrich inflight item")
+		}
+	}
+}
+
+func TestModel_Enrichment_SurgicalUpdate(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+
+	notif := triage.NotificationWithState{
+		Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()},
+	}
+	m.allNotifications = []triage.NotificationWithState{notif}
+	m.inflightEnrichments["1"] = time.Now()
+
+	// 1. Receive surgical update
+	results := map[string]models.EnrichmentResult{
+		"1": {ResourceState: "Merged", ResourceSubState: "APPROVED", FetchedAt: time.Now()},
+	}
+	_ = m.Transition(enrichmentBatchCompleteMsg{Results: results}, 0)
+
+	// 2. Assertions
+	assert.True(t, m.allNotifications[0].IsEnriched)
+	assert.Equal(t, "Merged", m.allNotifications[0].ResourceState)
+	assert.Empty(t, m.inflightEnrichments, "Inflight map should be cleared")
 }
 
 func TestModel_Transition_Filtering(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -96,10 +96,15 @@ type Model struct {
 	RateLimit         models.RateLimitInfo
 	heartbeatID       uint64
 	clockID           uint64
+	enrichID          uint64
 	heartbeatInterval time.Duration
 	clockInterval     time.Duration
-	lastQuitPress     time.Time
-	executor          types.CommandExecutor
+
+	// Enrichment Management
+	inflightEnrichments map[string]time.Time
+
+	lastQuitPress time.Time
+	executor      types.CommandExecutor
 
 	syncStarted bool
 }
@@ -183,8 +188,9 @@ func NewModel(
 		state:        StateList,
 		PollInterval: cfg.Notifications.SyncInterval,
 		// Default intervals
-		heartbeatInterval: time.Duration(cfg.Notifications.SyncInterval) * time.Second,
-		clockInterval:     1 * time.Minute,
+		heartbeatInterval:   time.Duration(cfg.Notifications.SyncInterval) * time.Second,
+		clockInterval:       1 * time.Minute,
+		inflightEnrichments: make(map[string]time.Time),
 	}
 
 	// Apply options
@@ -219,6 +225,15 @@ func (m *Model) tickClock() tea.Cmd {
 	id := m.clockID
 	return tea.Tick(m.clockInterval, func(_ time.Time) tea.Msg {
 		return clockTickMsg{ID: id}
+	})
+}
+
+func (m *Model) tickEnrich() tea.Cmd {
+	m.enrichID++
+	id := m.enrichID
+	debounce := time.Duration(m.config.Enrichment.DebounceMS) * time.Millisecond
+	return tea.Tick(debounce, func(_ time.Time) tea.Msg {
+		return viewportEnrichMsg{ID: id}
 	})
 }
 
@@ -278,10 +293,14 @@ type detailLoadedMsg struct {
 	ResourceSubState string
 }
 
+type enrichmentBatchCompleteMsg struct {
+	Results map[string]models.EnrichmentResult
+}
+
 type (
 	actionCompleteMsg struct{}
 	clearStatusMsg    struct{}
-	viewportEnrichMsg struct{}
+	viewportEnrichMsg struct{ ID uint64 }
 )
 
 type (

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -44,12 +44,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.detailView.viewport, cmd = m.detailView.viewport.Update(msg)
 		cmds = append(cmds, cmd)
 	case StateList:
+		oldPage := m.listView.list.Paginator.Page
 		m.listView.list, cmd = m.listView.list.Update(msg)
 		cmds = append(cmds, cmd)
 
-		// Debounced enrichment logic (after sub-model update ensures index is fresh)
-		if m.listView.list.Index() != oldIndex {
-			cmds = append(cmds, m.interpreter.Execute(ActionScheduleTick{TickType: TickEnrich, Interval: 250 * time.Millisecond}))
+		// Debounced enrichment logic (after sub-model update ensures index/page is fresh)
+		if m.listView.list.Index() != oldIndex || m.listView.list.Paginator.Page != oldPage {
+			cmds = append(cmds, m.interpreter.Execute(ActionScheduleTick{TickType: TickEnrich}))
 		}
 	}
 
@@ -68,6 +69,8 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		return m.handlePriorityUpdated(msg)
 	case syncCompleteMsg:
 		return m.handleSyncComplete(msg)
+	case enrichmentBatchCompleteMsg:
+		return m.handleEnrichmentBatchComplete(msg)
 	case detailLoadedMsg:
 		m.handleDetailLoaded(msg)
 	case pollTickMsg:
@@ -75,6 +78,9 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 	case clockTickMsg:
 		return m.handleClockTick(msg)
 	case viewportEnrichMsg:
+		if msg.ID != m.enrichID {
+			return nil
+		}
 		return []Action{ActionEnrichItems{Notifications: m.getVisibleNotifications()}}
 	case types.ErrMsg:
 		m.handleTransitionError(msg)
@@ -165,8 +171,18 @@ func (m *Model) getVisibleNotifications() []triage.NotificationWithState {
 	visible := m.listView.list.Items()[start:end]
 
 	var items []triage.NotificationWithState
+	now := time.Now()
+
 	for _, li := range visible {
 		if i, ok := li.(item); ok {
+			// 1. Skip if already inflight (with 30s TTL to prevent permanent blocking)
+			if started, ok := m.inflightEnrichments[i.notification.GitHubID]; ok {
+				if now.Sub(started) < 30*time.Second {
+					continue
+				}
+			}
+
+			// 2. Skip if already enriched and fresh
 			var isExpired bool
 			if i.notification.IsEnriched {
 				if i.notification.EnrichedAt.Valid {
@@ -339,6 +355,8 @@ func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
 
 func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 	m.allNotifications = msg.notifications
+	// Clear inflight on full reload to avoid stale blocks
+	m.inflightEnrichments = make(map[string]time.Time)
 	m.applyFilters()
 	if m.state == StateDetail {
 		m.refreshDetailView()
@@ -372,8 +390,35 @@ func (m *Model) handleSyncComplete(msg syncCompleteMsg) []Action {
 	}
 }
 
+func (m *Model) handleEnrichmentBatchComplete(msg enrichmentBatchCompleteMsg) []Action {
+	m.ui.SetFetching(false)
+
+	// Surgical update of in-memory notification slice
+	for id, res := range msg.Results {
+		delete(m.inflightEnrichments, id)
+
+		for idx, n := range m.allNotifications {
+			if n.GitHubID != id {
+				continue
+			}
+
+			m.allNotifications[idx].ResourceState = res.ResourceState
+			m.allNotifications[idx].ResourceSubState = res.ResourceSubState
+			m.allNotifications[idx].IsEnriched = true
+			m.allNotifications[idx].EnrichedAt.Time = res.FetchedAt
+			m.allNotifications[idx].EnrichedAt.Valid = true
+			break
+		}
+	}
+
+	m.applyFilters()
+	return nil
+}
+
 func (m *Model) handleDetailLoaded(msg detailLoadedMsg) {
 	m.ui.SetFetching(false)
+	delete(m.inflightEnrichments, msg.GitHubID)
+
 	for idx, n := range m.allNotifications {
 		if n.GitHubID != msg.GitHubID {
 			continue
@@ -418,6 +463,8 @@ func (m *Model) handleTransitionError(msg types.ErrMsg) {
 	m.err = msg.Err
 	m.ui.SetSyncing(false)
 	m.ui.SetFetching(false)
+	// Clear inflight on error to allow retry
+	m.inflightEnrichments = make(map[string]time.Time)
 }
 
 func (m *Model) handleListKey(msg tea.KeyMsg) []Action {


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #170

## Objective

Currently, live status badges (OPEN, CLOSED, MERGED) are only enriched when a notification is selected or during the initial load. This results in many "PEND" badges during normal triage. This PR implements proactive page-level enrichment and deduplication to ensure badges are enriched as soon as they become visible while avoiding redundant API calls.

## Changes

- **TUI Model**: Added `inflightEnrichments map[string]time.Time` to track and deduplicate active requests.
- **Enrichment Deduplication**: `getVisibleNotifications` now skips items that are already being enriched or have a fresh enrichment.
- **Proactive Trigger**: Updated the `Update` loop to reset a debounced enrichment tick (250ms) on any list index or page change.
- **Surgical Updates**: Introduced `enrichmentBatchCompleteMsg` to update the in-memory notification slice without reloading the whole list from the database.
- **Error Recovery**: `inflightEnrichments` is cleared on error or full reload to prevent stale blocking.

## Verification Results

- Added `TestModel_Enrichment_Deduplication` and `TestModel_Enrichment_SurgicalUpdate` in `internal/tui/logic_test.go`.
- All tests passed (`make check`):
  ```
  === RUN   TestModel_Transition_Enrichment
  --- PASS: TestModel_Transition_Enrichment (0.00s)
  === RUN   TestModel_Enrichment_Deduplication
  --- PASS: TestModel_Enrichment_Deduplication (0.00s)
  === RUN   TestModel_Enrichment_SurgicalUpdate
  --- PASS: TestModel_Enrichment_SurgicalUpdate (0.00s)
  ok      github.com/hirakiuc/gh-orbit/internal/tui       0.547s
  ```

## Checklist

- [x] All checks passed (`make check`)
- [x] Documentation updated (N/A)

(generated by AI)
Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>