### PR TITLE
fix: proactive batch enrichment and TUI refresh logic

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -128,10 +128,28 @@ func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (m
 		return e.fetchREST(ctx, u)
 	}
 
+	var data struct {
+		Repository struct {
+			PullRequest struct {
+				ID      string `json:"id"`
+				Body    string `json:"body"`
+				HTMLURL string `json:"url"`
+				Author  struct {
+					Login string `json:"login"`
+				} `json:"author"`
+				State            string `json:"state"`
+				Merged           bool   `json:"merged"`
+				IsDraft          bool   `json:"isDraft"`
+				ResourceSubState string `json:"reviewDecision"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
 	queryString := `
 		query($owner: String!, $repo: String!, $number: Int!) {
 			repository(owner: $owner, name: $repo) {
 				pullRequest(number: $number) {
+					id
 					body
 					url
 					author { login }
@@ -147,22 +165,6 @@ func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (m
 		"owner":  owner,
 		"repo":   repo,
 		"number": number,
-	}
-
-	var data struct {
-		Repository struct {
-			PullRequest struct {
-				Body    string `json:"body"`
-				HTMLURL string `json:"url"`
-				Author  struct {
-					Login string `json:"login"`
-				} `json:"author"`
-				State            string `json:"state"`
-				Merged           bool   `json:"merged"`
-				IsDraft          bool   `json:"isDraft"`
-				ResourceSubState string `json:"reviewDecision"`
-			} `json:"pullRequest"`
-		} `json:"repository"`
 	}
 
 	err = e.client.GQL().DoWithContext(ctx, queryString, variables, &data)
@@ -181,6 +183,7 @@ func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (m
 	}
 
 	return models.EnrichmentResult{
+		SubjectNodeID:    pr.ID,
 		Body:             pr.Body,
 		HTMLURL:          pr.HTMLURL,
 		Author:           pr.Author.Login,
@@ -192,6 +195,7 @@ func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (m
 
 func (e *EnrichmentEngine) fetchREST(ctx context.Context, u string) (models.EnrichmentResult, error) {
 	var data struct {
+		ID      string `json:"node_id"`
 		Body    string `json:"body"`
 		HTMLURL string `json:"html_url"`
 		User    struct {
@@ -219,6 +223,7 @@ func (e *EnrichmentEngine) fetchREST(ctx context.Context, u string) (models.Enri
 	}
 
 	return models.EnrichmentResult{
+		SubjectNodeID:    data.ID,
 		Body:             data.Body,
 		HTMLURL:          data.HTMLURL,
 		Author:           data.User.Login,

--- a/internal/api/enrichment_test.go
+++ b/internal/api/enrichment_test.go
@@ -31,6 +31,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 			res := response.(*struct {
 				Repository struct {
 					PullRequest struct {
+						ID      string `json:"id"`
 						Body    string `json:"body"`
 						HTMLURL string `json:"url"`
 						Author  struct {
@@ -43,6 +44,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 					} `json:"pullRequest"`
 				} `json:"repository"`
 			})
+			res.Repository.PullRequest.ID = "node_1"
 			res.Repository.PullRequest.Body = "PR Body"
 			res.Repository.PullRequest.ResourceSubState = "APPROVED"
 		}).Return(nil).Once()
@@ -60,6 +62,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 		mockREST.EXPECT().DoWithContext(mock.Anything, "GET", "url", nil, mock.Anything).Call.Run(func(args mock.Arguments) {
 			response := args.Get(4)
 			res := response.(*struct {
+				ID      string `json:"node_id"`
 				Body    string `json:"body"`
 				HTMLURL string `json:"html_url"`
 				User    struct {
@@ -68,6 +71,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 				State       string  `json:"state"`
 				StateReason *string `json:"state_reason"`
 			})
+			res.ID = "node_issue_1"
 			res.Body = "Issue Body"
 			res.State = "closed"
 			reason := "completed"

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -226,7 +226,7 @@ func TestRepository_MetadataAndEnrichment(t *testing.T) {
 	}}))
 
 	// 1. Enrich Notification (Combined body, author, etc)
-	require.NoError(t, db.EnrichNotification(ctx, id, "Some body", "author", "https://github.com/u", "OPEN", "APPROVED"))
+	require.NoError(t, db.EnrichNotification(ctx, id, "node_1", "Some body", "author", "https://github.com/u", "OPEN", "APPROVED"))
 
 	// Verify
 	ns, err := db.GetNotification(ctx, id)

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -13,18 +13,19 @@ import (
 
 // EnrichNotification updates a notification with detailed content (body, author).
 // It also propagates the state to all notifications sharing the same subject_node_id for consistency.
-func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, resourceSubState string) error {
+func (db *DB) EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// 1. Get the subject_node_id for this notification
-	var nodeID string
-	err = tx.QueryRowContext(ctx, "SELECT subject_node_id FROM notifications WHERE github_id = ?", id).Scan(&nodeID)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("failed to fetch node_id during enrichment: %w", err)
+	// 1. Get current nodeID if we didn't get one
+	if nodeID == "" {
+		err = tx.QueryRowContext(ctx, "SELECT subject_node_id FROM notifications WHERE github_id = ?", id).Scan(&nodeID)
+		if err != nil && err != sql.ErrNoRows {
+			return fmt.Errorf("failed to fetch node_id during enrichment: %w", err)
+		}
 	}
 
 	now := time.Now()
@@ -37,10 +38,11 @@ func (db *DB) EnrichNotification(ctx context.Context, id, body, author, htmlURL,
 		    html_url = COALESCE(NULLIF(?, ''), html_url),
 		    resource_state = ?,
 		    resource_sub_state = ?,
+		    subject_node_id = COALESCE(NULLIF(?, ''), subject_node_id),
 		    is_enriched = TRUE,
 		    enriched_at = ?
 		WHERE github_id = ?
-	`, body, author, htmlURL, resourceState, resourceSubState, now, id)
+	`, body, author, htmlURL, resourceState, resourceSubState, nodeID, now, id)
 	if err != nil {
 		return fmt.Errorf("failed to enrich notification: %w", err)
 	}

--- a/internal/mocks/mock_enrichment_repository.go
+++ b/internal/mocks/mock_enrichment_repository.go
@@ -21,17 +21,17 @@ func (_m *MockEnrichmentRepository) EXPECT() *MockEnrichmentRepository_Expecter 
 	return &MockEnrichmentRepository_Expecter{mock: &_m.Mock}
 }
 
-// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState, resourceSubState
-func (_m *MockEnrichmentRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error {
-	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState, resourceSubState)
+// EnrichNotification provides a mock function with given fields: ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState
+func (_m *MockEnrichmentRepository) EnrichNotification(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error {
+	ret := _m.Called(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EnrichNotification")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) error); ok {
-		r0 = rf(ctx, id, body, author, htmlURL, resourceState, resourceSubState)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -47,18 +47,19 @@ type MockEnrichmentRepository_EnrichNotification_Call struct {
 // EnrichNotification is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
+//   - nodeID string
 //   - body string
 //   - author string
 //   - htmlURL string
 //   - resourceState string
 //   - resourceSubState string
-func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockEnrichmentRepository_EnrichNotification_Call {
-	return &MockEnrichmentRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState, resourceSubState)}
+func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockEnrichmentRepository_EnrichNotification_Call {
+	return &MockEnrichmentRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
 }
 
-func (_c *MockEnrichmentRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, resourceSubState string)) *MockEnrichmentRepository_EnrichNotification_Call {
+func (_c *MockEnrichmentRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string)) *MockEnrichmentRepository_EnrichNotification_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string), args[7].(string))
 	})
 	return _c
 }
@@ -68,7 +69,7 @@ func (_c *MockEnrichmentRepository_EnrichNotification_Call) Return(_a0 error) *M
 	return _c
 }
 
-func (_c *MockEnrichmentRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string) error) *MockEnrichmentRepository_EnrichNotification_Call {
+func (_c *MockEnrichmentRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string, string) error) *MockEnrichmentRepository_EnrichNotification_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -71,17 +71,17 @@ func (_c *MockRepository_ArchiveThread_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// EnrichNotification provides a mock function with given fields: ctx, id, body, author, htmlURL, resourceState, resourceSubState
-func (_m *MockRepository) EnrichNotification(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error {
-	ret := _m.Called(ctx, id, body, author, htmlURL, resourceState, resourceSubState)
+// EnrichNotification provides a mock function with given fields: ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState
+func (_m *MockRepository) EnrichNotification(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error {
+	ret := _m.Called(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EnrichNotification")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) error); ok {
-		r0 = rf(ctx, id, body, author, htmlURL, resourceState, resourceSubState)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -97,18 +97,19 @@ type MockRepository_EnrichNotification_Call struct {
 // EnrichNotification is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
+//   - nodeID string
 //   - body string
 //   - author string
 //   - htmlURL string
 //   - resourceState string
 //   - resourceSubState string
-func (_e *MockRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockRepository_EnrichNotification_Call {
-	return &MockRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, body, author, htmlURL, resourceState, resourceSubState)}
+func (_e *MockRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockRepository_EnrichNotification_Call {
+	return &MockRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
 }
 
-func (_c *MockRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, body string, author string, htmlURL string, resourceState string, resourceSubState string)) *MockRepository_EnrichNotification_Call {
+func (_c *MockRepository_EnrichNotification_Call) Run(run func(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string)) *MockRepository_EnrichNotification_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string), args[7].(string))
 	})
 	return _c
 }
@@ -118,7 +119,7 @@ func (_c *MockRepository_EnrichNotification_Call) Return(_a0 error) *MockReposit
 	return _c
 }
 
-func (_c *MockRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string) error) *MockRepository_EnrichNotification_Call {
+func (_c *MockRepository_EnrichNotification_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string, string) error) *MockRepository_EnrichNotification_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -48,6 +48,7 @@ type BridgeHealth struct {
 
 // EnrichmentResult holds the fetched details for a notification.
 type EnrichmentResult struct {
+	SubjectNodeID    string
 	Body             string
 	HTMLURL          string
 	Author           string

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -84,21 +84,52 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState) tea.Cmd {
 		m.inflightEnrichments[n.GitHubID] = now
 	}
 
-	// For a single item enrichment (Detail View), we use FetchDetail
-	if len(toEnrich) == 1 {
-		n := toEnrich[0]
-		return m.FetchDetailCmd(n.GitHubID, n.SubjectURL, n.SubjectType)
+	// 2. Split into Batch (has node_id) and Discovery (missing node_id) groups
+	var batch []triage.NotificationWithState
+	var discovery []triage.NotificationWithState
+
+	for _, n := range toEnrich {
+		if n.SubjectNodeID != "" {
+			batch = append(batch, n)
+		} else {
+			discovery = append(discovery, n)
+		}
 	}
 
-	// For multiple items (Viewport), split into smaller chunks to utilize concurrent workers
 	var cmds []tea.Cmd
 
-	for i := 0; i < len(toEnrich); i += EnrichmentChunkSize {
+	// Handle Discovery items (one-by-one to get node_id)
+	// We use PriorityEnrich for proactive discovery to avoid blocking user actions
+	for _, n := range discovery {
+		id, url, st := n.GitHubID, n.SubjectURL, n.SubjectType
+		cmds = append(cmds, m.traffic.Submit(api.PriorityEnrich, func(ctx context.Context) tea.Msg {
+			res, err := m.enrich.FetchDetail(ctx, url, string(st))
+			if err != nil {
+				return types.ErrMsg{Err: err}
+			}
+			// Atomic DB update including nodeID
+			if err := m.db.EnrichNotification(ctx, id, res.SubjectNodeID, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState); err != nil {
+				return types.ErrMsg{Err: err}
+			}
+			return detailLoadedMsg{
+				GitHubID:         id,
+				SubjectNodeID:    res.SubjectNodeID,
+				Body:             res.Body,
+				Author:           res.Author,
+				HTMLURL:          res.HTMLURL,
+				ResourceState:    res.ResourceState,
+				ResourceSubState: res.ResourceSubState,
+			}
+		}))
+	}
+
+	// Handle Batch items (GraphQL batch fetch)
+	for i := 0; i < len(batch); i += EnrichmentChunkSize {
 		end := i + EnrichmentChunkSize
-		if end > len(toEnrich) {
-			end = len(toEnrich)
+		if end > len(batch) {
+			end = len(batch)
 		}
-		chunk := toEnrich[i:end]
+		chunk := batch[i:end]
 
 		cmds = append(cmds, m.traffic.Submit(api.PriorityEnrich, func(ctx context.Context) tea.Msg {
 			results := m.enrich.FetchHybridBatch(ctx, chunk)
@@ -125,13 +156,14 @@ func (m *Model) FetchDetailCmd(id, u string, subjectType triage.SubjectType) tea
 		}
 
 		// Update database with granular enrich method
-		err = m.db.EnrichNotification(ctx, id, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState)
+		err = m.db.EnrichNotification(ctx, id, res.SubjectNodeID, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 
 		return detailLoadedMsg{
 			GitHubID:         id,
+			SubjectNodeID:    res.SubjectNodeID,
 			Body:             res.Body,
 			Author:           res.Author,
 			HTMLURL:          res.HTMLURL,

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -234,14 +234,19 @@ func TestModel_Enrichment_SurgicalUpdate(t *testing.T) {
 	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
-		Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()},
+		Notification: triage.Notification{
+			GitHubID:      "1",
+			SubjectNodeID: "node_1",
+			IsEnriched:    false,
+			UpdatedAt:     time.Now(),
+		},
 	}
 	m.allNotifications = []triage.NotificationWithState{notif}
 	m.inflightEnrichments["1"] = time.Now()
 
-	// 1. Receive surgical update
+	// 1. Receive surgical update (indexed by SubjectNodeID)
 	results := map[string]models.EnrichmentResult{
-		"1": {ResourceState: "Merged", ResourceSubState: "APPROVED", FetchedAt: time.Now()},
+		"node_1": {ResourceState: "Merged", ResourceSubState: "APPROVED", FetchedAt: time.Now()},
 	}
 	_ = m.Transition(enrichmentBatchCompleteMsg{Results: results}, 0)
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -53,7 +53,7 @@ type notificationStore interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
 	MarkReadLocally(ctx context.Context, id string, isRead bool) error
 	SetPriority(ctx context.Context, id string, priority int) error
-	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, resourceSubState string) error
+	EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error
 }
 
 // Model represents the application state.
@@ -286,6 +286,7 @@ type syncCompleteMsg struct {
 
 type detailLoadedMsg struct {
 	GitHubID         string
+	SubjectNodeID    string
 	Body             string
 	Author           string
 	HTMLURL          string

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -394,20 +394,20 @@ func (m *Model) handleEnrichmentBatchComplete(msg enrichmentBatchCompleteMsg) []
 	m.ui.SetFetching(false)
 
 	// Surgical update of in-memory notification slice
-	for id, res := range msg.Results {
-		delete(m.inflightEnrichments, id)
-
+	for nodeID, res := range msg.Results {
 		for idx, n := range m.allNotifications {
-			if n.GitHubID != id {
+			if n.SubjectNodeID != nodeID {
 				continue
 			}
+
+			// Clear inflight for each notification matching this nodeID
+			delete(m.inflightEnrichments, n.GitHubID)
 
 			m.allNotifications[idx].ResourceState = res.ResourceState
 			m.allNotifications[idx].ResourceSubState = res.ResourceSubState
 			m.allNotifications[idx].IsEnriched = true
 			m.allNotifications[idx].EnrichedAt.Time = res.FetchedAt
 			m.allNotifications[idx].EnrichedAt.Valid = true
-			break
 		}
 	}
 
@@ -423,6 +423,7 @@ func (m *Model) handleDetailLoaded(msg detailLoadedMsg) {
 		if n.GitHubID != msg.GitHubID {
 			continue
 		}
+		m.allNotifications[idx].SubjectNodeID = msg.SubjectNodeID
 		m.allNotifications[idx].Body = msg.Body
 		m.allNotifications[idx].AuthorLogin = msg.Author
 		m.allNotifications[idx].HTMLURL = msg.HTMLURL

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -130,7 +130,7 @@ type SyncRepository interface {
 
 // EnrichmentRepository defines the database interactions required by the EnrichmentEngine.
 type EnrichmentRepository interface {
-	EnrichNotification(ctx context.Context, id, body, author, htmlURL, resourceState, resourceSubState string) error
+	EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error
 	UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, resourceSubState string) error
 }
 


### PR DESCRIPTION
Addresses #176.

### Problem
The proactive batch enrichment was ineffective for REST-synced notifications because they lacked `SubjectNodeID`. Additionally, an ID mismatch in the TUI logic prevented the `inflightEnrichments` map from being cleared, blocking subsequent updates.

### Fix
1. **Hybrid Enrichment Strategy**: Implemented in `enrichItems`. Notifications with `SubjectNodeID` use GraphQL batching, while those without use a one-by-one discovery call (using `PriorityEnrich`).
2. **SubjectNodeID Persistence**: Updated `FetchDetail`, `fetchPullRequestGQL`, and `fetchREST` to fetch the `node_id` and include it in `EnrichmentResult`. Updated the database layer to atomically save this ID.
3. **Correct ID Mapping**: Updated `handleEnrichmentBatchComplete` to map resource IDs back to all corresponding notification IDs and correctly clear the inflight state.
4. **TUI Refresh**: Verified that `applyFilters` is called correctly during reloads and enrichment completions.

### Verification
- Verified with new reproduction tests in `internal/tui` (verified and then removed).
- All existing tests pass (`make test`).

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>