### PR TITLE
fix: use compact JSON format for OTel trace output

### DIFF
--- a/internal/config/otel.go
+++ b/internal/config/otel.go
@@ -44,7 +44,6 @@ func SetupOTel(ctx context.Context, version string) (*sdktrace.TracerProvider, f
 	// 2. Create the JSON exporter
 	exporter, err := stdouttrace.New(
 		stdouttrace.WithWriter(file),
-		stdouttrace.WithPrettyPrint(),
 	)
 	if err != nil {
 		_ = file.Close()

--- a/internal/config/otel_test.go
+++ b/internal/config/otel_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupOTel(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	ctx := context.Background()
+	version := "1.0.0"
+
+	tp, cleanup, err := SetupOTel(ctx, version)
+	require.NoError(t, err)
+	require.NotNil(t, tp)
+	require.NotNil(t, cleanup)
+
+	// Ensure cleanup function runs without error
+	defer cleanup()
+
+	// Verify trace file exists
+	stateDir := filepath.Join(tmpDir, "gh-orbit")
+	tracePath := filepath.Join(stateDir, "orbit.traces.json")
+	assert.FileExists(t, tracePath)
+
+	// Verify directory permissions
+	info, err := os.Stat(stateDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+
+	// Verify file permissions
+	fInfo, err := os.Stat(tracePath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fInfo.Mode().Perm())
+}


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #175

## Objective

Reduce the volume and number of trace files by switching from pretty-printed JSON to compact JSON format for OpenTelemetry (OTel) traces.

## Changes

- Removed `stdouttrace.WithPrettyPrint()` from `internal/config/otel.go`.
- Added a new test file `internal/config/otel_test.go` to verify trace initialization and directory/file permissions.

## Verification Results

- Verified compact JSON output manually using `gh-orbit --verbose` with redirected XDG directories.
- All tests passed, including a new test for OTel setup:
  ```
  ok      github.com/hirakiuc/gh-orbit/internal/config    0.441s
  ```
- Full verification suite passed with `make fmt lint test`.

## Checklist

- [x] All checks passed (`make check`)
- [ ] Documentation updated (if applicable)

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>