### PR TITLE
fix: implement Native Focus Mode visual feedback

### DIFF
--- a/internal/api/macos_stub.go
+++ b/internal/api/macos_stub.go
@@ -28,7 +28,7 @@ func (s *stubNotifier) Status() types.BridgeStatus {
 
 // CheckFocusMode returns a no-op status for non-macOS platforms.
 func CheckFocusMode(executor types.CommandExecutor) string {
-	return "Unsupported platform"
+	return "Inactive"
 }
 
 // BridgeProbe represents the result of a single bridge diagnostic check.

--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -119,3 +119,7 @@ type ActionScheduleTick struct {
 }
 
 func (a ActionScheduleTick) Type() string { return "schedule_tick" }
+
+type ActionCheckFocusMode struct{}
+
+func (a ActionCheckFocusMode) Type() string { return "check_focus_mode" }

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -79,6 +79,10 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 		}
 	}
 
+	if _, ok := action.(ActionCheckFocusMode); ok {
+		return i.model.checkFocusMode()
+	}
+
 	if a, ok := action.(ActionScheduleTick); ok {
 		switch a.TickType {
 		case TickHeartbeat:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -88,6 +88,7 @@ type Model struct {
 	headerHeight     int
 	footerHeight     int
 	bridgeStatus     types.BridgeStatus
+	focusMode        string
 	interpreter      *Interpreter
 
 	// Background Sync State
@@ -209,6 +210,7 @@ func (m *Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.loadNotifications(true),
 		m.tickClock(),
+		m.checkFocusMode(),
 	)
 }
 
@@ -269,7 +271,15 @@ func (m *Model) syncNotificationsWithForce(force bool) tea.Cmd {
 	})
 }
 
+func (m *Model) checkFocusMode() tea.Cmd {
+	return func() tea.Msg {
+		return focusModeMsg(api.CheckFocusMode(m.executor))
+	}
+}
+
 // Messages
+type focusModeMsg string
+
 type notificationsLoadedMsg struct {
 	notifications []triage.NotificationWithState
 	IsInitial     bool

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -73,6 +73,8 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		return m.handleEnrichmentBatchComplete(msg)
 	case detailLoadedMsg:
 		m.handleDetailLoaded(msg)
+	case focusModeMsg:
+		m.focusMode = string(msg)
 	case pollTickMsg:
 		return m.handlePollTick(msg)
 	case clockTickMsg:
@@ -457,7 +459,10 @@ func (m *Model) handleClockTick(msg clockTickMsg) []Action {
 	if msg.ID != m.clockID {
 		return nil
 	}
-	return []Action{ActionScheduleTick{TickType: TickClock, Interval: m.clockInterval}}
+	return []Action{
+		ActionScheduleTick{TickType: TickClock, Interval: m.clockInterval},
+		ActionCheckFocusMode{},
+	}
 }
 
 func (m *Model) handleTransitionError(msg types.ErrMsg) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -126,7 +126,13 @@ func (m *Model) renderFooter() string {
 
 	health := bridgeStyle.Render(bridge)
 
-	// 4. Rate Limit Status
+	// 4. Focus Mode
+	focusIndicator := ""
+	if m.focusMode == "Active" {
+		focusIndicator = m.styles.PriorityMed.Render("[DND]")
+	}
+
+	// 5. Rate Limit Status
 	rlStatus := ""
 	if m.RateLimit.Limit > 0 {
 		threshold := int64(m.RateLimit.Limit) / 10
@@ -145,7 +151,7 @@ func (m *Model) renderFooter() string {
 		}
 	}
 
-	// 5. Version Information
+	// 6. Version Information
 	vStr := m.styles.SelectedDescription.Render(" " + m.version + " ")
 
 	statusLine := lipgloss.JoinHorizontal(
@@ -154,8 +160,10 @@ func (m *Model) renderFooter() string {
 		" ",
 		filters,
 		" ",
+		focusIndicator,
+		" ",
 		rlStatus,
-		lipgloss.PlaceHorizontal(m.width-lipgloss.Width(statusMsg)-lipgloss.Width(filters)-lipgloss.Width(rlStatus)-lipgloss.Width(bridge)-lipgloss.Width(vStr)-6, lipgloss.Right, vStr+" "+health),
+		lipgloss.PlaceHorizontal(m.width-lipgloss.Width(statusMsg)-lipgloss.Width(filters)-lipgloss.Width(focusIndicator)-lipgloss.Width(rlStatus)-lipgloss.Width(bridge)-lipgloss.Width(vStr)-8, lipgloss.Right, vStr+" "+health),
 	)
 
 	if !m.showHelp {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -98,8 +98,20 @@ func TestRenderHeader(t *testing.T) {
 func TestRenderFooter(t *testing.T) {
 	m := newTestModel(t)
 	m.width = 100
-	view := m.renderFooter()
-	assert.NotEmpty(t, view)
+
+	t.Run("Normal state", func(t *testing.T) {
+		m.focusMode = "Inactive"
+		view := m.renderFooter()
+		assert.NotEmpty(t, view)
+		assert.NotContains(t, stripANSI(view), "[DND]")
+	})
+
+	t.Run("Active Focus Mode", func(t *testing.T) {
+		m.focusMode = "Active"
+		view := m.renderFooter()
+		assert.NotEmpty(t, view)
+		assert.Contains(t, stripANSI(view), "[DND]")
+	})
 }
 
 func TestRenderMarkdown(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #100

## Objective

Add a visual indicator `[DND]` to the TUI footer when macOS Focus Mode (Do Not Disturb) is active. This provides users with immediate feedback that notifications might be suppressed by the system.

## Changes

- Updated `internal/api/macos_stub.go` to return `Inactive` for focus mode checks on non-macOS platforms.
- Added `ActionCheckFocusMode` to `internal/tui/actions_types.go`.
- Implemented asynchronous Focus Mode check in `internal/tui/interpreter.go`.
- Added `focusMode` state to `Model` in `internal/tui/model.go`.
- Updated `internal/tui/update.go` to handle focus mode updates on initialization and 1-minute clock ticks.
- Modified `renderFooter` in `internal/tui/view.go` to display the `[DND]` indicator.
- Updated `TestRenderFooter` in `internal/tui/view_test.go` to verify the new visual feedback.

## Verification Results

- Verified that `gh-orbit doctor` reports Focus as `Active` in the current macOS environment.
- Added unit test coverage for footer rendering with and without `[DND]`:
  ```
  ok      github.com/hirakiuc/gh-orbit/internal/tui       0.322s
  ```
- All tests passed successfully with `make fmt lint test`.

## Checklist

- [x] All checks passed (`make check`)
- [x] Documentation updated (if applicable)

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>