### PR TITLE
feat: high-density Repo-First TUI list layout

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/dustin/go-humanize"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 )
 
@@ -16,19 +18,32 @@ type RenderContext struct {
 }
 
 // RenderNotificationRow provides a consistent, non-truncated row layout.
-// Layout: [Indicator][Icon][Unread][Badge] [Title] [ID] [Priority]
+// RenderNotificationRow provides a consistent, high-density Repo-First row layout.
+// Layout: [Indicator][Icon][Unread][Badge] [Repo] │ [Title] [ID] [Time] [Priority]
 func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) string {
 	const minTitleWidth = 10
+	const repoWidth = 20
+
 	indicator := renderSelectionIndicator(ctx.Styles, ctx.IsSelected)
 	icon := renderNotificationIcon(n.SubjectType)
 	unread := renderUnreadIndicator(ctx.Styles, n.IsReadLocally)
 	badge := renderResourceStateBadge(ctx, n.ResourceState)
-	idStr := renderResourceID(ctx.Styles, n.SubjectURL)
+	repo := renderRepoColumn(ctx.Styles, n.RepositoryFullName, repoWidth)
+	divider := ctx.Styles.Separator.Render(" │ ")
+
+	idStr := ""
+	timeStr := ""
+	if ctx.Width >= 80 {
+		idStr = " " + renderResourceID(ctx.Styles, n.SubjectURL)
+		timeStr = " " + renderRelativeTime(ctx.Styles, n.UpdatedAt)
+	}
+
 	priority := renderPriorityBadge(ctx.Styles, n.Priority)
-	titleWidth := calculateAvailableTitleWidth(ctx.Width, minTitleWidth, icon, unread, badge, idStr, priority)
+
+	titleWidth := calculateAvailableTitleWidth(ctx.Width, minTitleWidth, icon, unread, badge, repo, divider, idStr, timeStr, priority)
 	title := renderNotificationTitle(ctx, n, titleWidth)
 
-	return fmt.Sprintf("%s%s%s%s%s%s%s", indicator, icon, unread, badge, title, idStr, priority)
+	return fmt.Sprintf("%s%s%s%s%s%s%s%s%s%s", indicator, icon, unread, badge, repo, divider, title, idStr, timeStr, priority)
 }
 
 func renderUnreadIndicator(styles Styles, isRead bool) string {
@@ -58,6 +73,18 @@ func renderNotificationIcon(subjectType triage.SubjectType) string {
 	default:
 		return "  "
 	}
+}
+
+func renderRepoColumn(styles Styles, repoFullName string, width int) string {
+	return styles.SelectedDescription.
+		Width(width).
+		MaxWidth(width).
+		Render(repoFullName)
+}
+
+func renderRelativeTime(styles Styles, updatedAt time.Time) string {
+	relTime := humanize.Time(updatedAt)
+	return styles.SelectedDescription.Render(relTime)
 }
 
 func renderResourceID(styles Styles, subjectURL string) string {
@@ -105,17 +132,20 @@ func renderPriorityBadge(styles Styles, priority int) string {
 	}
 }
 
-func calculateAvailableTitleWidth(totalWidth, minTitleWidth int, icon, unread, badge, idStr, priority string) int {
+func calculateAvailableTitleWidth(totalWidth, minTitleWidth int, icon, unread, badge, repo, divider, idStr, timeStr, priority string) int {
 	const selectionIndicatorWidth = 2
-	const layoutSafetyBuffer = 7 // 2 spaces + 5 extra cells for multi-width glyphs.
+	const layoutSafetyBuffer = 10 // Increased to handle multi-width icons and padding.
 
-	fixedWidth := selectionIndicatorWidth + lipgloss.Width(icon) + lipgloss.Width(unread) + lipgloss.Width(idStr) + layoutSafetyBuffer
-	if badge != "" {
-		fixedWidth += lipgloss.Width(badge) + 1
-	}
-	if priority != "" {
-		fixedWidth += lipgloss.Width(priority)
-	}
+	fixedWidth := selectionIndicatorWidth +
+		lipgloss.Width(icon) +
+		lipgloss.Width(unread) +
+		lipgloss.Width(badge) +
+		lipgloss.Width(repo) +
+		lipgloss.Width(divider) +
+		lipgloss.Width(idStr) +
+		lipgloss.Width(timeStr) +
+		lipgloss.Width(priority) +
+		layoutSafetyBuffer
 
 	availableTitleWidth := totalWidth - fixedWidth
 	if availableTitleWidth < minTitleWidth {
@@ -132,5 +162,20 @@ func renderNotificationTitle(ctx RenderContext, n triage.NotificationWithState, 
 	if ctx.IsSelected {
 		titleStyle = ctx.Styles.SelectedTitle
 	}
-	return titleStyle.Width(width).MaxWidth(width).Render(n.SubjectTitle)
+
+	// Sanitize title: remove newlines and tabs to maintain single-line density
+	cleanTitle := strings.ReplaceAll(n.SubjectTitle, "\n", " ")
+	cleanTitle = strings.ReplaceAll(cleanTitle, "\r", "")
+	cleanTitle = strings.ReplaceAll(cleanTitle, "\t", " ")
+	cleanTitle = strings.TrimSpace(cleanTitle)
+
+	// Manual truncation to ensure it fits in exactly 1 line
+	// Note: We use runes to handle multi-width characters more safely,
+	// although Title is usually ASCII.
+	runes := []rune(cleanTitle)
+	if len(runes) > width {
+		cleanTitle = string(runes[:width-3]) + "..."
+	}
+
+	return titleStyle.Width(width).MaxWidth(width).Render(cleanTitle)
 }

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -7,7 +7,6 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
-	"github.com/dustin/go-humanize"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 )
 
@@ -31,7 +30,7 @@ func newItemDelegate(s Styles, k KeyMap) itemDelegate {
 	return itemDelegate{styles: s, keys: k}
 }
 
-func (d itemDelegate) Height() int                               { return 2 }
+func (d itemDelegate) Height() int                               { return 1 }
 func (d itemDelegate) Spacing() int                              { return 0 }
 func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
 
@@ -51,7 +50,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 	isSelected := index == m.Index()
 
-	// 1. Target Identity Row (Indicator + Icon + Unread + Badge + Title + #ID + Priority)
+	// Target Identity Row (Indicator + Icon + Unread + Badge + Repo + Divider + Title + #ID + Time + Priority)
 	ctx := RenderContext{
 		Styles:     d.styles,
 		Width:      m.Width(),
@@ -60,12 +59,5 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	}
 	str := RenderNotificationRow(ctx, i.notification)
 
-	// 2. Meta info (line 2)
-	relTime := humanize.Time(i.notification.UpdatedAt)
-	description := fmt.Sprintf("%s • %s", i.notification.RepositoryFullName, relTime)
-	if isSelected {
-		description = d.styles.SelectedDescription.Render(description)
-	}
-
-	_, _ = fmt.Fprintf(w, "%s\n    %s", str, description)
+	_, _ = fmt.Fprint(w, str)
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -52,6 +52,8 @@ type Styles struct {
 
 	// Search
 	FuzzyMatch lipgloss.Style
+
+	Separator lipgloss.Style
 }
 
 // DefaultStyles returns the default styles for the application.
@@ -181,6 +183,9 @@ func DefaultStyles(isDark bool) Styles {
 		Foreground(accent).
 		Bold(true).
 		Underline(true)
+
+	s.Separator = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#484F58"))
 
 	// Resource States (Desaturated Professional Palette)
 	openBG := lipgloss.Color("#1B3A24")

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hirakiuc/gh-orbit/internal/triage"
@@ -17,18 +18,27 @@ func TestRenderNotificationRow_States(t *testing.T) {
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{
-			SubjectType:   "PullRequest",
-			SubjectTitle:  "Title",
-			SubjectURL:    "https://github.com/o/r/pull/123",
-			GitHubID:      "123",
-			ResourceState: "MERGED",
+			SubjectType:        "PullRequest",
+			SubjectTitle:       "Title",
+			SubjectURL:         "https://github.com/o/r/pull/123",
+			RepositoryFullName: "owner/repo",
+			GitHubID:           "123",
+			ResourceState:      "MERGED",
 		},
 	}
 
-	// Test normal
+	// Test normal (Repo-First)
 	out := RenderNotificationRow(ctx, notif)
-	assert.Contains(t, stripANSI(out), "Title")
-	assert.Contains(t, stripANSI(out), "MERGED")
+	plain := stripANSI(out)
+	assert.Contains(t, plain, "owner/repo")
+	assert.Contains(t, plain, "│")
+	assert.Contains(t, plain, "Title")
+	assert.Contains(t, plain, "MERGED")
+
+	// Verify order: repo before title
+	repoIdx := strings.Index(plain, "owner/repo")
+	titleIdx := strings.Index(plain, "Title")
+	assert.Less(t, repoIdx, titleIdx, "Repo must come before Title")
 
 	// Test selected
 	ctx.IsSelected = true
@@ -42,7 +52,7 @@ func TestRenderNotificationRow_States(t *testing.T) {
 	notif.SubjectTitle = "Very Long Title That Should Be Truncated"
 	outPriority := RenderNotificationRow(ctx, notif)
 
-	plain := stripANSI(outPriority)
+	plain = stripANSI(outPriority)
 	// Log for diagnostic visibility in CI if it fails
 	t.Logf("Actual row width: %d, Content: [%s]", len(plain), plain)
 
@@ -58,19 +68,21 @@ func TestRenderNotificationRow_EmptyState(t *testing.T) {
 
 	notifOpen := triage.NotificationWithState{
 		Notification: triage.Notification{
-			SubjectType:   "PullRequest",
-			SubjectTitle:  "Title",
-			SubjectURL:    "https://github.com/o/r/pull/123",
-			ResourceState: "OPEN",
+			SubjectType:        "PullRequest",
+			SubjectTitle:       "Title",
+			SubjectURL:         "https://github.com/o/r/pull/123",
+			RepositoryFullName: "owner/repo",
+			ResourceState:      "OPEN",
 		},
 	}
 
 	notifEmpty := triage.NotificationWithState{
 		Notification: triage.Notification{
-			SubjectType:   "PullRequest",
-			SubjectTitle:  "Title",
-			SubjectURL:    "https://github.com/o/r/pull/124",
-			ResourceState: "", // Empty state should use placeholder
+			SubjectType:        "PullRequest",
+			SubjectTitle:       "Title",
+			SubjectURL:         "https://github.com/o/r/pull/124",
+			RepositoryFullName: "owner/repo",
+			ResourceState:      "", // Empty state should use placeholder
 		},
 	}
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #102

## Objective

Refine the TUI list rendering to achieve high-density information display and improved scannability. This switch to a "Repo-First" layout prioritizes domain-based triage by creating a vertical column of project contexts.

## Changes

- Consolidated the 2-line list item into a single high-density line, doubling vertical information density.
- Implemented "Repo-First" layout: `[Badge] [Repo] │ [Title] [ID] [Time] [Priority]`.
- Added a 20-character semi-fixed column for Repository names with tail-truncation.
- Added a subtle vertical separator (`│`) to distinguish project context from notification content.
- Implemented responsive design: hides Resource ID and Relative Time if terminal width < 80 characters.
- Refined Title rendering with newline sanitization and rune-aware manual truncation to ensure single-line integrity.
- Updated `internal/tui/styles.go` with a new `Separator` style and refined metadata visibility.
- Updated unit tests in `internal/tui/view_test.go` to verify the new column ordering and alignment.

## Verification Results

- Verified the new layout manually in the TUI.
- All unit tests passed, including refined `TestRenderNotificationRow`:
  ```
  ok      github.com/hirakiuc/gh-orbit/internal/tui       0.302s
  ```
- Full verification suite (`make check`) passed successfully.

## Checklist

- [x] All checks passed (`make check`)
- [ ] Documentation updated (if applicable)

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>