### PR TITLE
fix: TUI list layout breakage and overflow

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -76,6 +76,12 @@ func renderNotificationIcon(subjectType triage.SubjectType) string {
 }
 
 func renderRepoColumn(styles Styles, repoFullName string, width int) string {
+	// Manual truncation to ensure it fits in exactly 1 line
+	runes := []rune(repoFullName)
+	if len(runes) > width {
+		repoFullName = string(runes[:width-3]) + "..."
+	}
+
 	return styles.SelectedDescription.
 		Width(width).
 		MaxWidth(width).

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -116,6 +116,7 @@ func (m *Model) transitionDetail(msg tea.Msg) []Action {
 		case key.Matches(msg, m.keys.Help):
 			m.showHelp = !m.showHelp
 			m.help.ShowAll = m.showHelp
+			m.syncSubModelSizes()
 		case key.Matches(msg, m.keys.OpenBrowser):
 			if i, ok := m.listView.list.SelectedItem().(item); ok {
 				actions = append(actions, ActionViewWeb{Notification: i.notification})
@@ -341,7 +342,25 @@ func (m *Model) handleWindowSize(msg tea.WindowSizeMsg) {
 
 	m.help.SetWidth(msg.Width)
 
+	m.syncSubModelSizes()
 	m.updateMarkdownRenderer()
+}
+
+func (m *Model) syncSubModelSizes() {
+	header := m.renderHeader()
+	footer := m.renderFooter()
+
+	m.headerHeight = lipgloss.Height(header)
+	m.footerHeight = lipgloss.Height(footer)
+
+	availHeight := m.height - m.headerHeight - m.footerHeight
+	if availHeight < 0 {
+		availHeight = 0
+	}
+
+	m.listView.list.SetSize(m.width, availHeight)
+	m.detailView.viewport.SetWidth(m.width)
+	m.detailView.viewport.SetHeight(availHeight)
 }
 
 func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
@@ -490,6 +509,7 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 	case key.Matches(msg, m.keys.Help):
 		m.showHelp = !m.showHelp
 		m.help.ShowAll = m.showHelp
+		m.syncSubModelSizes()
 	case key.Matches(msg, m.keys.NextTab):
 		m.cycleTab(1)
 	case key.Matches(msg, m.keys.PrevTab):

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -25,20 +25,6 @@ func (m *Model) View() tea.View {
 	m.headerHeight = lipgloss.Height(header)
 	m.footerHeight = lipgloss.Height(footer)
 
-	// Update sub-model sizes dynamically
-	availHeight := m.height - m.headerHeight - m.footerHeight
-	if availHeight < 0 {
-		availHeight = 0
-	}
-
-	switch m.state {
-	case StateList:
-		m.listView.list.SetSize(m.width, availHeight)
-	case StateDetail:
-		m.detailView.viewport.SetWidth(m.width)
-		m.detailView.viewport.SetHeight(availHeight)
-	}
-
 	var content string
 	switch m.state {
 	case StateDetail:

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/stretchr/testify/assert"
 )
@@ -124,6 +125,34 @@ func TestRenderFooter(t *testing.T) {
 		assert.NotEmpty(t, view)
 		assert.Contains(t, stripANSI(view), "[DND]")
 	})
+}
+
+func TestRenderNotificationRow_LongRepo(t *testing.T) {
+	ctx := RenderContext{
+		Styles: DefaultStyles(true),
+		Width:  100,
+	}
+
+	notif := triage.NotificationWithState{
+		Notification: triage.Notification{
+			SubjectType:        "PullRequest",
+			SubjectTitle:       "Small Title",
+			SubjectURL:         "https://github.com/o/r/pull/123",
+			RepositoryFullName: "a-very-long-repository-name-that-exceeds-twenty-chars",
+			GitHubID:           "123",
+			ResourceState:      "OPEN",
+		},
+	}
+
+	out := RenderNotificationRow(ctx, notif)
+	plain := stripANSI(out)
+
+	// Verify that the output is exactly 1 line
+	assert.NotContains(t, out, "\n", "Row must not contain newlines")
+	assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
+
+	// Verify truncation of repo name
+	assert.Contains(t, plain, "a-very-long-repos...", "Repo name must be truncated with ellipsis")
 }
 
 func TestRenderMarkdown(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #181

## Objective

Fix TUI layout regressions introduced in #102 where long repository names caused row wrapping and the list view overflowed the terminal height, hiding the footer and pager.

## Changes

- **Repository Truncation**: Implemented strict 1-line rune-based truncation for the repository column in `internal/tui/components.go`.
- **Sizing Refactor**: Moved all sub-model resizing (`list.SetSize`, `viewport.SetSize`) out of the `View()` function and into a new `syncSubModelSizes()` method.
- **Resizing Orchestration**: `syncSubModelSizes()` is now called during window resize (`handleWindowSize`) and whenever the help menu is toggled, ensuring correct height calculation based on actual header/footer sizes.
- **Test Coverage**: Added `TestRenderNotificationRow_LongRepo` to `internal/tui/view_test.go` to ensure that items remain exactly 1 line high regardless of input length.

## Verification Results

- Verified that `TestRenderNotificationRow_LongRepo` passes and confirms 1-line output.
- Full verification suite (`make check`) passed.
- Manual verification confirms that the footer and pager remain visible even with full lists and long repository names.

## Checklist

- [x] All checks passed (`make check`)
- [ ] Documentation updated (if applicable)

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>