### PR TITLE
feat: trigger enrichment on terminal height increase

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -376,7 +376,7 @@ func TestModel_Transition_Global(t *testing.T) {
 	actions := m.Transition(tea.WindowSizeMsg{Width: 100, Height: 50}, 0)
 	assert.Equal(t, 100, m.width)
 	assert.Equal(t, 50, m.height)
-	assert.Empty(t, actions)
+	assert.Contains(t, actions, ActionScheduleTick{TickType: TickEnrich})
 
 	// Error Msg
 	msg := types.ErrMsg{Err: assert.AnError}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -61,6 +61,7 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.handleWindowSize(msg)
+		return []Action{ActionScheduleTick{TickType: TickEnrich}}
 	case tea.BackgroundColorMsg:
 		m.handleBackgroundColor(msg)
 	case notificationsLoadedMsg:


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #182

## Objective

Ensure that newly visible notifications are automatically enriched when the terminal height is increased, providing live status badges for newly revealed items without requiring manual interaction.

## Changes

- Modified `transitionGlobal` in `internal/tui/update.go` to return `ActionScheduleTick{TickType: TickEnrich}` upon receiving a `tea.WindowSizeMsg`.
- This leverages the existing debounced enrichment mechanism (`TickEnrich`), which ensures efficient processing after resizing.
- Updated `TestModel_Transition_Global` in `internal/tui/logic_test.go` to verify that the enrichment trigger is correctly returned on window resize.

## Verification Results

- Verified that `TestModel_Transition_Global` passes with the new trigger logic.
- Full verification suite (`make check`) passed.
- Manual verification confirms that resizing the terminal triggers enrichment for newly visible items.

## Checklist

- [x] All checks passed (`make check`)
- [ ] Documentation updated (if applicable)

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>