### PR TITLE
feat: replace raw API Quota with humanized Last Synced status

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -95,6 +95,7 @@ type Model struct {
 	LastSyncAt        time.Time
 	PollInterval      int
 	RateLimit         models.RateLimitInfo
+	QuotaResetStatus  string // Cached humanized reset duration
 	heartbeatID       uint64
 	clockID           uint64
 	enrichID          uint64
@@ -269,6 +270,15 @@ func (m *Model) syncNotificationsWithForce(force bool) tea.Cmd {
 		}
 		return syncCompleteMsg{rateLimit: rl}
 	})
+}
+
+func (m *Model) updateQuotaResetStatus() {
+	if m.RateLimit.Reset.IsZero() {
+		m.QuotaResetStatus = ""
+		return
+	}
+
+	m.QuotaResetStatus = time.Until(m.RateLimit.Reset).Round(time.Minute).String()
 }
 
 func (m *Model) checkFocusMode() tea.Cmd {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -406,6 +406,7 @@ func (m *Model) handleSyncComplete(msg syncCompleteMsg) []Action {
 	m.ui.SetSyncing(false)
 	m.LastSyncAt = time.Now()
 	m.RateLimit = msg.rateLimit
+	m.updateQuotaResetStatus()
 	return []Action{
 		ActionUpdateRateLimit{Info: msg.rateLimit},
 		ActionLoadNotifications{IsInitial: false},
@@ -479,6 +480,7 @@ func (m *Model) handleClockTick(msg clockTickMsg) []Action {
 	if msg.ID != m.clockID {
 		return nil
 	}
+	m.updateQuotaResetStatus()
 	return []Action{
 		ActionScheduleTick{TickType: TickClock, Interval: m.clockInterval},
 		ActionCheckFocusMode{},

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -75,8 +75,7 @@ func (m *Model) renderHeader() string {
 		}
 
 		if remaining < threshold {
-			reset := time.Until(m.RateLimit.Reset).Round(time.Minute)
-			status = m.styles.PriorityMed.Render(fmt.Sprintf("Quota: %d (resets in %v)", remaining, reset))
+			status = m.styles.PriorityMed.Render(fmt.Sprintf("Quota: %d (resets in %s)", remaining, m.QuotaResetStatus))
 		} else {
 			if m.LastSyncAt.IsZero() {
 				status = m.styles.Help.Render("Last synced: Never")

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/glamour"
@@ -66,7 +67,23 @@ func (m *Model) renderHeader() string {
 	if m.ui.syncing {
 		status = m.ui.spinner.View() + " Syncing..."
 	} else {
-		status = fmt.Sprintf("Quota: %d", m.traffic.Remaining())
+		remaining := m.traffic.Remaining()
+		threshold := 1000
+		if m.RateLimit.Limit > 0 {
+			// Using float64 for precise percentage calculation.
+			threshold = int(float64(m.RateLimit.Limit) * 0.2)
+		}
+
+		if remaining < threshold {
+			reset := time.Until(m.RateLimit.Reset).Round(time.Minute)
+			status = m.styles.PriorityMed.Render(fmt.Sprintf("Quota: %d (resets in %v)", remaining, reset))
+		} else {
+			if m.LastSyncAt.IsZero() {
+				status = m.styles.Help.Render("Last synced: Never")
+			} else {
+				status = "Last synced: " + humanize.Time(m.LastSyncAt)
+			}
+		}
 	}
 
 	header := lipgloss.JoinHorizontal(

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -127,6 +127,7 @@ func TestRenderHeader_States(t *testing.T) {
 		m.ui.syncing = false
 		m.RateLimit.Limit = 5000
 		m.RateLimit.Reset = time.Now().Add(15 * time.Minute)
+		m.updateQuotaResetStatus()
 
 		view := m.renderHeader()
 		plain := stripANSI(view)

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/stretchr/testify/assert"
 )
@@ -106,6 +108,58 @@ func TestRenderHeader(t *testing.T) {
 	view := m.renderHeader()
 	assert.NotEmpty(t, view)
 	assert.Contains(t, stripANSI(view), "Inbox")
+}
+
+func TestRenderHeader_States(t *testing.T) {
+	t.Run("Syncing", func(t *testing.T) {
+		m := newTestModel(t)
+		m.ui.syncing = true
+		view := m.renderHeader()
+		assert.Contains(t, stripANSI(view), "Syncing...")
+	})
+
+	t.Run("Low Quota", func(t *testing.T) {
+		m := newTestModel(t)
+		mockTraffic := mocks.NewMockTrafficController(t)
+		mockTraffic.EXPECT().Remaining().Return(800).Once()
+		m.traffic = mockTraffic
+
+		m.ui.syncing = false
+		m.RateLimit.Limit = 5000
+		m.RateLimit.Reset = time.Now().Add(15 * time.Minute)
+
+		view := m.renderHeader()
+		plain := stripANSI(view)
+		assert.Contains(t, plain, "Quota: 800")
+		assert.Contains(t, plain, "resets in 15m")
+	})
+
+	t.Run("Never Synced", func(t *testing.T) {
+		m := newTestModel(t)
+		mockTraffic := mocks.NewMockTrafficController(t)
+		mockTraffic.EXPECT().Remaining().Return(5000).Once()
+		m.traffic = mockTraffic
+
+		m.ui.syncing = false
+		m.LastSyncAt = time.Time{}
+
+		view := m.renderHeader()
+		assert.Contains(t, stripANSI(view), "Last synced: Never")
+	})
+
+	t.Run("Recently Synced", func(t *testing.T) {
+		m := newTestModel(t)
+		mockTraffic := mocks.NewMockTrafficController(t)
+		mockTraffic.EXPECT().Remaining().Return(5000).Once()
+		m.traffic = mockTraffic
+
+		m.ui.syncing = false
+		// Use a fixed time for humanize to be consistent
+		m.LastSyncAt = time.Now().Add(-2 * time.Minute)
+
+		view := m.renderHeader()
+		assert.Contains(t, stripANSI(view), "Last synced: 2 minutes ago")
+	})
 }
 
 func TestRenderFooter(t *testing.T) {


### PR DESCRIPTION
Closes #188.

### Changes
- Replace the raw GitHub API Quota label in the header with a dynamic status indicator.
- Display `Last synced: Xm ago` (humanized relative time) by default.
- Show `Last synced: Never` (dimmed) if no sync has occurred yet.
- Only show API Quota as a warning if it falls below 20% of the limit (or 1,000 requests).
- Include the quota reset time in the warning state (e.g., `Quota: 800 (resets in 15m)`).
- Uses `github.com/dustin/go-humanize` for the relative time strings.

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>