### PR TITLE
docs: update agentic-core references and consolidate mandates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,19 +51,21 @@ This project uses the extension's standard "Workbench" files:
 - **PR Requirement**: No Pull Request will be merged unless `make check` passes 100%.
 - **Resilience**: Locally, gates may skip specific tools with a warning if they are missing, but the CI pipeline is strict and will block on any failure.
 
----
-
 ## 2. Sandbox & Environment Constraints (macOS Seatbelt)
 
-AI agents operate in a restricted sandbox. You MUST adhere to these path redirections:
+AI agents operate in a restricted sandbox. You MUST adhere to these path redirections and environment settings:
 
-- **Mandatory ./tmp usage**: All caching and build artifacts MUST reside in the project-local `./tmp`.
-- **Environment Variables**: Always prepend the following to shell commands:
+- **Operation not permitted**: If you encounter this error (or "Permission denied"), it is likely due to sandbox constraints. Do not attempt to work around these by modifying system paths.
+- **Mandatory ./tmp usage**: All caching, builds, and transient artifacts MUST reside in the project-local `./tmp`.
+- **Environment Variables**: Always prepend or export the following when running build or test tools:
   - `GOCACHE=$(pwd)/tmp/go-cache`
   - `GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache`
   - `TMPDIR=$(pwd)/tmp`
   - `HOME=$(pwd)/tmp/swift-home`
-- **SwiftPM Logic**: Use `--disable-sandbox` and `--build-path ./tmp/swift-build` for all native builds.
+- **Swift Command Redirection**: When building or testing native components, always append:
+  - `--disable-sandbox`
+  - `--build-path ./tmp/swift-build`
+- **Prefer Makefile**: Use namespaced `make` targets (e.g., `make go/build`, `make native/check`) as they are already configured to respect these sandbox-friendly paths.
 
 ---
 
@@ -71,6 +73,6 @@ AI agents operate in a restricted sandbox. You MUST adhere to these path redirec
 
 To minimize redundancy, this project delegates foundational logic to the `agentic-core` extension:
 
-- **Shell Safety**: Strictly follow the high-precision piping patterns in the extension's `rules/shell-safety.md`.
+- **Shell Safety**: Strictly follow the shell safety protocols defined by the **agentic-core** extension.
 - **GitHub API**: Use the extension's `github-operations` skill for all GraphQL/Rest interactions.
 - **Review Protocol**: Follow the extension's `reviewer-role` SIGN-OFF protocol.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,27 +15,15 @@ Always include the following co-authored-by footer in commit messages:
 
 ### 2.2 Shell Safety
 
-Strictly follow the shell safety protocols defined in [.agent/rules/shell-safety.md](.agent/rules/shell-safety.md).
+Strictly follow the shell safety protocols defined by the **agentic-core** extension.
 
 ### 2.3 Strategy Review
 
-Mandatory adherence to the [Strategy Review Workflow](.agent/workflows/strategy-review/WORKFLOW.md) before any changes to `internal/`, `cmd/`, or `native/`.
+Mandatory adherence to the **Strategy Review Workflow** provided by the **agentic-core** extension before any changes to `internal/`, `cmd/`, or `native/`.
 
 ### 2.4 Sandbox & macOS Seatbelt
 
-This project is configured with a restricted sandbox for AI tools (macOS Seatbelt).
-
-- **Operation not permitted**: If you encounter this error (or "Permission denied") when running shell commands, it is likely due to sandbox constraints. Do not attempt to work around these by modifying system paths.
-- **Mandatory ./tmp usage**: You MUST use the project's `./tmp` directory for all caches, builds, and transient files.
-- **Environment Variables**: Always prepend or export the following when running build or test tools:
-  - `GOCACHE=$(pwd)/tmp/go-cache`
-  - `GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache`
-  - `TMPDIR=$(pwd)/tmp`
-  - `HOME=$(pwd)/tmp/swift-home` (For SwiftPM caches)
-- **Swift Command Redirection**: When building or testing native components, always append:
-  - `--disable-sandbox`
-  - `--build-path ./tmp/swift-build`
-- **Prefer Makefile**: Use namespaced `make` targets (e.g., `make go/build`, `make native/check`) as they are already configured to respect these sandbox-friendly paths.
+This project is configured with a restricted sandbox for AI tools. You MUST strictly follow the environment constraints and path redirections defined in [AGENTS.md](AGENTS.md#2-sandbox--environment-constraints-macos-seatbelt).
 
 ## 3. Security Boundary Note
 


### PR DESCRIPTION
This PR updates AGENTS.md and GEMINI.md to correctly reference the agentic-core extension's mandates and workflows.

Key changes:
- Replaced fragile hardcoded extension paths with descriptive references.
- Consolidated Sandbox and macOS Seatbelt instructions into AGENTS.md as the single source of truth.
- Updated GEMINI.md to link to the environment constraints in AGENTS.md.
- Verified all changes with markdownlint.