### PR TITLE
fix: MCP server connection loop log flooding and lifecycle

### DIFF
--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hirakiuc/gh-orbit/internal/engine/transport"
@@ -78,13 +80,10 @@ func (s *MCPServer) Serve(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on UDS %s: %w", s.socket, err)
 	}
-	defer func() {
-		_ = l.Close()
-		_ = os.Remove(s.socket)
-	}()
 
 	// Secure the socket file immediately
 	if err := os.Chmod(s.socket, 0o600); err != nil {
+		_ = l.Close()
 		return fmt.Errorf("failed to secure socket file: %w", err)
 	}
 
@@ -102,15 +101,25 @@ func (s *MCPServer) Serve(ctx context.Context) error {
 	go s.eventLoop(ctx)
 
 	// 6. Connection Loop
+	done := make(chan struct{})
+	var isClosing atomic.Bool
+
 	go func() {
+		defer close(done)
 		for {
 			conn, err := secureListener.Accept()
 			if err != nil {
+				if isClosing.Load() || errors.Is(err, net.ErrClosed) {
+					return
+				}
+
 				select {
 				case <-ctx.Done():
 					return
 				default:
 					s.engine.Logger.ErrorContext(ctx, "failed to accept connection", "error", err)
+					// Small backoff to prevent log flooding
+					time.Sleep(100 * time.Millisecond)
 					continue
 				}
 			}
@@ -119,13 +128,27 @@ func (s *MCPServer) Serve(ctx context.Context) error {
 		}
 	}()
 
+	var serveErr error
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		serveErr = ctx.Err()
 	case sig := <-sigChan:
 		s.engine.Logger.InfoContext(ctx, "received signal, shutting down", "signal", sig)
-		return nil
 	}
+
+	// 7. Graceful Shutdown
+	isClosing.Store(true)
+	_ = l.Close()
+	_ = os.Remove(s.socket)
+
+	// Wait for connection loop to exit
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		s.engine.Logger.WarnContext(ctx, "connection loop did not exit gracefully")
+	}
+
+	return serveErr
 }
 
 func (s *MCPServer) eventLoop(ctx context.Context) {

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -98,6 +100,54 @@ func TestMCPServer_UDSHandshake(t *testing.T) {
 	// 3. Signal exit
 	cancel()
 	<-errChan
+}
+
+func TestMCPServer_GracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := config.DefaultConfig()
+
+	executor := api.NewOSCommandExecutor()
+
+	cwd, _ := os.Getwd()
+	tmpDir := filepath.Join(cwd, "../../tmp")
+	_ = os.MkdirAll(tmpDir, 0o700)
+	socketPath := filepath.Join(tmpDir, "mcp-shutdown-test.sock")
+
+	// Use a buffer to capture logs
+	var logBuf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	eng, err := NewCoreEngine(ctx, cfg, logger, executor)
+	if err != nil {
+		t.Logf("Skipping test: %v", err)
+		return
+	}
+	defer eng.Shutdown(ctx)
+
+	server := NewMCPServer(eng, socketPath, true, false)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.Serve(ctx)
+	}()
+
+	// Give it a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Trigger shutdown
+	cancel()
+
+	select {
+	case err := <-errChan:
+		assert.True(t, errors.Is(err, context.Canceled) || err == nil)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server did not shut down gracefully within timeout")
+	}
+
+	// Verify no "failed to accept connection" errors in log
+	assert.NotContains(t, logBuf.String(), "failed to accept connection")
 }
 
 func TestMCPAdapter_Debounce(t *testing.T) {


### PR DESCRIPTION
## Description
This PR fixes a bug where the MCP server background connection loop would flood logs with "use of closed network connection" errors during shutdown.

## Key Changes
- **Synchronization**: Added a `done` channel to ensure the `Serve` function waits for the background loop to exit cleanly.
- **Robustness**: Replaced string-based error matching with `errors.Is(err, net.ErrClosed)` for idiomatic and reliable detection of intentional listener closure.
- **Observability**: Implemented a shutdown guard using `atomic.Bool` to suppress expected errors during the graceful exit sequence.
- **Testability**: Added `TestMCPServer_GracefulShutdown` to `internal/engine/mcp_test.go` to provide automated verification of this behavior.

## Fixes
Resolves #222

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>