### PR TITLE
feat: greedy redaction, console logging, and robust binary resolution

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -121,15 +121,8 @@ class TerminalManager: ObservableObject {
             adapter.isDarkMode(isDark)
 
             // 1. Resolve binary
-            let executableURL: URL
-            if let auxURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
-                executableURL = auxURL
-            } else {
-                executableURL = URL(fileURLWithPath: "bin/gh-orbit")
-            }
-
-            guard FileManager.default.fileExists(atPath: executableURL.path) else {
-                self.launchError = "gh-orbit binary not found at \(executableURL.path)"
+            guard let executableURL = PathResolver.resolveBinary() else {
+                self.launchError = "gh-orbit binary not found. Please ensure it's in your PATH or set GH_ORBIT_BIN."
                 return
             }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -1,16 +1,31 @@
 import Foundation
 
+/// Protocol for file system operations to allow mocking.
+protocol FileSystem {
+    func fileExists(atPath: String) -> Bool
+    var currentDirectoryPath: String { get }
+}
+
+struct RealFileSystem: FileSystem {
+    func fileExists(atPath: String) -> Bool {
+        return FileManager.default.fileExists(atPath: atPath)
+    }
+    var currentDirectoryPath: String {
+        return FileManager.default.currentDirectoryPath
+    }
+}
+
 /// PathResolver handles the discovery of the gh-orbit binary across different environments.
 struct PathResolver {
-    static func resolveBinary() -> URL? {
-        let fileManager = FileManager.default
+    static func resolveBinary(
+        fileSystem: FileSystem = RealFileSystem(),
+        env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
 
         // 1. GH_ORBIT_BIN environment override
-        if let envPath = ProcessInfo.processInfo.environment["GH_ORBIT_BIN"],
-            !envPath.isEmpty
-        {
+        if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
             let url = URL(fileURLWithPath: envPath)
-            if fileManager.fileExists(atPath: url.path) {
+            if fileSystem.fileExists(atPath: url.path) {
                 return url
             }
         }
@@ -22,7 +37,7 @@ struct PathResolver {
 
         // 3. Project Root (Debug/Development only)
         #if DEBUG
-            if let devURL = resolveDevBinary() {
+            if let devURL = resolveDevBinary(fileSystem: fileSystem) {
                 return devURL
             }
         #endif
@@ -34,7 +49,7 @@ struct PathResolver {
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)
-            if fileManager.fileExists(atPath: url.path) {
+            if fileSystem.fileExists(atPath: url.path) {
                 return url
             }
         }
@@ -43,15 +58,14 @@ struct PathResolver {
     }
 
     #if DEBUG
-        private static func resolveDevBinary() -> URL? {
-            let fileManager = FileManager.default
-            let currentDir = fileManager.currentDirectoryPath
+        private static func resolveDevBinary(fileSystem: FileSystem) -> URL? {
+            let currentDir = fileSystem.currentDirectoryPath
             var searchURL = URL(fileURLWithPath: currentDir)
 
             // Walk up at most 5 levels to find project root (containing bin/gh-orbit)
             for _ in 0..<5 {
                 let binURL = searchURL.appendingPathComponent("bin/gh-orbit")
-                if fileManager.fileExists(atPath: binURL.path) {
+                if fileSystem.fileExists(atPath: binURL.path) {
                     return binURL
                 }
 
@@ -65,7 +79,7 @@ struct PathResolver {
                 }
 
                 // If we find markers but bin/gh-orbit wasn't there, stop anyway
-                if fileManager.fileExists(atPath: goModURL.path) || fileManager.fileExists(atPath: agentsURL.path) {
+                if fileSystem.fileExists(atPath: goModURL.path) || fileSystem.fileExists(atPath: agentsURL.path) {
                     break
                 }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// PathResolver handles the discovery of the gh-orbit binary across different environments.
+struct PathResolver {
+    static func resolveBinary() -> URL? {
+        let fileManager = FileManager.default
+
+        // 1. GH_ORBIT_BIN environment override
+        if let envPath = ProcessInfo.processInfo.environment["GH_ORBIT_BIN"],
+            !envPath.isEmpty
+        {
+            let url = URL(fileURLWithPath: envPath)
+            if fileManager.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        // 2. App Bundle (Production)
+        if let bundleURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
+            return bundleURL
+        }
+
+        // 3. Project Root (Debug/Development only)
+        #if DEBUG
+            if let devURL = resolveDevBinary() {
+                return devURL
+            }
+        #endif
+
+        // 4. Standard Absolute Fallbacks
+        let fallbacks = [
+            "/usr/local/bin/gh-orbit",
+            "/opt/homebrew/bin/gh-orbit",
+        ]
+        for path in fallbacks {
+            let url = URL(fileURLWithPath: path)
+            if fileManager.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    #if DEBUG
+        private static func resolveDevBinary() -> URL? {
+            let fileManager = FileManager.default
+            let currentDir = fileManager.currentDirectoryPath
+            var searchURL = URL(fileURLWithPath: currentDir)
+
+            // Walk up at most 5 levels to find project root (containing bin/gh-orbit)
+            for _ in 0..<5 {
+                let binURL = searchURL.appendingPathComponent("bin/gh-orbit")
+                if fileManager.fileExists(atPath: binURL.path) {
+                    return binURL
+                }
+
+                // Look for project sentinels
+                let goModURL = searchURL.appendingPathComponent("go.mod")
+                let agentsURL = searchURL.appendingPathComponent("AGENTS.md")
+
+                // Stop if we hit user home or root or find project markers
+                if searchURL.path == "/" || searchURL.path == "/Users" {
+                    break
+                }
+
+                // If we find markers but bin/gh-orbit wasn't there, stop anyway
+                if fileManager.fileExists(atPath: goModURL.path) || fileManager.fileExists(atPath: agentsURL.path) {
+                    break
+                }
+
+                searchURL.deleteLastPathComponent()
+            }
+
+            return nil
+        }
+    #endif
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -3,6 +3,18 @@ import Testing
 
 @testable import OrbitCockpit
 
+struct MockFileSystem: FileSystem {
+    var exists: Set<String> = []
+    var currentPath: String = "/test/project"
+
+    func fileExists(atPath: String) -> Bool {
+        return exists.contains(atPath)
+    }
+    var currentDirectoryPath: String {
+        return currentPath
+    }
+}
+
 @Suite("Process Lifecycle Tests")
 @MainActor
 struct LifecycleTests {
@@ -49,11 +61,44 @@ struct LifecycleTests {
         #expect(duration > 0.05)
     }
 
-    @Test("PathResolver binary discovery")
-    func testResolveBinary() async throws {
-        let url = PathResolver.resolveBinary()
-        if let binURL = url {
-            #expect(binURL.path.contains("gh-orbit"))
-        }
+    @Test("PathResolver binary discovery logic")
+    func testPathResolver() async throws {
+        // 1. Test Environment Override
+        var fileSystem = MockFileSystem()
+        fileSystem.exists.insert("/custom/bin/gh-orbit")
+        let env = ["GH_ORBIT_BIN": "/custom/bin/gh-orbit"]
+
+        let url1 = PathResolver.resolveBinary(fileSystem: fileSystem, env: env)
+        #expect(url1?.path == "/custom/bin/gh-orbit")
+
+        // 2. Test Project Root Discovery (at depth 0)
+        var fileSystem2 = MockFileSystem()
+        fileSystem2.currentPath = "/Users/dev/orbit"
+        fileSystem2.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url2 = PathResolver.resolveBinary(fileSystem: fileSystem2, env: [:])
+        #expect(url2?.path == "/Users/dev/orbit/bin/gh-orbit")
+
+        // 3. Test Project Root Discovery (walking up 2 levels)
+        var fileSystem3 = MockFileSystem()
+        fileSystem3.currentPath = "/Users/dev/orbit/internal/engine"
+        fileSystem3.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url3 = PathResolver.resolveBinary(fileSystem: fileSystem3, env: [:])
+        #expect(url3?.path == "/Users/dev/orbit/bin/gh-orbit")
+
+        // 4. Test Search Limit (6 levels deep should fail)
+        var fileSystem4 = MockFileSystem()
+        fileSystem4.currentPath = "/Users/dev/orbit/1/2/3/4/5/6"
+        fileSystem4.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url4 = PathResolver.resolveBinary(fileSystem: fileSystem4, env: [:])
+        #expect(url4 == nil)
+
+        // 5. Test Sentinel Stop (stops at go.mod even if binary is higher)
+        var fileSystem5 = MockFileSystem()
+        fileSystem5.currentPath = "/Users/dev/orbit/subdir"
+        fileSystem5.exists.insert("/Users/dev/bin/gh-orbit")  // binary is higher up
+        fileSystem5.exists.insert("/Users/dev/orbit/go.mod")  // but project root is here
+        let url5 = PathResolver.resolveBinary(fileSystem: fileSystem5, env: [:])
+        #expect(url5 == nil)  // Should not find the binary because search stops at go.mod
     }
+
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -49,4 +49,11 @@ struct LifecycleTests {
         #expect(duration > 0.05)
     }
 
+    @Test("PathResolver binary discovery")
+    func testResolveBinary() async throws {
+        let url = PathResolver.resolveBinary()
+        if let binURL = url {
+            #expect(binURL.path.contains("gh-orbit"))
+        }
+    }
 }


### PR DESCRIPTION
## Description
This PR combines security hardening for credentials with major observability improvements for the native macOS integration.

## Key Changes
- **Greedy Redaction**: Updated the `tokenRegex` in `internal/config` to match the entire GitHub token string (including underscores), preventing entropy leakage. Centralized this logic into `config.RedactSecrets`.
- **Direct Engine Logging**: Refactored `SetupLogger` to support custom `io.Writer` sinks. `gh-orbit engine` now defaults to `stderr`, allowing the native app to capture its logs directly.
- **Robust Binary Resolution**: Implemented `PathResolver` in Swift. It uses a multi-tier search (Env Var -> Bundle -> Project Root) with bounded walk-up and `#if DEBUG` guards for dev mode.
- **Automated Verification**: Added unit tests for redaction patterns and binary discovery.

## Fixes
Resolves #226, #228

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>