### PR TITLE
feat: implement self-contained macOS bundle (Phase 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,13 +118,17 @@ native/build: go/build
 	cp bin/$(BINARY_NAME) bin/$(COCKPIT_NAME).app/Contents/Helpers/
 	# 3. Bundle Metadata
 	cp native/OrbitCockpit/Resources/Info.plist bin/$(COCKPIT_NAME).app/Contents/
-	# 4. Ad-hoc Sign everything
+	# 4. Inside-out Signing (Helper first, then App)
 	@if [ "$$(uname)" = "Darwin" ]; then \
-		echo "Signing Cockpit bundle components..."; \
-		codesign -f -s - -i gh-orbit-cli bin/$(COCKPIT_NAME).app/Contents/Helpers/$(BINARY_NAME); \
-		codesign -f -s - -i gh-orbit-cockpit bin/$(COCKPIT_NAME).app/Contents/MacOS/$(COCKPIT_NAME); \
+		echo "Signing Cockpit bundle components (inside-out)..."; \
+		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/Helper.entitlements -i com.github.hirakiuc.gh-orbit.helper bin/$(COCKPIT_NAME).app/Contents/Helpers/$(BINARY_NAME); \
+		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/OrbitCockpit.entitlements -i com.github.hirakiuc.gh-orbit bin/$(COCKPIT_NAME).app/Contents/MacOS/$(COCKPIT_NAME); \
 	fi
 	@echo "Orbit Cockpit ready at bin/$(COCKPIT_NAME).app"
+
+.PHONY: native/dist
+native/dist: native/build ## Verify bundle integrity
+	codesign -vvv --deep --strict bin/$(COCKPIT_NAME).app
 
 native/test:
 	@echo "Running Swift tests..."

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,15 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	"gopkg.in/yaml.v3"
 )
+
+// AppGroupID is the shared container ID for sandboxed communication on macOS.
+// This matches the entitlement in native/OrbitCockpit.
+const AppGroupID = "com.github.hirakiuc.gh-orbit"
 
 // Config represents the application configuration.
 type Config struct {
@@ -275,8 +280,40 @@ func AuditPermissions(ctx context.Context, logger *slog.Logger, root string) err
 	})
 }
 
-// ResolveConfigPath returns the path to config.yml (XDG_CONFIG_HOME/gh/extensions/gh-orbit).
+// isSandboxed returns true if the process is running within a macOS App Sandbox.
+func isSandboxed() bool {
+	return os.Getenv("APP_SANDBOX_CONTAINER_ID") != ""
+}
+
+// resolveAppGroupDir returns the path to the shared App Group container on macOS.
+func resolveAppGroupDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	// Shared App Group container path
+	return filepath.Join(home, "Library/Group Containers", AppGroupID), nil
+}
+
+// resolveDarwinAppSupport returns the sandboxed Application Support path.
+func resolveDarwinAppSupport() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library/Application Support/gh-orbit"), nil
+}
+
+// ResolveConfigPath returns the path to config.yml.
 func ResolveConfigPath() (string, error) {
+	if runtime.GOOS == "darwin" && isSandboxed() {
+		dir, err := resolveDarwinAppSupport()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, "config.yml"), nil
+	}
+
 	dir, err := resolveXDG("XDG_CONFIG_HOME", ".config")
 	if err != nil {
 		return "", err
@@ -284,8 +321,12 @@ func ResolveConfigPath() (string, error) {
 	return filepath.Join(dir, "gh", "extensions", "gh-orbit", "config.yml"), nil
 }
 
-// ResolveDataDir returns the path to the data directory (XDG_DATA_HOME).
+// ResolveDataDir returns the path to the data directory.
 func ResolveDataDir() (string, error) {
+	if runtime.GOOS == "darwin" && isSandboxed() {
+		return resolveAppGroupDir()
+	}
+
 	dir, err := resolveXDG("XDG_DATA_HOME", ".local/share")
 	if err != nil {
 		return "", err
@@ -293,8 +334,12 @@ func ResolveDataDir() (string, error) {
 	return filepath.Join(dir, "gh-orbit"), nil
 }
 
-// ResolveStateDir returns the path to the state directory (XDG_STATE_HOME).
+// ResolveStateDir returns the path to the state directory.
 func ResolveStateDir() (string, error) {
+	if runtime.GOOS == "darwin" && isSandboxed() {
+		return resolveAppGroupDir()
+	}
+
 	dir, err := resolveXDG("XDG_STATE_HOME", ".local/state")
 	if err != nil {
 		return "", err
@@ -302,7 +347,7 @@ func ResolveStateDir() (string, error) {
 	return filepath.Join(dir, "gh-orbit"), nil
 }
 
-// ResolveTracePath returns the path to orbit.traces.json (XDG_STATE_HOME/gh-orbit/orbit.traces.json).
+// ResolveTracePath returns the path to orbit.traces.json.
 func ResolveTracePath() (string, error) {
 	dir, err := ResolveStateDir()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -196,4 +197,37 @@ func TestConfig_AuditPermissions(t *testing.T) {
 	fInfo, err := os.Stat(fPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o600), fInfo.Mode().Perm())
+}
+
+func TestResolvePaths_Sandbox(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Sandbox path resolution is only applicable on Darwin")
+	}
+
+	t.Run("Standard (XDG) Resolution", func(t *testing.T) {
+		t.Setenv("APP_SANDBOX_CONTAINER_ID", "")
+		t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg")
+
+		path, err := ResolveConfigPath()
+		require.NoError(t, err)
+		assert.Contains(t, path, "/tmp/xdg")
+	})
+
+	t.Run("Sandboxed Resolution", func(t *testing.T) {
+		t.Setenv("APP_SANDBOX_CONTAINER_ID", "com.github.hirakiuc.gh-orbit")
+
+		// In sandbox, ResolveStateDir and ResolveDataDir should point to Library/Group Containers
+		state, err := ResolveStateDir()
+		require.NoError(t, err)
+		assert.Contains(t, state, "Library/Group Containers/"+AppGroupID)
+
+		data, err := ResolveDataDir()
+		require.NoError(t, err)
+		assert.Contains(t, data, "Library/Group Containers/"+AppGroupID)
+
+		// Config should point to Library/Application Support
+		config, err := ResolveConfigPath()
+		require.NoError(t, err)
+		assert.Contains(t, config, "Library/Application Support/gh-orbit")
+	})
 }

--- a/native/OrbitCockpit/Helper.entitlements
+++ b/native/OrbitCockpit/Helper.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>$(TEAM_ID).group.com.github.hirakiuc.gh-orbit</string>
+    </array>
+</dict>
+</plist>

--- a/native/OrbitCockpit/OrbitCockpit.entitlements
+++ b/native/OrbitCockpit/OrbitCockpit.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>$(TEAM_ID).group.com.github.hirakiuc.gh-orbit</string>
+    </array>
+</dict>
+</plist>

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -10,6 +10,9 @@ class NativeEngineManager: ObservableObject {
     private let maxAttempts: Int
     private let baseDelayNS: UInt64
 
+    // App Group for shared communication within Sandbox
+    private let appGroupID = "com.github.hirakiuc.gh-orbit"
+
     init(socketPath: String? = nil, maxAttempts: Int = 10, baseDelayNS: UInt64 = 50_000_000) {
         self.maxAttempts = maxAttempts
         self.baseDelayNS = baseDelayNS
@@ -17,11 +20,16 @@ class NativeEngineManager: ObservableObject {
         if let socketPath = socketPath {
             self.socketPath = socketPath
         } else {
-            // Resolve socket path
-            let runtimeDir =
-                ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"]
-                ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/.local/run/gh-orbit")
-            self.socketPath = runtimeDir + "/engine.sock"
+            // Resolve socket path: prioritize shared App Group container for Sandbox compliance
+            if let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) {
+                self.socketPath = groupURL.appendingPathComponent("engine.sock").path
+            } else {
+                // Fallback for non-sandboxed dev mode
+                let runtimeDir =
+                    ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"]
+                    ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/.local/run/gh-orbit")
+                self.socketPath = runtimeDir + "/engine.sock"
+            }
         }
     }
 
@@ -46,7 +54,6 @@ class NativeEngineManager: ObservableObject {
     private func waitForSocket(path: String) async -> Bool {
         for attempt in 1...maxAttempts {
             if FileManager.default.fileExists(atPath: path) {
-                // Attempt to probe the socket
                 return true
             }
             // Exponential backoff

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -121,15 +121,8 @@ class TerminalManager: ObservableObject {
             adapter.isDarkMode(isDark)
 
             // 1. Resolve binary
-            let executableURL: URL
-            if let auxURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
-                executableURL = auxURL
-            } else {
-                executableURL = URL(fileURLWithPath: "bin/gh-orbit")
-            }
-
-            guard FileManager.default.fileExists(atPath: executableURL.path) else {
-                self.launchError = "gh-orbit binary not found at \(executableURL.path)"
+            guard let executableURL = PathResolver.resolveBinary() else {
+                self.launchError = "gh-orbit binary not found. Please ensure it's in your PATH or set GH_ORBIT_BIN."
                 return
             }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -137,8 +137,12 @@ class TerminalManager: ObservableObject {
 
             // Propagate environment including GH_TOKEN if available
             var env = ProcessInfo.processInfo.environment
-            // Ensure XDG_RUNTIME_DIR is set so TUI finds the same socket
-            if env["XDG_RUNTIME_DIR"] == nil {
+
+            // Prioritize App Group container for Sandbox IPC
+            let appGroupID = "com.github.hirakiuc.gh-orbit"
+            if let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) {
+                env["XDG_RUNTIME_DIR"] = groupURL.path
+            } else if env["XDG_RUNTIME_DIR"] == nil {
                 let home = FileManager.default.homeDirectoryForCurrentUser.path
                 env["XDG_RUNTIME_DIR"] = home + "/.local/run"
             }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -1,16 +1,31 @@
 import Foundation
 
+/// Protocol for file system operations to allow mocking.
+protocol FileSystem {
+    func fileExists(atPath: String) -> Bool
+    var currentDirectoryPath: String { get }
+}
+
+struct RealFileSystem: FileSystem {
+    func fileExists(atPath: String) -> Bool {
+        return FileManager.default.fileExists(atPath: atPath)
+    }
+    var currentDirectoryPath: String {
+        return FileManager.default.currentDirectoryPath
+    }
+}
+
 /// PathResolver handles the discovery of the gh-orbit binary across different environments.
 struct PathResolver {
-    static func resolveBinary() -> URL? {
-        let fileManager = FileManager.default
+    static func resolveBinary(
+        fileSystem: FileSystem = RealFileSystem(),
+        env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
 
         // 1. GH_ORBIT_BIN environment override
-        if let envPath = ProcessInfo.processInfo.environment["GH_ORBIT_BIN"],
-            !envPath.isEmpty
-        {
+        if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
             let url = URL(fileURLWithPath: envPath)
-            if fileManager.fileExists(atPath: url.path) {
+            if fileSystem.fileExists(atPath: url.path) {
                 return url
             }
         }
@@ -22,7 +37,7 @@ struct PathResolver {
 
         // 3. Project Root (Debug/Development only)
         #if DEBUG
-            if let devURL = resolveDevBinary() {
+            if let devURL = resolveDevBinary(fileSystem: fileSystem) {
                 return devURL
             }
         #endif
@@ -34,7 +49,7 @@ struct PathResolver {
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)
-            if fileManager.fileExists(atPath: url.path) {
+            if fileSystem.fileExists(atPath: url.path) {
                 return url
             }
         }
@@ -43,15 +58,14 @@ struct PathResolver {
     }
 
     #if DEBUG
-        private static func resolveDevBinary() -> URL? {
-            let fileManager = FileManager.default
-            let currentDir = fileManager.currentDirectoryPath
+        private static func resolveDevBinary(fileSystem: FileSystem) -> URL? {
+            let currentDir = fileSystem.currentDirectoryPath
             var searchURL = URL(fileURLWithPath: currentDir)
 
             // Walk up at most 5 levels to find project root (containing bin/gh-orbit)
             for _ in 0..<5 {
                 let binURL = searchURL.appendingPathComponent("bin/gh-orbit")
-                if fileManager.fileExists(atPath: binURL.path) {
+                if fileSystem.fileExists(atPath: binURL.path) {
                     return binURL
                 }
 
@@ -65,7 +79,7 @@ struct PathResolver {
                 }
 
                 // If we find markers but bin/gh-orbit wasn't there, stop anyway
-                if fileManager.fileExists(atPath: goModURL.path) || fileManager.fileExists(atPath: agentsURL.path) {
+                if fileSystem.fileExists(atPath: goModURL.path) || fileSystem.fileExists(atPath: agentsURL.path) {
                     break
                 }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -21,21 +21,22 @@ struct PathResolver {
         fileSystem: FileSystem = RealFileSystem(),
         env: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL? {
-
-        // 1. GH_ORBIT_BIN environment override
-        if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
-            let url = URL(fileURLWithPath: envPath)
-            if fileSystem.fileExists(atPath: url.path) {
-                return url
-            }
-        }
-
-        // 2. App Bundle (Production)
+        // 1. App Bundle (Production Highest Priority - Prevents Hijacking)
         if let bundleURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
             return bundleURL
         }
 
-        // 3. Project Root (Debug/Development only)
+        // 2. GH_ORBIT_BIN environment override (Debug/Development Only)
+        #if DEBUG
+            if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
+                let url = URL(fileURLWithPath: envPath)
+                if fileSystem.fileExists(atPath: url.path) {
+                    return url
+                }
+            }
+        #endif
+
+        // 3. Project Root (Debug/Development Only)
         #if DEBUG
             if let devURL = resolveDevBinary(fileSystem: fileSystem) {
                 return devURL

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// PathResolver handles the discovery of the gh-orbit binary across different environments.
+struct PathResolver {
+    static func resolveBinary() -> URL? {
+        let fileManager = FileManager.default
+
+        // 1. GH_ORBIT_BIN environment override
+        if let envPath = ProcessInfo.processInfo.environment["GH_ORBIT_BIN"],
+            !envPath.isEmpty
+        {
+            let url = URL(fileURLWithPath: envPath)
+            if fileManager.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        // 2. App Bundle (Production)
+        if let bundleURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
+            return bundleURL
+        }
+
+        // 3. Project Root (Debug/Development only)
+        #if DEBUG
+            if let devURL = resolveDevBinary() {
+                return devURL
+            }
+        #endif
+
+        // 4. Standard Absolute Fallbacks
+        let fallbacks = [
+            "/usr/local/bin/gh-orbit",
+            "/opt/homebrew/bin/gh-orbit",
+        ]
+        for path in fallbacks {
+            let url = URL(fileURLWithPath: path)
+            if fileManager.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    #if DEBUG
+        private static func resolveDevBinary() -> URL? {
+            let fileManager = FileManager.default
+            let currentDir = fileManager.currentDirectoryPath
+            var searchURL = URL(fileURLWithPath: currentDir)
+
+            // Walk up at most 5 levels to find project root (containing bin/gh-orbit)
+            for _ in 0..<5 {
+                let binURL = searchURL.appendingPathComponent("bin/gh-orbit")
+                if fileManager.fileExists(atPath: binURL.path) {
+                    return binURL
+                }
+
+                // Look for project sentinels
+                let goModURL = searchURL.appendingPathComponent("go.mod")
+                let agentsURL = searchURL.appendingPathComponent("AGENTS.md")
+
+                // Stop if we hit user home or root or find project markers
+                if searchURL.path == "/" || searchURL.path == "/Users" {
+                    break
+                }
+
+                // If we find markers but bin/gh-orbit wasn't there, stop anyway
+                if fileManager.fileExists(atPath: goModURL.path) || fileManager.fileExists(atPath: agentsURL.path) {
+                    break
+                }
+
+                searchURL.deleteLastPathComponent()
+            }
+
+            return nil
+        }
+    #endif
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -3,6 +3,18 @@ import Testing
 
 @testable import OrbitCockpit
 
+struct MockFileSystem: FileSystem {
+    var exists: Set<String> = []
+    var currentPath: String = "/test/project"
+
+    func fileExists(atPath: String) -> Bool {
+        return exists.contains(atPath)
+    }
+    var currentDirectoryPath: String {
+        return currentPath
+    }
+}
+
 @Suite("Process Lifecycle Tests")
 @MainActor
 struct LifecycleTests {
@@ -49,11 +61,44 @@ struct LifecycleTests {
         #expect(duration > 0.05)
     }
 
-    @Test("PathResolver binary discovery")
-    func testResolveBinary() async throws {
-        let url = PathResolver.resolveBinary()
-        if let binURL = url {
-            #expect(binURL.path.contains("gh-orbit"))
-        }
+    @Test("PathResolver binary discovery logic")
+    func testPathResolver() async throws {
+        // 1. Test Environment Override
+        var fileSystem = MockFileSystem()
+        fileSystem.exists.insert("/custom/bin/gh-orbit")
+        let env = ["GH_ORBIT_BIN": "/custom/bin/gh-orbit"]
+
+        let url1 = PathResolver.resolveBinary(fileSystem: fileSystem, env: env)
+        #expect(url1?.path == "/custom/bin/gh-orbit")
+
+        // 2. Test Project Root Discovery (at depth 0)
+        var fileSystem2 = MockFileSystem()
+        fileSystem2.currentPath = "/Users/dev/orbit"
+        fileSystem2.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url2 = PathResolver.resolveBinary(fileSystem: fileSystem2, env: [:])
+        #expect(url2?.path == "/Users/dev/orbit/bin/gh-orbit")
+
+        // 3. Test Project Root Discovery (walking up 2 levels)
+        var fileSystem3 = MockFileSystem()
+        fileSystem3.currentPath = "/Users/dev/orbit/internal/engine"
+        fileSystem3.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url3 = PathResolver.resolveBinary(fileSystem: fileSystem3, env: [:])
+        #expect(url3?.path == "/Users/dev/orbit/bin/gh-orbit")
+
+        // 4. Test Search Limit (6 levels deep should fail)
+        var fileSystem4 = MockFileSystem()
+        fileSystem4.currentPath = "/Users/dev/orbit/1/2/3/4/5/6"
+        fileSystem4.exists.insert("/Users/dev/orbit/bin/gh-orbit")
+        let url4 = PathResolver.resolveBinary(fileSystem: fileSystem4, env: [:])
+        #expect(url4 == nil)
+
+        // 5. Test Sentinel Stop (stops at go.mod even if binary is higher)
+        var fileSystem5 = MockFileSystem()
+        fileSystem5.currentPath = "/Users/dev/orbit/subdir"
+        fileSystem5.exists.insert("/Users/dev/bin/gh-orbit")  // binary is higher up
+        fileSystem5.exists.insert("/Users/dev/orbit/go.mod")  // but project root is here
+        let url5 = PathResolver.resolveBinary(fileSystem: fileSystem5, env: [:])
+        #expect(url5 == nil)  // Should not find the binary because search stops at go.mod
     }
+
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -49,4 +49,11 @@ struct LifecycleTests {
         #expect(duration > 0.05)
     }
 
+    @Test("PathResolver binary discovery")
+    func testResolveBinary() async throws {
+        let url = PathResolver.resolveBinary()
+        if let binURL = url {
+            #expect(binURL.path.contains("gh-orbit"))
+        }
+    }
 }


### PR DESCRIPTION
## Description
This PR implements Phase 1 of the self-contained macOS bundle strategy approved in RFC #230. It focuses on sandbox compliance, refined path resolution, and secure build orchestration.

## Key Changes
- **Sandbox-Aware Paths**: 
    - Implemented `isSandboxed()` and `resolveAppGroupDir()` in Go to redirect state/data to shared App Group containers when running under the macOS Sandbox.
    - Updated `NativeEngineManager` (Swift) to use App Group containers for UDS communication, bypassing the 104-character path limit.
- **Robust Binary Resolution**: Refactored `PathResolver` to prioritize the internal bundle URL (`Contents/Helpers/gh-orbit`) in production while maintaining a 5-level bounded walk-up for development.
- **Inside-Out Signing**: 
    - Created host and helper entitlements.
    - Updated `Makefile` to build, bundle, and sign components in the correct security order (Helper first, then host App).
- **Automated Verification**: Added rigorous unit tests in `LifecycleTests.swift` and `config_test.go` to verify path resolution tiers and sandbox redirection.

## Fixes
Resolves #228, #230

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>