### PR TITLE
fix: align bundle identifiers and harden binary resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ native/build: go/build
 	# 4. Inside-out Signing (Helper first, then App)
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		echo "Signing Cockpit bundle components (inside-out)..."; \
-		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/Helper.entitlements -i com.github.hirakiuc.gh-orbit.helper bin/$(COCKPIT_NAME).app/Contents/Helpers/$(BINARY_NAME); \
-		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/OrbitCockpit.entitlements -i com.github.hirakiuc.gh-orbit bin/$(COCKPIT_NAME).app/Contents/MacOS/$(COCKPIT_NAME); \
+		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/Helper.entitlements -i com.hirakiuc.gh-orbit.cockpit.helper bin/$(COCKPIT_NAME).app/Contents/Helpers/$(BINARY_NAME); \
+		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/OrbitCockpit.entitlements -i com.hirakiuc.gh-orbit.cockpit bin/$(COCKPIT_NAME).app/Contents/MacOS/$(COCKPIT_NAME); \
 	fi
 	@echo "Orbit Cockpit ready at bin/$(COCKPIT_NAME).app"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 
 // AppGroupID is the shared container ID for sandboxed communication on macOS.
 // This matches the entitlement in native/OrbitCockpit.
-const AppGroupID = "com.github.hirakiuc.gh-orbit"
+const AppGroupID = "com.hirakiuc.gh-orbit.cockpit"
 
 // Config represents the application configuration.
 type Config struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,7 +214,7 @@ func TestResolvePaths_Sandbox(t *testing.T) {
 	})
 
 	t.Run("Sandboxed Resolution", func(t *testing.T) {
-		t.Setenv("APP_SANDBOX_CONTAINER_ID", "com.github.hirakiuc.gh-orbit")
+		t.Setenv("APP_SANDBOX_CONTAINER_ID", "com.hirakiuc.gh-orbit.cockpit")
 
 		// In sandbox, ResolveStateDir and ResolveDataDir should point to Library/Group Containers
 		state, err := ResolveStateDir()

--- a/native/OrbitCockpit/Helper.entitlements
+++ b/native/OrbitCockpit/Helper.entitlements
@@ -8,7 +8,7 @@
     <true/>
     <key>com.apple.security.application-groups</key>
     <array>
-        <string>$(TEAM_ID).group.com.github.hirakiuc.gh-orbit</string>
+        <string>$(TEAM_ID).group.com.hirakiuc.gh-orbit.cockpit</string>
     </array>
 </dict>
 </plist>

--- a/native/OrbitCockpit/OrbitCockpit.entitlements
+++ b/native/OrbitCockpit/OrbitCockpit.entitlements
@@ -8,7 +8,7 @@
     <true/>
     <key>com.apple.security.application-groups</key>
     <array>
-        <string>$(TEAM_ID).group.com.github.hirakiuc.gh-orbit</string>
+        <string>$(TEAM_ID).group.com.hirakiuc.gh-orbit.cockpit</string>
     </array>
 </dict>
 </plist>

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -11,7 +11,7 @@ class NativeEngineManager: ObservableObject {
     private let baseDelayNS: UInt64
 
     // App Group for shared communication within Sandbox
-    private let appGroupID = "com.github.hirakiuc.gh-orbit"
+    private let appGroupID = "com.hirakiuc.gh-orbit.cockpit"
 
     init(socketPath: String? = nil, maxAttempts: Int = 10, baseDelayNS: UInt64 = 50_000_000) {
         self.maxAttempts = maxAttempts

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -139,7 +139,7 @@ class TerminalManager: ObservableObject {
             var env = ProcessInfo.processInfo.environment
 
             // Prioritize App Group container for Sandbox IPC
-            let appGroupID = "com.github.hirakiuc.gh-orbit"
+            let appGroupID = "com.hirakiuc.gh-orbit.cockpit"
             if let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) {
                 env["XDG_RUNTIME_DIR"] = groupURL.path
             } else if env["XDG_RUNTIME_DIR"] == nil {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -21,12 +21,27 @@ struct PathResolver {
         fileSystem: FileSystem = RealFileSystem(),
         env: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL? {
+
         // 1. App Bundle (Production Highest Priority - Prevents Hijacking)
+        // Standard API lookup
         if let bundleURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
             return bundleURL
         }
 
-        // 2. GH_ORBIT_BIN environment override (Debug/Development Only)
+        // 2. Manual Bundle Lookup Fallback (Defensive)
+        // If we are running from a bundle but standard API fails, look relative to executable
+        if let executableURL = Bundle.main.executableURL {
+            let helpersURL =
+                executableURL
+                .deletingLastPathComponent()  // MacOS
+                .deletingLastPathComponent()  // Contents
+                .appendingPathComponent("Helpers/gh-orbit")
+            if fileSystem.fileExists(atPath: helpersURL.path) {
+                return helpersURL
+            }
+        }
+
+        // 3. GH_ORBIT_BIN environment override (Debug/Development Only)
         #if DEBUG
             if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
                 let url = URL(fileURLWithPath: envPath)
@@ -36,14 +51,14 @@ struct PathResolver {
             }
         #endif
 
-        // 3. Project Root (Debug/Development Only)
+        // 4. Project Root (Debug/Development Only)
         #if DEBUG
             if let devURL = resolveDevBinary(fileSystem: fileSystem) {
                 return devURL
             }
         #endif
 
-        // 4. Standard Absolute Fallbacks
+        // 5. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
             "/opt/homebrew/bin/gh-orbit",


### PR DESCRIPTION
## Description
This PR standardizes the bundle and App Group identifiers across the entire project and hardens the binary resolution logic to ensure stable behavior in ad-hoc signed macOS bundles.

## Key Changes
- **Standardized Identifier**: 
    - Standardized on `com.hirakiuc.gh-orbit.cockpit` across Go constants, Swift code, Entitlements, and Makefile.
    - Updated `internal/config/config_test.go` mocks to match the new ID.
- **Hardened Path Discovery**:
    - Added a manual defensive fallback to `PathResolver.swift` that looks for `../../Helpers/gh-orbit` relative to the app's executable.
    - This ensures discovery even if `Bundle.main.url(forAuxiliaryExecutable:)` fails in ad-hoc builds.
- **Security**: 
    - Aligned signing identifiers in `Makefile` to `com.hirakiuc.gh-orbit.cockpit` (host) and `com.hirakiuc.gh-orbit.cockpit.helper` (engine).

## Fixes
Resolves #232

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>