### PR TITLE
fix: ensure real-time log propagation in native app

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
@@ -1,26 +1,52 @@
+import AppKit
 import SwiftUI
 
 struct LogConsoleView: View {
     let logs: String
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(logs)
-                        .font(.system(.caption, design: .monospaced))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(8)
-                        .id("bottom")
+        ZStack(alignment: .topTrailing) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if logs.isEmpty {
+                            Text("Initializing log stream...")
+                                .foregroundColor(.secondary)
+                                .italic()
+                        } else {
+                            Text(logs)
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        Color.clear.frame(height: 1).id("bottom")
+                    }
+                    .padding(8)
                 }
-            }
-            .background(Color(NSColor.textBackgroundColor))
-            .onChange(of: logs) { _, _ in
-                // Auto-scroll to bottom on update
-                withAnimation {
+                .background(Color(NSColor.textBackgroundColor))
+                .onChange(of: logs) { _, _ in
+                    // Auto-scroll to bottom on update
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
+
+            // Overlay Controls
+            HStack {
+                Button(action: copyToClipboard) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.plain)
+                .padding(4)
+                .background(Color.secondary.opacity(0.2))
+                .cornerRadius(4)
+                .help("Copy logs to clipboard")
+            }
+            .padding(8)
         }
+    }
+
+    private func copyToClipboard() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(logs, forType: .string)
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -39,9 +39,13 @@ class NativeEngineManager: ObservableObject {
             }
         }
 
-        // Bind logs from supervisor to our published property
+        // Bind logs from supervisor to our published property using explicit sink
+        // to ensure MainActor safety and prevent reference cycles.
         engineSupervisor.$fullLog
-            .assign(to: \.engineLog, on: self)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] logs in
+                self?.engineLog = logs
+            }
             .store(in: &cancellables)
     }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
@@ -90,11 +90,17 @@ class ProcessSupervisor: ObservableObject {
     }
 
     private func appendLog(_ line: String) {
+        let isFirstLog = logBuffer.isEmpty
         logBuffer.append(line)
         if logBuffer.count > maxLogLines {
             logBuffer.removeFirst()
         }
-        pendingLogs = true
+
+        if isFirstLog {
+            publishLogs()
+        } else {
+            pendingLogs = true
+        }
     }
 
     private func startLogTimer() {

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -118,4 +118,28 @@ struct LifecycleTests {
         #expect(supervisor.fullLog.contains("hello-world"))
         supervisor.stop()
     }
+
+    @Test("Manager log propagation")
+    func testManagerLogPropagation() async throws {
+        // Since we can't easily mock the internal supervisor in NativeEngineManager,
+        // we'll rely on the fact that NativeEngineManager starts an engine that prints to stderr.
+        // We'll use a fast-retry manager for testing.
+        let manager = NativeEngineManager(maxAttempts: 2, baseDelayNS: 10_000_000)
+
+        // We use a binary that just prints something to stderr
+        let bashURL = URL(fileURLWithPath: "/bin/bash")
+        await manager.startEngine(executable: bashURL)
+
+        // NativeEngineManager currently starts the process with "engine" argument
+        // bash -c "echo error >&2" would be better but startEngine signature is fixed.
+        // But even if bash fails (command not found), it prints to stderr.
+
+        for _ in 0..<20 {
+            if !manager.engineLog.isEmpty { break }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(!manager.engineLog.isEmpty)
+        manager.stopEngine()
+    }
 }


### PR DESCRIPTION
## Description
This PR fixes the empty debug console by hardening the log propagation chain from the `ProcessSupervisor` to the UI. It also improves the console's robustness and usability.

## Key Changes
- **"First Byte" Visibility**: Updated `ProcessSupervisor` to publish the first log entry immediately, bypassing the debouncer for instant startup feedback.
- **Robust Binding**: Refactored `NativeEngineManager` to use an explicit `sink` with `receive(on: RunLoop.main)`, ensuring thread-safe and reliable state updates.
- **UI Enhancements**:
    - Added an "Initializing..." placeholder for empty logs.
    - Implemented a **Copy to Clipboard** button in the `LogConsoleView`.
- **Automated Verification**: Added `testManagerLogPropagation` to verify the multi-hop log pipeline.

## Fixes
Resolves #236

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>