### PR TITLE
fix: resolve nested state propagation and enhance TUI crash observability

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 @main
@@ -134,6 +135,15 @@ class TerminalManager: ObservableObject {
     @Published var launchError: String?
 
     private var isDark: Bool = true
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        engineManager.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
 
     func updateTheme(isDark: Bool) {
         self.isDark = isDark

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -58,10 +58,10 @@ struct PathResolver {
             }
         #endif
 
-        // 5. Standard Absolute Fallbacks
+        // 4. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit",
+            "/opt/homebrew/bin/gh-orbit"
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -69,7 +69,10 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     func processTerminated(source: TerminalView, exitCode: Int32?) {
-        // Implementation
+        let code = exitCode ?? -1
+        let message = "\r\n\r\n[Process terminated with exit code \(code)]\r\n"
+        let bytes = [UInt8](message.utf8)
+        source.feed(byteArray: bytes[...])
     }
 
     func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 
@@ -22,5 +23,24 @@ struct TerminalManagerTests {
         manager.engines["TUI"] = mockEngine
         let stored = try #require(manager.engines["TUI"])
         #expect(stored === mockEngine)
+    }
+
+    @Test("Nested State Propagation")
+    @MainActor
+    func testNestedStatePropagation() async throws {
+        let manager = TerminalManager()
+        var didFire = false
+
+        let cancellable = manager.objectWillChange.sink { _ in
+            didFire = true
+        }
+
+        manager.engineManager.engineLog = "Test log entry"
+
+        // Yield to allow Combine to process the event
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(didFire)
+        cancellable.cancel()
     }
 }


### PR DESCRIPTION
## Description
This PR resolves two distinct observability gaps in the native app: the SwiftUI Log Console remaining stuck on "Initializing...", and the SwiftTerm view silently hanging on TUI crashes.

## Key Changes
- **Nested State Propagation**: 
    - `TerminalManager` now explicitly subscribes to its nested `NativeEngineManager`'s `objectWillChange` publisher.
    - The subscription (`AnyCancellable`) is stored securely to prevent premature deallocation.
    - Added `testNestedStatePropagation` to `TerminalManagerTests.swift` to protect this reactive chain against regressions.
- **TUI Crash Diagnostics**:
    - Implemented `LocalProcessTerminalViewDelegate.processTerminated` in `SwiftTermAdapter`.
    - If the TUI subprocess unexpectedly dies, the terminal window will inject `[Process terminated with exit code X]` into the screen buffer.

## Fixes
Resolves #238

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>