### PR TITLE
feat: implement unified Activity Monitor for native app

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/ActivityMonitor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ActivityMonitor.swift
@@ -1,0 +1,65 @@
+import Combine
+import Foundation
+
+/// ActivityMonitor serves as the centralized log aggregator and publisher for the native app.
+/// It debounces high-volume updates to protect SwiftUI rendering performance.
+@MainActor
+class ActivityMonitor: ObservableObject {
+    /// The aggregated log stream for UI display.
+    @Published var fullLog: String = ""
+
+    /// Bounded buffer for logs (approx 5MB)
+    private var logBuffer: [String] = []
+    private let maxLogLines = 5000
+
+    // Performance: Debounce UI updates
+    private var pendingLogs: Bool = false
+    private var logTimer: Timer?
+
+    init() {
+        startLogTimer()
+    }
+
+    // Timer is managed by the actor's lifecycle.
+    // In SwiftUI, an @StateObject's lifecycle is tied to the view.
+
+    /// Appends a new log line with the specified component prefix.
+    /// - Parameters:
+    ///   - component: The source of the log (e.g., "[App]", "[Engine]").
+    ///   - message: The log content.
+    func log(component: String, message: String) {
+        let isFirstLog = logBuffer.isEmpty
+        let formattedLine = "\(component) \(message)"
+
+        logBuffer.append(formattedLine)
+        if logBuffer.count > maxLogLines {
+            logBuffer.removeFirst()
+        }
+
+        if isFirstLog {
+            publishLogs()
+        } else {
+            pendingLogs = true
+        }
+    }
+
+    private func startLogTimer() {
+        logTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                if self?.pendingLogs == true {
+                    self?.publishLogs()
+                }
+            }
+        }
+    }
+
+    private func publishLogs() {
+        fullLog = logBuffer.joined(separator: "\n")
+        pendingLogs = false
+    }
+
+    /// Synchronously returns the current log buffer content.
+    func getLogs() -> String {
+        return logBuffer.joined(separator: "\n")
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
@@ -1,26 +1,52 @@
+import AppKit
 import SwiftUI
 
 struct LogConsoleView: View {
     let logs: String
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(logs)
-                        .font(.system(.caption, design: .monospaced))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(8)
-                        .id("bottom")
+        ZStack(alignment: .topTrailing) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if logs.isEmpty {
+                            Text("Initializing log stream...")
+                                .foregroundColor(.secondary)
+                                .italic()
+                        } else {
+                            Text(logs)
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        Color.clear.frame(height: 1).id("bottom")
+                    }
+                    .padding(8)
                 }
-            }
-            .background(Color(NSColor.textBackgroundColor))
-            .onChange(of: logs) { _, _ in
-                // Auto-scroll to bottom on update
-                withAnimation {
+                .background(Color(NSColor.textBackgroundColor))
+                .onChange(of: logs) { _, _ in
+                    // Auto-scroll to bottom on update
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
+
+            // Overlay Controls
+            HStack {
+                Button(action: copyToClipboard) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.plain)
+                .padding(4)
+                .background(Color.secondary.opacity(0.2))
+                .cornerRadius(4)
+                .help("Copy logs to clipboard")
+            }
+            .padding(8)
         }
+    }
+
+    private func copyToClipboard() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(logs, forType: .string)
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -39,9 +39,13 @@ class NativeEngineManager: ObservableObject {
             }
         }
 
-        // Bind logs from supervisor to our published property
+        // Bind logs from supervisor to our published property using explicit sink
+        // to ensure MainActor safety and prevent reference cycles.
         engineSupervisor.$fullLog
-            .assign(to: \.engineLog, on: self)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] logs in
+                self?.engineLog = logs
+            }
             .store(in: &cancellables)
     }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -6,9 +6,6 @@ import Foundation
 class NativeEngineManager: ObservableObject {
     @Published var isEngineReady: Bool = false
 
-    /// The log stream from the underlying engine process.
-    @Published var engineLog: String = ""
-
     private var engineSupervisor = ProcessSupervisor()
     private var socketPath: String
 
@@ -18,9 +15,12 @@ class NativeEngineManager: ObservableObject {
     // App Group for shared communication within Sandbox
     private let appGroupID = "com.hirakiuc.gh-orbit.cockpit"
 
-    private var cancellables = Set<AnyCancellable>()
-
-    init(socketPath: String? = nil, maxAttempts: Int = 10, baseDelayNS: UInt64 = 50_000_000) {
+    init(
+        socketPath: String? = nil,
+        maxAttempts: Int = 10,
+        baseDelayNS: UInt64 = 50_000_000,
+        onLog: ((String) -> Void)? = nil
+    ) {
         self.maxAttempts = maxAttempts
         self.baseDelayNS = baseDelayNS
 
@@ -39,14 +39,10 @@ class NativeEngineManager: ObservableObject {
             }
         }
 
-        // Bind logs from supervisor to our published property using explicit sink
-        // to ensure MainActor safety and prevent reference cycles.
-        engineSupervisor.$fullLog
-            .receive(on: RunLoop.main)
-            .sink { [weak self] logs in
-                self?.engineLog = logs
-            }
-            .store(in: &cancellables)
+        // Set the supervisor's logging closure
+        engineSupervisor.onLog = { message in
+            onLog?(message)
+        }
     }
 
     func startEngine(executable: URL) async {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 @main
@@ -134,6 +135,15 @@ class TerminalManager: ObservableObject {
     @Published var launchError: String?
 
     private var isDark: Bool = true
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        engineManager.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
 
     func updateTheme(isDark: Bool) {
         self.isDark = isDark

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -4,9 +4,19 @@ import SwiftUI
 @main
 @MainActor
 struct OrbitCockpitApp: App {
+    @StateObject private var activityMonitor = ActivityMonitor()
+
+    init() {
+        // App Lifecycle Logging (Safe: No environment variables exposed)
+        let monitor = ActivityMonitor()
+        monitor.log(component: "[App]", message: "Launched Orbit Cockpit")
+        _activityMonitor = StateObject(wrappedValue: monitor)
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(activityMonitor)
         }
     }
 }
@@ -16,6 +26,7 @@ struct ContentView: View {
     @State private var selectedPane: String? = "TUI"
     @State private var showDebugLogs: Bool = false
     @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var activityMonitor: ActivityMonitor
 
     // In a real app, these would be managed in a ViewModel/Store
     @StateObject private var terminalManager = TerminalManager()
@@ -37,7 +48,7 @@ struct ContentView: View {
 
                 if showDebugLogs {
                     Divider()
-                    LogConsoleView(logs: terminalManager.engineManager.engineLog)
+                    LogConsoleView(logs: activityMonitor.fullLog)
                         .frame(height: 200)
                 }
             }
@@ -48,7 +59,7 @@ struct ContentView: View {
                     Label("Debug Logs", systemImage: "ladybug")
                         .foregroundColor(showDebugLogs ? .accentColor : .secondary)
                 }
-                .help("Toggle Engine Debug Logs")
+                .help("Toggle Activity Monitor")
             }
         }
         .onChange(of: colorScheme) { _, newValue in
@@ -56,6 +67,8 @@ struct ContentView: View {
         }
         .onAppear {
             terminalManager.updateTheme(isDark: colorScheme == .dark)
+            // Inject the monitor into the manager
+            terminalManager.setMonitor(activityMonitor)
         }
     }
 }
@@ -72,7 +85,7 @@ struct Sidebar: View {
                     Label("TUI", systemImage: "terminal")
                     Spacer()
                     Circle()
-                        .fill(terminalManager.engineManager.isEngineReady ? Color.green : Color.yellow)
+                        .fill(terminalManager.engineManager?.isEngineReady == true ? Color.green : Color.yellow)
                         .frame(width: 8, height: 8)
                 }
                 .tag("TUI")
@@ -131,18 +144,28 @@ struct TerminalHostView: View {
 @MainActor
 class TerminalManager: ObservableObject {
     @Published var engines: [String: OrbitTerminalEngine] = [:]
-    @Published var engineManager = NativeEngineManager()
+    @Published var engineManager: NativeEngineManager?
     @Published var launchError: String?
 
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
 
-    init() {
-        engineManager.objectWillChange
+    init() {}
+
+    func setMonitor(_ monitor: ActivityMonitor) {
+        guard engineManager == nil else { return }
+
+        let newManager = NativeEngineManager(onLog: { msg in
+            monitor.log(component: "[Engine]", message: msg)
+        })
+
+        newManager.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+
+        self.engineManager = newManager
     }
 
     func updateTheme(isDark: Bool) {
@@ -164,7 +187,9 @@ class TerminalManager: ObservableObject {
             }
 
             // 2. Ensure Engine is running
-            await engineManager.startEngine(executable: executableURL)
+            if let engineMgr = engineManager {
+                await engineMgr.startEngine(executable: executableURL)
+            }
 
             // 3. Launch TUI
             var args: [String] = []

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -58,10 +58,10 @@ struct PathResolver {
             }
         #endif
 
-        // 5. Standard Absolute Fallbacks
+        // 4. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit",
+            "/opt/homebrew/bin/gh-orbit"
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -61,7 +61,7 @@ struct PathResolver {
         // 4. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit"
+            "/opt/homebrew/bin/gh-orbit",
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
@@ -90,11 +90,17 @@ class ProcessSupervisor: ObservableObject {
     }
 
     private func appendLog(_ line: String) {
+        let isFirstLog = logBuffer.isEmpty
         logBuffer.append(line)
         if logBuffer.count > maxLogLines {
             logBuffer.removeFirst()
         }
-        pendingLogs = true
+
+        if isFirstLog {
+            publishLogs()
+        } else {
+            pendingLogs = true
+        }
     }
 
     private func startLogTimer() {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// ProcessSupervisor handles the lifecycle and observability of a subprocess.
@@ -8,20 +7,12 @@ class ProcessSupervisor: ObservableObject {
     @Published var exitCode: Int32?
     @Published var lastError: String?
 
-    /// The aggregated log stream for UI display, updated via debounced mechanism.
-    @Published var fullLog: String = ""
-
     private var process: Process?
     private let outputPipe = Pipe()
     private let errorPipe = Pipe()
 
-    /// Bounded buffer for logs (approx 5MB)
-    private var logBuffer: [String] = []
-    private let maxLogLines = 5000
-
-    // Performance: Debounce UI updates during high-volume logs
-    private var pendingLogs: Bool = false
-    private var logTimer: Timer?
+    /// Closure to push logs to a central monitor.
+    var onLog: ((String) -> Void)?
 
     func start(executable: URL, arguments: [String], environment: [String: String]?) throws {
         let process = Process()
@@ -48,7 +39,7 @@ class ProcessSupervisor: ObservableObject {
             guard !data.isEmpty else { return }
             if let line = String(data: data, encoding: .utf8) {
                 DispatchQueue.main.async {
-                    self?.appendLog(line)
+                    self?.onLog?(line)
                     self?.lastError = line
                 }
             }
@@ -60,7 +51,7 @@ class ProcessSupervisor: ObservableObject {
             guard !data.isEmpty else { return }
             if let line = String(data: data, encoding: .utf8) {
                 DispatchQueue.main.async {
-                    self?.appendLog(line)
+                    self?.onLog?(line)
                 }
             }
         }
@@ -71,54 +62,15 @@ class ProcessSupervisor: ObservableObject {
                 self?.exitCode = process.terminationStatus
                 self?.errorPipe.fileHandleForReading.readabilityHandler = nil
                 self?.outputPipe.fileHandleForReading.readabilityHandler = nil
-                self?.publishLogs()  // Final sync
             }
         }
 
         try process.run()
         self.process = process
         self.isRunning = true
-
-        // Start debouncer
-        startLogTimer()
     }
 
     func stop() {
         process?.terminate()
-        logTimer?.invalidate()
-        logTimer = nil
-    }
-
-    private func appendLog(_ line: String) {
-        let isFirstLog = logBuffer.isEmpty
-        logBuffer.append(line)
-        if logBuffer.count > maxLogLines {
-            logBuffer.removeFirst()
-        }
-
-        if isFirstLog {
-            publishLogs()
-        } else {
-            pendingLogs = true
-        }
-    }
-
-    private func startLogTimer() {
-        logTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                if self?.pendingLogs == true {
-                    self?.publishLogs()
-                }
-            }
-        }
-    }
-
-    private func publishLogs() {
-        fullLog = logBuffer.joined()
-        pendingLogs = false
-    }
-
-    func getLogs() -> String {
-        return logBuffer.joined()
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -69,7 +69,10 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     func processTerminated(source: TerminalView, exitCode: Int32?) {
-        // Implementation
+        let code = exitCode ?? -1
+        let message = "\r\n\r\n[Process terminated with exit code \(code)]\r\n"
+        let bytes = [UInt8](message.utf8)
+        source.feed(byteArray: bytes[...])
     }
 
     func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -118,4 +118,28 @@ struct LifecycleTests {
         #expect(supervisor.fullLog.contains("hello-world"))
         supervisor.stop()
     }
+
+    @Test("Manager log propagation")
+    func testManagerLogPropagation() async throws {
+        // Since we can't easily mock the internal supervisor in NativeEngineManager,
+        // we'll rely on the fact that NativeEngineManager starts an engine that prints to stderr.
+        // We'll use a fast-retry manager for testing.
+        let manager = NativeEngineManager(maxAttempts: 2, baseDelayNS: 10_000_000)
+
+        // We use a binary that just prints something to stderr
+        let bashURL = URL(fileURLWithPath: "/bin/bash")
+        await manager.startEngine(executable: bashURL)
+
+        // NativeEngineManager currently starts the process with "engine" argument
+        // bash -c "echo error >&2" would be better but startEngine signature is fixed.
+        // But even if bash fails (command not found), it prints to stderr.
+
+        for _ in 0..<20 {
+            if !manager.engineLog.isEmpty { break }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(!manager.engineLog.isEmpty)
+        manager.stopEngine()
+    }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -101,45 +101,33 @@ struct LifecycleTests {
         #expect(url5 == nil)  // Should not find the binary because search stops at go.mod
     }
 
-    @Test("ProcessSupervisor log publication")
-    func testLogPublication() async throws {
-        let supervisor = ProcessSupervisor()
+    @Test("ActivityMonitor aggregation and debouncing")
+    func testActivityMonitor() async throws {
+        let monitor = ActivityMonitor()
 
-        // Use /bin/echo to generate output
-        let echoURL = URL(fileURLWithPath: "/bin/echo")
-        try supervisor.start(executable: echoURL, arguments: ["hello-world"], environment: nil)
+        #expect(monitor.fullLog.isEmpty)
 
-        // Wait for process and debouncer (0.1s interval)
+        monitor.log(component: "[App]", message: "Launch started")
+
+        // Wait for debouncer (0.1s interval)
         for _ in 0..<20 {
-            if !supervisor.fullLog.isEmpty { break }
+            if !monitor.fullLog.isEmpty { break }
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 
-        #expect(supervisor.fullLog.contains("hello-world"))
-        supervisor.stop()
-    }
+        #expect(monitor.fullLog.contains("[App] Launch started"))
 
-    @Test("Manager log propagation")
-    func testManagerLogPropagation() async throws {
-        // Since we can't easily mock the internal supervisor in NativeEngineManager,
-        // we'll rely on the fact that NativeEngineManager starts an engine that prints to stderr.
-        // We'll use a fast-retry manager for testing.
-        let manager = NativeEngineManager(maxAttempts: 2, baseDelayNS: 10_000_000)
+        // Test multi-source aggregation
+        monitor.log(component: "[Engine]", message: "Engine started")
 
-        // We use a binary that just prints something to stderr
-        let bashURL = URL(fileURLWithPath: "/bin/bash")
-        await manager.startEngine(executable: bashURL)
-
-        // NativeEngineManager currently starts the process with "engine" argument
-        // bash -c "echo error >&2" would be better but startEngine signature is fixed.
-        // But even if bash fails (command not found), it prints to stderr.
-
+        // Wait for debouncer again
         for _ in 0..<20 {
-            if !manager.engineLog.isEmpty { break }
+            if monitor.fullLog.contains("[Engine]") { break }
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 
-        #expect(!manager.engineLog.isEmpty)
-        manager.stopEngine()
+        let logs = monitor.getLogs()
+        #expect(logs.contains("[App] Launch started"))
+        #expect(logs.contains("[Engine] Engine started"))
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -29,13 +29,16 @@ struct TerminalManagerTests {
     @MainActor
     func testNestedStatePropagation() async throws {
         let manager = TerminalManager()
+        let monitor = ActivityMonitor()
+        manager.setMonitor(monitor)
+
         var didFire = false
 
         let cancellable = manager.objectWillChange.sink { _ in
             didFire = true
         }
 
-        manager.engineManager.engineLog = "Test log entry"
+        manager.engineManager?.isEngineReady = true
 
         // Yield to allow Combine to process the event
         try await Task.sleep(nanoseconds: 10_000_000)

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 
@@ -22,5 +23,24 @@ struct TerminalManagerTests {
         manager.engines["TUI"] = mockEngine
         let stored = try #require(manager.engines["TUI"])
         #expect(stored === mockEngine)
+    }
+
+    @Test("Nested State Propagation")
+    @MainActor
+    func testNestedStatePropagation() async throws {
+        let manager = TerminalManager()
+        var didFire = false
+
+        let cancellable = manager.objectWillChange.sink { _ in
+            didFire = true
+        }
+
+        manager.engineManager.engineLog = "Test log entry"
+
+        // Yield to allow Combine to process the event
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(didFire)
+        cancellable.cancel()
     }
 }


### PR DESCRIPTION
## Description
This PR transitions the native app's observability pipeline from brittle nested `@Published` chains to a robust, centralized `ActivityMonitor`. It provides a holistic, chronological view of the app's entire lifecycle.

## Key Changes
- **Centralized Sink**: Created `ActivityMonitor` as a single `ObservableObject` that manages a 5000-line bounded buffer and handles debounced UI updates.
- **Dependency Injection**: Refactored `ProcessSupervisor` and `NativeEngineManager` to accept logging closures instead of managing their own state. The monitor is instantiated at the app root and injected via the environment.
- **Contextual Prefixing**: Logs are now prefixed with their component source (e.g., `[App]`, `[Engine]`), making chronological debugging much easier.
- **Automated Verification**: Added `testActivityMonitor` to verify multi-source aggregation and debouncing logic.

## Fixes
Resolves #240

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>