### PR TITLE
fix: resolve UI race conditions and TUI initialization crashes

### DIFF
--- a/native/OrbitCockpit/Helper.entitlements
+++ b/native/OrbitCockpit/Helper.entitlements
@@ -6,9 +6,5 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>$(TEAM_ID).group.com.hirakiuc.gh-orbit.cockpit</string>
-    </array>
 </dict>
 </plist>

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -4,32 +4,32 @@ import SwiftUI
 @main
 @MainActor
 struct OrbitCockpitApp: App {
-    @StateObject private var activityMonitor = ActivityMonitor()
+    @StateObject private var activityMonitor: ActivityMonitor
+    @StateObject private var terminalManager: TerminalManager
 
     init() {
         // App Lifecycle Logging (Safe: No environment variables exposed)
         let monitor = ActivityMonitor()
         monitor.log(component: "[App]", message: "Launched Orbit Cockpit")
         _activityMonitor = StateObject(wrappedValue: monitor)
+        _terminalManager = StateObject(wrappedValue: TerminalManager(monitor: monitor))
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(activityMonitor)
+                .environmentObject(terminalManager)
         }
     }
 }
-
 @MainActor
 struct ContentView: View {
     @State private var selectedPane: String? = "TUI"
     @State private var showDebugLogs: Bool = false
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var activityMonitor: ActivityMonitor
-
-    // In a real app, these would be managed in a ViewModel/Store
-    @StateObject private var terminalManager = TerminalManager()
+    @EnvironmentObject var terminalManager: TerminalManager
 
     var body: some View {
         NavigationSplitView {
@@ -67,8 +67,6 @@ struct ContentView: View {
         }
         .onAppear {
             terminalManager.updateTheme(isDark: colorScheme == .dark)
-            // Inject the monitor into the manager
-            terminalManager.setMonitor(activityMonitor)
         }
     }
 }
@@ -150,11 +148,7 @@ class TerminalManager: ObservableObject {
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
 
-    init() {}
-
-    func setMonitor(_ monitor: ActivityMonitor) {
-        guard engineManager == nil else { return }
-
+    init(monitor: ActivityMonitor) {
         let newManager = NativeEngineManager(onLog: { msg in
             monitor.log(component: "[Engine]", message: msg)
         })

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -10,14 +10,16 @@ struct TerminalManagerTests {
     @Test("Manager initial state")
     @MainActor
     func testInitialization() async throws {
-        let manager = TerminalManager()
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
         #expect(manager.engines.isEmpty)
     }
 
     @Test("Engine mapping preservation")
     @MainActor
     func testEngineStorage() async throws {
-        let manager = TerminalManager()
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
         let mockEngine = SwiftTermAdapter()
 
         manager.engines["TUI"] = mockEngine
@@ -28,9 +30,8 @@ struct TerminalManagerTests {
     @Test("Nested State Propagation")
     @MainActor
     func testNestedStatePropagation() async throws {
-        let manager = TerminalManager()
         let monitor = ActivityMonitor()
-        manager.setMonitor(monitor)
+        let manager = TerminalManager(monitor: monitor)
 
         var didFire = false
 


### PR DESCRIPTION
## Description
This PR resolves critical race conditions during the SwiftUI initialization sequence that caused the TUI to fall back to standalone mode and crash with Exit Code 5. 

## Key Changes
- **Deterministic Initialization**: Instantiated `TerminalManager` and `ActivityMonitor` at the `OrbitCockpitApp` root, guaranteeing all dependencies are wired before any view renders.
- **Safe Injection**: Changed `TerminalManager` to require `ActivityMonitor` via `init()` rather than an unsafe `.onAppear` method call.
- **Sandbox Compliance**: Removed the extraneous `com.apple.security.application-groups` key from `Helper.entitlements` to align with strict macOS Sandbox inheritance rules, completely resolving the SIGTRAP (Exit Code 5) crash during `posix_spawn`.

## Fixes
Resolves #242

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>