### PR TITLE
fix: formalize app bundle signing and implement structured lifecycle logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ native/build: go/build
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		echo "Signing Cockpit bundle components (inside-out)..."; \
 		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/Helper.entitlements -i com.hirakiuc.gh-orbit.cockpit.helper bin/$(COCKPIT_NAME).app/Contents/Helpers/$(BINARY_NAME); \
-		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/OrbitCockpit.entitlements -i com.hirakiuc.gh-orbit.cockpit bin/$(COCKPIT_NAME).app/Contents/MacOS/$(COCKPIT_NAME); \
+		codesign -f -s - --options runtime --entitlements native/OrbitCockpit/OrbitCockpit.entitlements -i com.hirakiuc.gh-orbit.cockpit bin/$(COCKPIT_NAME).app; \
 	fi
 	@echo "Orbit Cockpit ready at bin/$(COCKPIT_NAME).app"
 

--- a/native/OrbitCockpit/Helper.entitlements
+++ b/native/OrbitCockpit/Helper.entitlements
@@ -6,9 +6,5 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>$(TEAM_ID).group.com.hirakiuc.gh-orbit.cockpit</string>
-    </array>
 </dict>
 </plist>

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ActivityMonitor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ActivityMonitor.swift
@@ -1,15 +1,36 @@
 import Combine
 import Foundation
+import SwiftUI
+
+public enum LogLevel: Int, Comparable {
+    case debug = 0
+    case info = 1
+    case warning = 2
+    case error = 3
+
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+}
+
+public struct LogEntry: Identifiable, Equatable {
+    // swiftlint:disable:next identifier_name
+    public let id = UUID()
+    public let timestamp: Date
+    public let component: String
+    public let level: LogLevel
+    public let message: String
+}
 
 /// ActivityMonitor serves as the centralized log aggregator and publisher for the native app.
 /// It debounces high-volume updates to protect SwiftUI rendering performance.
 @MainActor
 class ActivityMonitor: ObservableObject {
     /// The aggregated log stream for UI display.
-    @Published var fullLog: String = ""
+    @Published var logs: [LogEntry] = []
 
-    /// Bounded buffer for logs (approx 5MB)
-    private var logBuffer: [String] = []
+    /// Bounded buffer for logs
+    private var logBuffer: [LogEntry] = []
     private let maxLogLines = 5000
 
     // Performance: Debounce UI updates
@@ -20,18 +41,16 @@ class ActivityMonitor: ObservableObject {
         startLogTimer()
     }
 
-    // Timer is managed by the actor's lifecycle.
-    // In SwiftUI, an @StateObject's lifecycle is tied to the view.
-
-    /// Appends a new log line with the specified component prefix.
+    /// Appends a new log entry with the specified component prefix and severity.
     /// - Parameters:
     ///   - component: The source of the log (e.g., "[App]", "[Engine]").
+    ///   - level: The severity level.
     ///   - message: The log content.
-    func log(component: String, message: String) {
+    func log(component: String, level: LogLevel = .info, message: String) {
         let isFirstLog = logBuffer.isEmpty
-        let formattedLine = "\(component) \(message)"
+        let entry = LogEntry(timestamp: Date(), component: component, level: level, message: message)
 
-        logBuffer.append(formattedLine)
+        logBuffer.append(entry)
         if logBuffer.count > maxLogLines {
             logBuffer.removeFirst()
         }
@@ -54,12 +73,12 @@ class ActivityMonitor: ObservableObject {
     }
 
     private func publishLogs() {
-        fullLog = logBuffer.joined(separator: "\n")
+        logs = logBuffer
         pendingLogs = false
     }
 
     /// Synchronously returns the current log buffer content.
-    func getLogs() -> String {
-        return logBuffer.joined(separator: "\n")
+    func getLogs() -> [LogEntry] {
+        return logBuffer
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/LogConsoleView.swift
@@ -2,35 +2,47 @@ import AppKit
 import SwiftUI
 
 struct LogConsoleView: View {
-    let logs: String
+    let logs: [LogEntry]
+    @State private var showDebug: Bool = false
+
+    var filteredLogs: [LogEntry] {
+        if showDebug { return logs }
+        return logs.filter { $0.level >= .info }
+    }
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ScrollViewReader { proxy in
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
+                    LazyVStack(alignment: .leading, spacing: 4) {
                         if logs.isEmpty {
                             Text("Initializing log stream...")
                                 .foregroundColor(.secondary)
                                 .italic()
                         } else {
-                            Text(logs)
-                                .font(.system(.caption, design: .monospaced))
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                            ForEach(filteredLogs) { entry in
+                                LogEntryRow(entry: entry)
+                            }
                         }
                         Color.clear.frame(height: 1).id("bottom")
                     }
                     .padding(8)
                 }
                 .background(Color(NSColor.textBackgroundColor))
-                .onChange(of: logs) { _, _ in
+                .onChange(of: filteredLogs) { _, _ in
                     // Auto-scroll to bottom on update
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
 
             // Overlay Controls
-            HStack {
+            HStack(spacing: 8) {
+                Toggle("Debug", isOn: $showDebug)
+                    .toggleStyle(.checkbox)
+                    .padding(4)
+                    .background(Color.secondary.opacity(0.2))
+                    .cornerRadius(4)
+
                 Button(action: copyToClipboard) {
                     Label("Copy", systemImage: "doc.on.doc")
                 }
@@ -47,6 +59,31 @@ struct LogConsoleView: View {
     private func copyToClipboard() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(logs, forType: .string)
+        let text = filteredLogs.map { "\($0.component) \($0.message)" }.joined(separator: "\n")
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
+struct LogEntryRow: View {
+    let entry: LogEntry
+
+    private var levelColor: Color {
+        switch entry.level {
+        case .debug: return .gray
+        case .info: return .primary
+        case .warning: return .yellow
+        case .error: return .red
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(entry.component)
+                .bold()
+            Text(entry.message)
+        }
+        .font(.system(.caption, design: .monospaced))
+        .foregroundColor(levelColor)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -19,29 +19,32 @@ class NativeEngineManager: ObservableObject {
         socketPath: String? = nil,
         maxAttempts: Int = 10,
         baseDelayNS: UInt64 = 50_000_000,
-        onLog: ((String) -> Void)? = nil
+        onLog: ((String, LogLevel) -> Void)? = nil
     ) {
         self.maxAttempts = maxAttempts
         self.baseDelayNS = baseDelayNS
 
         if let socketPath = socketPath {
             self.socketPath = socketPath
+            onLog?("Using explicit socket path: \(self.socketPath)", .debug)
         } else {
             // Resolve socket path: prioritize shared App Group container for Sandbox compliance
             if let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) {
                 self.socketPath = groupURL.appendingPathComponent("engine.sock").path
+                onLog?("Resolved App Group socket path: \(self.socketPath)", .debug)
             } else {
                 // Fallback for non-sandboxed dev mode
                 let runtimeDir =
                     ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"]
                     ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/.local/run/gh-orbit")
                 self.socketPath = runtimeDir + "/engine.sock"
+                onLog?("Resolved Fallback socket path: \(self.socketPath)", .debug)
             }
         }
 
         // Set the supervisor's logging closure
-        engineSupervisor.onLog = { message in
-            onLog?(message)
+        engineSupervisor.onLog = { message, level in
+            onLog?(message, level)
         }
     }
 
@@ -49,6 +52,7 @@ class NativeEngineManager: ObservableObject {
         guard !engineSupervisor.isRunning else { return }
 
         do {
+            engineSupervisor.onLog?("Starting gh-orbit engine with executable: \(executable.path)", .debug)
             // Start engine with verbose logging for debugging
             try engineSupervisor.start(
                 executable: executable,
@@ -58,7 +62,13 @@ class NativeEngineManager: ObservableObject {
 
             // Wait for socket to appear with retries
             isEngineReady = await waitForSocket(path: socketPath)
+            if isEngineReady {
+                engineSupervisor.onLog?("Engine is ready (socket found).", .info)
+            } else {
+                engineSupervisor.onLog?("Engine failed to become ready (socket not found).", .error)
+            }
         } catch {
+            engineSupervisor.onLog?("Failed to start engine: \(error)", .error)
             print("Failed to start engine: \(error)")
         }
     }
@@ -76,6 +86,7 @@ class NativeEngineManager: ObservableObject {
     }
 
     func stopEngine() {
+        engineSupervisor.onLog?("Stopping gh-orbit engine.", .info)
         engineSupervisor.stop()
         isEngineReady = false
     }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -4,32 +4,32 @@ import SwiftUI
 @main
 @MainActor
 struct OrbitCockpitApp: App {
-    @StateObject private var activityMonitor = ActivityMonitor()
+    @StateObject private var activityMonitor: ActivityMonitor
+    @StateObject private var terminalManager: TerminalManager
 
     init() {
         // App Lifecycle Logging (Safe: No environment variables exposed)
         let monitor = ActivityMonitor()
         monitor.log(component: "[App]", message: "Launched Orbit Cockpit")
         _activityMonitor = StateObject(wrappedValue: monitor)
+        _terminalManager = StateObject(wrappedValue: TerminalManager(monitor: monitor))
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(activityMonitor)
+                .environmentObject(terminalManager)
         }
     }
 }
-
 @MainActor
 struct ContentView: View {
     @State private var selectedPane: String? = "TUI"
     @State private var showDebugLogs: Bool = false
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var activityMonitor: ActivityMonitor
-
-    // In a real app, these would be managed in a ViewModel/Store
-    @StateObject private var terminalManager = TerminalManager()
+    @EnvironmentObject var terminalManager: TerminalManager
 
     var body: some View {
         NavigationSplitView {
@@ -67,8 +67,6 @@ struct ContentView: View {
         }
         .onAppear {
             terminalManager.updateTheme(isDark: colorScheme == .dark)
-            // Inject the monitor into the manager
-            terminalManager.setMonitor(activityMonitor)
         }
     }
 }
@@ -150,11 +148,7 @@ class TerminalManager: ObservableObject {
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
 
-    init() {}
-
-    func setMonitor(_ monitor: ActivityMonitor) {
-        guard engineManager == nil else { return }
-
+    init(monitor: ActivityMonitor) {
         let newManager = NativeEngineManager(onLog: { msg in
             monitor.log(component: "[Engine]", message: msg)
         })

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -10,7 +10,7 @@ struct OrbitCockpitApp: App {
     init() {
         // App Lifecycle Logging (Safe: No environment variables exposed)
         let monitor = ActivityMonitor()
-        monitor.log(component: "[App]", message: "Launched Orbit Cockpit")
+        monitor.log(component: "[App]", level: .info, message: "Launched Orbit Cockpit")
         _activityMonitor = StateObject(wrappedValue: monitor)
         _terminalManager = StateObject(wrappedValue: TerminalManager(monitor: monitor))
     }
@@ -23,6 +23,7 @@ struct OrbitCockpitApp: App {
         }
     }
 }
+
 @MainActor
 struct ContentView: View {
     @State private var selectedPane: String? = "TUI"
@@ -48,7 +49,7 @@ struct ContentView: View {
 
                 if showDebugLogs {
                     Divider()
-                    LogConsoleView(logs: activityMonitor.fullLog)
+                    LogConsoleView(logs: activityMonitor.logs)
                         .frame(height: 200)
                 }
             }
@@ -147,10 +148,16 @@ class TerminalManager: ObservableObject {
 
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
+    private var onLog: ((String, LogLevel) -> Void)?
 
     init(monitor: ActivityMonitor) {
-        let newManager = NativeEngineManager(onLog: { msg in
-            monitor.log(component: "[Engine]", message: msg)
+        let logFunc: (String, LogLevel) -> Void = { msg, level in
+            monitor.log(component: "[App]", level: level, message: msg)
+        }
+        self.onLog = logFunc
+
+        let newManager = NativeEngineManager(onLog: { msg, level in
+            monitor.log(component: "[Engine]", level: level, message: msg)
         })
 
         newManager.objectWillChange
@@ -174,14 +181,18 @@ class TerminalManager: ObservableObject {
             let adapter = SwiftTermAdapter()
             adapter.isDarkMode(isDark)
 
+            onLog?("Resolving gh-orbit binary...", .debug)
             // 1. Resolve binary
-            guard let executableURL = PathResolver.resolveBinary() else {
+            guard let executableURL = PathResolver.resolveBinary(onLog: onLog) else {
+                onLog?("gh-orbit binary not found. Launch aborted.", .error)
                 self.launchError = "gh-orbit binary not found. Please ensure it's in your PATH or set GH_ORBIT_BIN."
                 return
             }
+            onLog?("Final binary resolved to: \(executableURL.path)", .debug)
 
             // 2. Ensure Engine is running
             if let engineMgr = engineManager {
+                onLog?("Delegating to NativeEngineManager to start background engine...", .debug)
                 await engineMgr.startEngine(executable: executableURL)
             }
 
@@ -198,11 +209,14 @@ class TerminalManager: ObservableObject {
             let appGroupID = "com.hirakiuc.gh-orbit.cockpit"
             if let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) {
                 env["XDG_RUNTIME_DIR"] = groupURL.path
+                onLog?("Set TUI XDG_RUNTIME_DIR to App Group container: \(groupURL.path)", .debug)
             } else if env["XDG_RUNTIME_DIR"] == nil {
                 let home = FileManager.default.homeDirectoryForCurrentUser.path
                 env["XDG_RUNTIME_DIR"] = home + "/.local/run"
+                onLog?("Set TUI XDG_RUNTIME_DIR to Fallback: \(home)/.local/run", .debug)
             }
 
+            onLog?("Launching TUI process with args: \(args)", .debug)
             adapter.startProcess(
                 executable: executableURL, args: args, environment: env.map { "\($0.key)=\($0.value)" })
             engines[name] = adapter

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -19,24 +19,27 @@ struct RealFileSystem: FileSystem {
 struct PathResolver {
     static func resolveBinary(
         fileSystem: FileSystem = RealFileSystem(),
-        env: [String: String] = ProcessInfo.processInfo.environment
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        onLog: ((String, LogLevel) -> Void)? = nil
     ) -> URL? {
+        onLog?("Starting binary resolution...", .debug)
 
         // 1. App Bundle (Production Highest Priority - Prevents Hijacking)
-        // Standard API lookup
         if let bundleURL = Bundle.main.url(forAuxiliaryExecutable: "gh-orbit") {
+            onLog?("Found binary via Bundle.main at: \(bundleURL.path)", .debug)
             return bundleURL
         }
 
         // 2. Manual Bundle Lookup Fallback (Defensive)
-        // If we are running from a bundle but standard API fails, look relative to executable
         if let executableURL = Bundle.main.executableURL {
             let helpersURL =
                 executableURL
                 .deletingLastPathComponent()  // MacOS
                 .deletingLastPathComponent()  // Contents
                 .appendingPathComponent("Helpers/gh-orbit")
+            onLog?("Checking manual fallback at: \(helpersURL.path)", .debug)
             if fileSystem.fileExists(atPath: helpersURL.path) {
+                onLog?("Found binary via manual fallback at: \(helpersURL.path)", .debug)
                 return helpersURL
             }
         }
@@ -45,7 +48,9 @@ struct PathResolver {
         #if DEBUG
             if let envPath = env["GH_ORBIT_BIN"], !envPath.isEmpty {
                 let url = URL(fileURLWithPath: envPath)
+                onLog?("Checking GH_ORBIT_BIN at: \(url.path)", .debug)
                 if fileSystem.fileExists(atPath: url.path) {
+                    onLog?("Found binary via GH_ORBIT_BIN at: \(url.path)", .debug)
                     return url
                 }
             }
@@ -53,49 +58,54 @@ struct PathResolver {
 
         // 4. Project Root (Debug/Development Only)
         #if DEBUG
-            if let devURL = resolveDevBinary(fileSystem: fileSystem) {
+            if let devURL = resolveDevBinary(fileSystem: fileSystem, onLog: onLog) {
                 return devURL
             }
         #endif
 
-        // 4. Standard Absolute Fallbacks
+        // 5. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
             "/opt/homebrew/bin/gh-orbit",
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)
+            onLog?("Checking absolute fallback at: \(url.path)", .debug)
             if fileSystem.fileExists(atPath: url.path) {
+                onLog?("Found binary via fallback at: \(url.path)", .debug)
                 return url
             }
         }
 
+        onLog?("Failed to find gh-orbit binary.", .error)
         return nil
     }
 
     #if DEBUG
-        private static func resolveDevBinary(fileSystem: FileSystem) -> URL? {
+        private static func resolveDevBinary(fileSystem: FileSystem, onLog: ((String, LogLevel) -> Void)?) -> URL? {
             let currentDir = fileSystem.currentDirectoryPath
             var searchURL = URL(fileURLWithPath: currentDir)
+            onLog?("Starting project root walk-up from: \(currentDir)", .debug)
 
-            // Walk up at most 5 levels to find project root (containing bin/gh-orbit)
-            for _ in 0..<5 {
+            for level in 0..<5 {
                 let binURL = searchURL.appendingPathComponent("bin/gh-orbit")
+                onLog?("Checking level \(level) at: \(binURL.path)", .debug)
+
                 if fileSystem.fileExists(atPath: binURL.path) {
+                    onLog?("Found binary via project root at: \(binURL.path)", .debug)
                     return binURL
                 }
 
-                // Look for project sentinels
                 let goModURL = searchURL.appendingPathComponent("go.mod")
                 let agentsURL = searchURL.appendingPathComponent("AGENTS.md")
 
-                // Stop if we hit user home or root or find project markers
                 if searchURL.path == "/" || searchURL.path == "/Users" {
+                    onLog?("Hit system boundary at \(searchURL.path), stopping walk-up.", .debug)
                     break
                 }
 
-                // If we find markers but bin/gh-orbit wasn't there, stop anyway
                 if fileSystem.fileExists(atPath: goModURL.path) || fileSystem.fileExists(atPath: agentsURL.path) {
+                    onLog?("Hit project sentinel at \(searchURL.path), stopping walk-up.", .debug)
                     break
                 }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
@@ -12,7 +12,20 @@ class ProcessSupervisor: ObservableObject {
     private let errorPipe = Pipe()
 
     /// Closure to push logs to a central monitor.
-    var onLog: ((String) -> Void)?
+    var onLog: ((String, LogLevel) -> Void)?
+
+    nonisolated func parseLogLevel(from line: String, defaultLevel: LogLevel) -> LogLevel {
+        if line.contains("\"level\":\"DEBUG\"") || line.contains("\"level\":\"debug\"") {
+            return .debug
+        } else if line.contains("\"level\":\"INFO\"") || line.contains("\"level\":\"info\"") {
+            return .info
+        } else if line.contains("\"level\":\"WARN\"") || line.contains("\"level\":\"warn\"") {
+            return .warning
+        } else if line.contains("\"level\":\"ERROR\"") || line.contains("\"level\":\"error\"") {
+            return .error
+        }
+        return defaultLevel
+    }
 
     func start(executable: URL, arguments: [String], environment: [String: String]?) throws {
         let process = Process()
@@ -38,8 +51,9 @@ class ProcessSupervisor: ObservableObject {
             let data = handle.availableData
             guard !data.isEmpty else { return }
             if let line = String(data: data, encoding: .utf8) {
+                let level = self?.parseLogLevel(from: line, defaultLevel: .error) ?? .error
                 DispatchQueue.main.async {
-                    self?.onLog?(line)
+                    self?.onLog?(line, level)
                     self?.lastError = line
                 }
             }
@@ -50,8 +64,9 @@ class ProcessSupervisor: ObservableObject {
             let data = handle.availableData
             guard !data.isEmpty else { return }
             if let line = String(data: data, encoding: .utf8) {
+                let level = self?.parseLogLevel(from: line, defaultLevel: .info) ?? .info
                 DispatchQueue.main.async {
-                    self?.onLog?(line)
+                    self?.onLog?(line, level)
                 }
             }
         }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -105,29 +105,48 @@ struct LifecycleTests {
     func testActivityMonitor() async throws {
         let monitor = ActivityMonitor()
 
-        #expect(monitor.fullLog.isEmpty)
+        #expect(monitor.logs.isEmpty)
 
-        monitor.log(component: "[App]", message: "Launch started")
+        monitor.log(component: "[App]", level: .info, message: "Launch started")
 
         // Wait for debouncer (0.1s interval)
         for _ in 0..<20 {
-            if !monitor.fullLog.isEmpty { break }
+            if !monitor.logs.isEmpty { break }
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 
-        #expect(monitor.fullLog.contains("[App] Launch started"))
+        #expect(monitor.logs.contains(where: { $0.component == "[App]" && $0.message == "Launch started" }))
 
         // Test multi-source aggregation
-        monitor.log(component: "[Engine]", message: "Engine started")
+        monitor.log(component: "[Engine]", level: .debug, message: "Engine started")
 
         // Wait for debouncer again
         for _ in 0..<20 {
-            if monitor.fullLog.contains("[Engine]") { break }
+            if monitor.logs.count > 1 { break }
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 
         let logs = monitor.getLogs()
-        #expect(logs.contains("[App] Launch started"))
-        #expect(logs.contains("[Engine] Engine started"))
+        let hasAppLog = logs.contains(where: { $0.component == "[App]" && $0.message == "Launch started" })
+        #expect(hasAppLog)
+
+        let hasEngineLog = logs.contains(where: {
+            $0.component == "[Engine]" && $0.message == "Engine started" && $0.level == .debug
+        })
+        #expect(hasEngineLog)
+    }
+
+    @Test("Structured log parsing")
+    func testStructuredLogParsing() async throws {
+        let supervisor = ProcessSupervisor()
+
+        let debugLog = supervisor.parseLogLevel(from: "{\"level\":\"DEBUG\",\"msg\":\"testing\"}", defaultLevel: .error)
+        #expect(debugLog == .debug)
+
+        let infoLog = supervisor.parseLogLevel(from: "{\"level\":\"INFO\",\"msg\":\"testing\"}", defaultLevel: .error)
+        #expect(infoLog == .info)
+
+        let unknownLog = supervisor.parseLogLevel(from: "just a raw string", defaultLevel: .error)
+        #expect(unknownLog == .error)
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -10,14 +10,16 @@ struct TerminalManagerTests {
     @Test("Manager initial state")
     @MainActor
     func testInitialization() async throws {
-        let manager = TerminalManager()
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
         #expect(manager.engines.isEmpty)
     }
 
     @Test("Engine mapping preservation")
     @MainActor
     func testEngineStorage() async throws {
-        let manager = TerminalManager()
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
         let mockEngine = SwiftTermAdapter()
 
         manager.engines["TUI"] = mockEngine
@@ -28,9 +30,8 @@ struct TerminalManagerTests {
     @Test("Nested State Propagation")
     @MainActor
     func testNestedStatePropagation() async throws {
-        let manager = TerminalManager()
         let monitor = ActivityMonitor()
-        manager.setMonitor(monitor)
+        let manager = TerminalManager(monitor: monitor)
 
         var didFire = false
 


### PR DESCRIPTION
## Description
This PR formally resolves the `EXC_BAD_ACCESS` macOS Sandbox termination and transitions the Activity Monitor to a structured, severity-filtered logging paradigm to help diagnose the lingering `Exit Code 5` crash.

## Key Changes
- **Code Signing**: Formalized the `Makefile` hotfix. The final step now explicitly targets `bin/OrbitCockpit.app`, ensuring the entire bundle (including `Info.plist`) is validated by macOS Gatekeeper.
- **Structured Logging**: `ActivityMonitor` now manages a bounded array of `LogEntry` structs with discrete severity levels (`DEBUG`, `INFO`, `WARN`, `ERROR`) instead of raw strings.
- **Log Parsing**: `ProcessSupervisor` performs fast string matching to extract the severity directly from the Go engine's JSON `slog` output format.
- **Diagnostic Tracing**: Injected comprehensive `DEBUG` logs across `PathResolver`, `NativeEngineManager`, and `TerminalManager` to trace binary paths, socket resolution, and exact arguments passed to `SwiftTerm` and the engine subprocess.
- **UI Enhancements**: Updated `LogConsoleView` to render color-coded log entries and added a "Show Debug Logs" toggle to reduce visual noise by default.

## Fixes
Resolves #244

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>