### PR TITLE
fix: grant sandbox exception for gh CLI credential access

### DIFF
--- a/native/OrbitCockpit/OrbitCockpit.entitlements
+++ b/native/OrbitCockpit/OrbitCockpit.entitlements
@@ -10,5 +10,9 @@
     <array>
         <string>$(TEAM_ID).group.com.hirakiuc.gh-orbit.cockpit</string>
     </array>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <array>
+        <string>/.config/gh</string>
+    </array>
 </dict>
 </plist>

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -48,7 +48,7 @@ class NativeEngineManager: ObservableObject {
         }
     }
 
-    func startEngine(executable: URL) async {
+    func startEngine(executable: URL, environment: [String: String]? = nil) async {
         guard !engineSupervisor.isRunning else { return }
 
         do {
@@ -57,7 +57,7 @@ class NativeEngineManager: ObservableObject {
             try engineSupervisor.start(
                 executable: executable,
                 arguments: ["engine", "--socket", socketPath, "--insecure-dev"],
-                environment: nil
+                environment: environment
             )
 
             // Wait for socket to appear with retries

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -190,20 +190,15 @@ class TerminalManager: ObservableObject {
             }
             onLog?("Final binary resolved to: \(executableURL.path)", .debug)
 
-            // 2. Ensure Engine is running
-            if let engineMgr = engineManager {
-                onLog?("Delegating to NativeEngineManager to start background engine...", .debug)
-                await engineMgr.startEngine(executable: executableURL)
-            }
-
-            // 3. Launch TUI
-            var args: [String] = []
-            if name != "TUI" {
-                args = ["agent", "--name", name]
-            }
-
             // Propagate environment including GH_TOKEN if available
             var env = ProcessInfo.processInfo.environment
+
+            // Resolve real user home directory to bypass sandbox redirection for gh config
+            if let passwdEntry = getpwuid(getuid()), let dir = passwdEntry.pointee.pw_dir {
+                let realHome = String(cString: dir)
+                env["GH_CONFIG_DIR"] = realHome + "/.config/gh"
+                onLog?("Set GH_CONFIG_DIR to: \(realHome)/.config/gh", .debug)
+            }
 
             // Prioritize App Group container for Sandbox IPC
             let appGroupID = "com.hirakiuc.gh-orbit.cockpit"
@@ -214,6 +209,18 @@ class TerminalManager: ObservableObject {
                 let home = FileManager.default.homeDirectoryForCurrentUser.path
                 env["XDG_RUNTIME_DIR"] = home + "/.local/run"
                 onLog?("Set TUI XDG_RUNTIME_DIR to Fallback: \(home)/.local/run", .debug)
+            }
+
+            // 2. Ensure Engine is running
+            if let engineMgr = engineManager {
+                onLog?("Delegating to NativeEngineManager to start background engine...", .debug)
+                await engineMgr.startEngine(executable: executableURL, environment: env)
+            }
+
+            // 3. Launch TUI
+            var args: [String] = []
+            if name != "TUI" {
+                args = ["agent", "--name", name]
             }
 
             onLog?("Launching TUI process with args: \(args)", .debug)


### PR DESCRIPTION
## Description
This PR resolves the `authentication token not found` crash by granting the native app read-only access to the `gh` CLI's global configuration directory and safely redirecting `go-gh`'s path resolution.

## Key Changes
- **Sandbox Exception**: Added `com.apple.security.temporary-exception.files.home-relative-path.read-only` for `/.config/gh` to `OrbitCockpit.entitlements`.
- **Inheritance Compliance**: Ensured the exception is *not* duplicated in `Helper.entitlements`, maintaining strict Apple inheritance rules and preventing `SIGTRAP` (Exit Code 5) crashes.
- **Environment Redirection**: Utilized POSIX `getpwuid(getuid())` to fetch the real user home path (bypassing sandbox container inflation) and injected the `GH_CONFIG_DIR` environment variable into both Engine and TUI subprocesses.

## Fixes
Resolves #246

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>