### PR TITLE
fix: additional TUI nil pointer panics in MCP mode

### DIFF
--- a/internal/api/notifier_darwin.go
+++ b/internal/api/notifier_darwin.go
@@ -49,6 +49,9 @@ func (n *DarwinNotifier) Status() types.BridgeStatus {
 
 // CheckFocusMode detects if "Do Not Disturb" or other focus modes are active.
 func CheckFocusMode(executor types.CommandExecutor) string {
+	if executor == nil {
+		return "Unknown"
+	}
 	// macOS Sequoia/Sonoma: uses 'dnd -status' via osascript (approximated)
 	out, err := executor.Execute(context.Background(), "defaults", "read", "com.apple.controlcenter", "NSStatusItem Visible FocusModes")
 	if err != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -203,6 +203,7 @@ func NewModel(
 		heartbeatInterval:   time.Duration(cfg.Notifications.SyncInterval) * time.Second,
 		clockInterval:       1 * time.Minute,
 		inflightEnrichments: make(map[string]time.Time),
+		executor:            api.NewOSCommandExecutor(), // Default executor
 	}
 
 	// Apply options
@@ -262,6 +263,11 @@ func (m *Model) Shutdown() {
 
 func (m *Model) submitTask(priority int, fn types.TaskFunc) tea.Cmd {
 	return func() tea.Msg {
+		if m.traffic == nil {
+			// In MCP mode or if traffic controller is missing, execute immediately
+			return fn(context.Background())
+		}
+
 		resChan, err := m.traffic.Submit(priority, fn)
 		if err != nil {
 			return types.ErrMsg{Err: err}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -66,6 +66,8 @@ func (m *Model) renderHeader() string {
 	status := ""
 	if m.ui.syncing {
 		status = m.ui.spinner.View() + " Syncing..."
+	} else if m.traffic == nil {
+		status = m.styles.Help.Render("Connected to Engine")
 	} else {
 		remaining := m.traffic.Remaining()
 		threshold := 1000

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -118,6 +118,15 @@ func TestRenderHeader_States(t *testing.T) {
 		assert.Contains(t, stripANSI(view), "Syncing...")
 	})
 
+	t.Run("Nil Traffic (MCP Mode)", func(t *testing.T) {
+		m := newTestModel(t)
+		m.traffic = nil
+		m.ui.syncing = false
+
+		view := m.renderHeader()
+		assert.Contains(t, stripANSI(view), "Connected to Engine")
+	})
+
 	t.Run("Low Quota", func(t *testing.T) {
 		m := newTestModel(t)
 		mockTraffic := mocks.NewMockTrafficController(t)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -66,7 +66,7 @@ struct PathResolver {
         // 5. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit"
+            "/opt/homebrew/bin/gh-orbit",
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)


### PR DESCRIPTION
## Description
The TUI continues to experience nil pointer dereference panics when running in "Connected" (MCP) mode. This PR hardens the view and model layers to handle missing controllers gracefully.

## Key Changes
- **`renderHeader` Nil-Safety**: Re-implemented the guard to display "Connected to Engine" when `traffic` is nil.
- **`submitTask` Nil-Safety**: Added a check in `internal/tui/model.go` to execute tasks immediately if the traffic controller is missing, preventing crashes during background loading.
- **`CheckFocusMode` Nil-Safety**: Added a defensive nil check for the `CommandExecutor` in `internal/api/notifier_darwin.go`.
- **Automatic Initialization**: Ensured `NewModel` always provides a default `OSCommandExecutor` to prevent nil executor crashes during TUI initialization.

## Fixes
Resolves #251, #252

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>