### PR TITLE
fix: decompose high-complexity hotspots (Phase 6.1)

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -329,6 +329,62 @@ func (e *EnrichmentEngine) fetchByNodeIDs(ctx context.Context, ids []string, res
 	ctx, span := tracer.Start(ctx, "enrichment.gql_batch")
 	defer span.End()
 
+	data, err := e.executeGQLBatch(ctx, ids)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "enrichment: graphql batch fetch failed", "error", err)
+		return
+	}
+
+	if e.logger.Enabled(ctx, slog.LevelDebug) {
+		e.logger.DebugContext(ctx, "enrichment: graphql batch fetch complete",
+			"cost", data.RateLimit.Cost,
+			"remaining", data.RateLimit.Remaining,
+			"node_count", len(data.Nodes))
+	}
+
+	e.client.ReportRateLimit(models.RateLimitInfo{
+		Limit:     data.RateLimit.Cost + data.RateLimit.Remaining,
+		Remaining: data.RateLimit.Remaining,
+		Used:      data.RateLimit.Cost,
+	})
+
+	span.SetAttributes(
+		attribute.Int("gql.cost", data.RateLimit.Cost),
+		attribute.Int("gql.nodes", len(data.Nodes)),
+	)
+
+	for _, node := range data.Nodes {
+		if node.ID == "" {
+			continue
+		}
+
+		state, subState := parseNodeState(node.Typename, node.State, node.Merged, node.IsDraft, node.ReviewDecision, node.StateReason, node.Closed)
+		if state != "" || subState != "" {
+			e.updateNodeState(ctx, node.ID, state, subState, results)
+		}
+	}
+}
+
+type gqlNode struct {
+	Typename       string  `json:"__typename"`
+	ID             string  `json:"id"`
+	State          string  `json:"state"`
+	Merged         bool    `json:"merged"`
+	IsDraft        bool    `json:"isDraft"`
+	ReviewDecision string  `json:"reviewDecision"`
+	StateReason    *string `json:"stateReason"`
+	Closed         bool    `json:"closed"`
+}
+
+type gqlBatchResponse struct {
+	Nodes []gqlNode `json:"nodes"`
+	RateLimit struct {
+		Cost      int `json:"cost"`
+		Remaining int `json:"remaining"`
+	} `json:"rateLimit"`
+}
+
+func (e *EnrichmentEngine) executeGQLBatch(ctx context.Context, ids []string) (*gqlBatchResponse, error) {
 	queryString := `
 		query($ids: [ID!]!) {
 			nodes(ids: $ids) {
@@ -359,86 +415,87 @@ func (e *EnrichmentEngine) fetchByNodeIDs(ctx context.Context, ids []string, res
 		} `json:"rateLimit"`
 	}
 
-	// Best Practice: Use DoWithContext for generic context propagation in go-gh GQL
-	// Signature: DoWithContext(ctx, query, variables, response)
 	err := e.client.GQL().DoWithContext(ctx, queryString, variables, &data)
 	if err != nil {
-		e.logger.ErrorContext(ctx, "enrichment: graphql batch fetch failed", "error", err)
-		return
+		return nil, err
 	}
 
-	if e.logger.Enabled(ctx, slog.LevelDebug) {
-		e.logger.DebugContext(ctx, "enrichment: graphql batch fetch complete",
-			"cost", data.RateLimit.Cost,
-			"remaining", data.RateLimit.Remaining,
-			"node_count", len(data.Nodes))
+	// Map to named struct for decomposition helpers
+	resp := &gqlBatchResponse{
+		RateLimit: struct {
+			Cost      int `json:"cost"`
+			Remaining int `json:"remaining"`
+		}{
+			Cost:      data.RateLimit.Cost,
+			Remaining: data.RateLimit.Remaining,
+		},
 	}
 
-	e.client.ReportRateLimit(models.RateLimitInfo{
-		Limit:     data.RateLimit.Cost + data.RateLimit.Remaining, // Best guess for Limit
-		Remaining: data.RateLimit.Remaining,
-		Used:      data.RateLimit.Cost,
-	})
+	for _, n := range data.Nodes {
+		resp.Nodes = append(resp.Nodes, gqlNode{
+			Typename:       n.Typename,
+			ID:             n.ID,
+			State:          n.State,
+			Merged:         n.Merged,
+			IsDraft:        n.IsDraft,
+			ReviewDecision: n.ReviewDecision,
+			StateReason:    n.StateReason,
+			Closed:         n.Closed,
+		})
+	}
 
-	span.SetAttributes(
-		attribute.Int("gql.cost", data.RateLimit.Cost),
-		attribute.Int("gql.nodes", len(data.Nodes)),
-	)
+	return resp, nil
+}
 
-	for _, node := range data.Nodes {
-		if node.ID == "" {
-			continue
+func parseNodeState(typename, nodeState string, merged, isDraft bool, reviewDecision string, stateReason *string, closed bool) (string, string) {
+	state := ""
+	subState := ""
+
+	switch triage.SubjectType(typename) {
+	case triage.SubjectPullRequest:
+		if merged {
+			state = "Merged"
+		} else if isDraft {
+			state = "Draft"
+		} else if nodeState != "" {
+			state = strings.ToUpper(nodeState[:1]) + strings.ToLower(nodeState[1:])
 		}
-
-		state := ""
-		subState := ""
-
-		switch triage.SubjectType(node.Typename) {
-		case triage.SubjectPullRequest:
-			if node.Merged {
-				state = "Merged"
-			} else if node.IsDraft {
-				state = "Draft"
-			} else if node.State != "" {
-				state = strings.ToUpper(node.State[:1]) + strings.ToLower(node.State[1:])
-			}
-			subState = node.ReviewDecision
-		case triage.SubjectIssue:
-			if node.State != "" {
-				state = strings.ToUpper(node.State[:1]) + strings.ToLower(node.State[1:])
-			}
-			if node.StateReason != nil {
-				subState = *node.StateReason
-			}
-		case triage.SubjectDiscussion:
-			if node.Closed {
-				state = "Closed"
-			} else {
-				state = "Open"
-			}
-			if node.StateReason != nil {
-				subState = *node.StateReason
-			}
+		subState = reviewDecision
+	case triage.SubjectIssue:
+		if nodeState != "" {
+			state = strings.ToUpper(nodeState[:1]) + strings.ToLower(nodeState[1:])
 		}
-
-		if state != "" || subState != "" {
-			// Observability: Log transition
-			e.logger.DebugContext(ctx, "enrichment: node state fetched",
-				"node_id", node.ID,
-				"new_state", state,
-				"new_substate", subState)
-
-			if err := e.db.UpdateResourceStateByNodeID(ctx, node.ID, state, subState); err != nil {
-				e.logger.ErrorContext(ctx, "enrichment: failed to update resource state", "node_id", node.ID, "error", err)
-			}
-
-			// Populate results for immediate TUI refresh
-			results[node.ID] = models.EnrichmentResult{
-				ResourceState:    state,
-				ResourceSubState: subState,
-				FetchedAt:        time.Now(),
-			}
+		if stateReason != nil {
+			subState = *stateReason
 		}
+	case triage.SubjectDiscussion:
+		if closed {
+			state = "Closed"
+		} else {
+			state = "Open"
+		}
+		if stateReason != nil {
+			subState = *stateReason
+		}
+	}
+
+	return state, subState
+}
+
+func (e *EnrichmentEngine) updateNodeState(ctx context.Context, nodeID, state, subState string, results map[string]models.EnrichmentResult) {
+	e.logger.DebugContext(ctx, "enrichment: node state fetched",
+		"node_id", nodeID,
+		"new_state", state,
+		"new_substate", subState)
+
+	if err := e.db.UpdateResourceStateByNodeID(ctx, nodeID, state, subState); err != nil {
+		e.logger.ErrorContext(ctx, "enrichment: failed to update resource state", "node_id", nodeID, "error", err)
+	}
+
+	results[nodeID] = models.EnrichmentResult{
+		ResourceState:    state,
+		ResourceSubState: subState,
+		FetchedAt:        time.Now(),
 	}
 }
 

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -92,117 +92,24 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 	metaKey := "notifications"
 	rlInfo := models.RateLimitInfo{Limit: 5000, Remaining: 5000}
 
-	meta, err := s.db.GetSyncMeta(ctx, userID, metaKey)
+	meta, err := s.initSyncMeta(ctx, userID, metaKey, syncID)
 	if err != nil {
 		return rlInfo, err
 	}
 
-	// Initialize meta if not exists
-	if meta == nil {
-		meta = &models.SyncMeta{
-			UserID:       userID,
-			Key:          metaKey,
-			PollInterval: DefaultPollInterval,
-		}
-	}
-
-	// 1. Self-Healing: Detect and clear corrupted ETags (e.g., W/"")
-	if meta.ETag == `W/""` {
-		if s.logger.Enabled(ctx, slog.LevelDebug) {
-			s.logger.DebugContext(ctx, "sync: self-healing corrupted ETag", "sync_id", syncID, "etag", meta.ETag)
-		}
-		meta.ETag = ""
-	}
-
-	// Check if we should poll based on LastSyncAt and PollInterval
-	if !force && time.Since(meta.LastSyncAt).Seconds() < float64(meta.PollInterval) {
-		if s.logger.Enabled(ctx, slog.LevelDebug) {
-			s.logger.DebugContext(ctx, "sync: skipping poll, interval not reached",
-				"sync_id", syncID,
-				"interval", meta.PollInterval,
-				"last_sync", meta.LastSyncAt)
-		}
-		return rlInfo, types.ErrSyncIntervalNotReached // Too soon to poll
-	}
-
-	if s.logger.Enabled(ctx, slog.LevelDebug) {
-		s.logger.DebugContext(ctx, "sync: executing API fetch",
-			"sync_id", syncID,
-			"etag", meta.ETag,
-			"last_modified", meta.LastModified)
+	if s.shouldSkipPoll(ctx, meta, force, syncID) {
+		return rlInfo, types.ErrSyncIntervalNotReached
 	}
 
 	notifications, newMeta, rlInfo, err := s.fetcher.FetchNotifications(ctx, meta, force)
 	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to fetch notifications", "sync_id", syncID, "error", err)
-		meta.LastError = err.Error()
-		meta.LastErrorAt = time.Now()
-		if updateErr := s.db.UpdateSyncMeta(ctx, *meta); updateErr != nil {
-			s.logger.ErrorContext(ctx, "failed to update sync meta after fetch error", "sync_id", syncID, "error", updateErr)
-		}
-		return rlInfo, err
+		return s.handleFetchError(ctx, meta, syncID, rlInfo, err)
 	}
 
 	span.SetAttributes(attribute.Int("notification_count", len(notifications)))
 
-	// If 304 Not Modified, notifications will be empty but newMeta might have updated PollInterval
-	if len(notifications) == 0 {
-		if s.logger.Enabled(ctx, slog.LevelDebug) {
-			s.logger.DebugContext(ctx, "sync: no new notifications (304 or empty)", "sync_id", syncID)
-		}
-	} else {
-		s.logger.InfoContext(ctx, "sync: processing new notifications",
-			"sync_id", syncID,
-			"count", len(notifications))
-
-		var newlyDiscoveredIDs []string
-		var triageNotifications []triage.Notification
-		for _, n := range notifications {
-			triageNotifications = append(triageNotifications, triage.Notification{
-				GitHubID:           n.ID,
-				SubjectTitle:       n.Subject.Title,
-				SubjectURL:         n.Subject.URL,
-				SubjectType:        triage.SubjectType(n.Subject.Type),
-				Reason:             n.Reason,
-				RepositoryFullName: n.Repository.FullName,
-				SubjectNodeID:      n.Subject.NodeID,
-				HTMLURL:            "", // Will be enriched in later phases if needed
-				UpdatedAt:          n.UpdatedAt,
-			})
-		}
-
-		if err := s.db.UpsertNotifications(ctx, triageNotifications); err != nil {
-			s.logger.ErrorContext(ctx, "sync: failed to batch upsert notifications", "error", err)
-			return rlInfo, err
-		}
-
-		for _, n := range notifications {
-			// We only trigger alerts for notifications arriving AFTER the established baseline
-			// AND that we haven't notified for yet.
-			state, err := s.db.GetNotification(ctx, n.ID)
-			if err == nil && state != nil && !state.IsNotified {
-				// Alerts are sent only for truly new items (arrival > baseline sync)
-				if n.UpdatedAt.After(meta.LastSyncAt) {
-					if s.alerts != nil {
-						if notifyErr := s.alerts.Notify(ctx, n); notifyErr != nil {
-							s.logger.WarnContext(ctx, "failed to send alert for notification", "id", n.ID, "error", notifyErr)
-						}
-					}
-				}
-				// Mark as "processed" even if alert failed (to prevent infinite retry storm)
-				newlyDiscoveredIDs = append(newlyDiscoveredIDs, n.ID)
-			}
-		}
-
-		// Batch mark as notified to preserve baseline state
-		if len(newlyDiscoveredIDs) > 0 {
-			if s.logger.Enabled(ctx, slog.LevelDebug) {
-				s.logger.DebugContext(ctx, "sync: marking notifications as notified", "count", len(newlyDiscoveredIDs))
-			}
-			if err := s.db.MarkNotifiedBatch(ctx, newlyDiscoveredIDs); err != nil {
-				s.logger.ErrorContext(ctx, "failed to mark notifications as notified", "error", err)
-			}
-		}
+	if err := s.processSyncResults(ctx, notifications, meta, syncID); err != nil {
+		return rlInfo, err
 	}
 
 	newMeta.LastSyncAt = time.Now()
@@ -217,4 +124,145 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 	s.OnMutation()
 
 	return rlInfo, nil
+}
+
+func (s *SyncEngine) initSyncMeta(ctx context.Context, userID string, key string, syncID int64) (*models.SyncMeta, error) {
+	meta, err := s.db.GetSyncMeta(ctx, userID, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize meta if not exists
+	if meta == nil {
+		meta = &models.SyncMeta{
+			UserID:       userID,
+			Key:          key,
+			PollInterval: DefaultPollInterval,
+		}
+	}
+
+	// Self-Healing: Detect and clear corrupted ETags (e.g., W/"")
+	if meta.ETag == `W/""` {
+		if s.logger.Enabled(ctx, slog.LevelDebug) {
+			s.logger.DebugContext(ctx, "sync: self-healing corrupted ETag", "sync_id", syncID, "etag", meta.ETag)
+		}
+		meta.ETag = ""
+	}
+
+	return meta, nil
+}
+
+func (s *SyncEngine) shouldSkipPoll(ctx context.Context, meta *models.SyncMeta, force bool, syncID int64) bool {
+	if force {
+		return false
+	}
+
+	if time.Since(meta.LastSyncAt).Seconds() < float64(meta.PollInterval) {
+		if s.logger.Enabled(ctx, slog.LevelDebug) {
+			s.logger.DebugContext(ctx, "sync: skipping poll, interval not reached",
+				"sync_id", syncID,
+				"interval", meta.PollInterval,
+				"last_sync", meta.LastSyncAt)
+		}
+		return true
+	}
+	return false
+}
+
+func (s *SyncEngine) handleFetchError(ctx context.Context, meta *models.SyncMeta, syncID int64, rl models.RateLimitInfo, err error) (models.RateLimitInfo, error) {
+	s.logger.ErrorContext(ctx, "failed to fetch notifications", "sync_id", syncID, "error", err)
+	meta.LastError = err.Error()
+	meta.LastErrorAt = time.Now()
+	if updateErr := s.db.UpdateSyncMeta(ctx, *meta); updateErr != nil {
+		s.logger.ErrorContext(ctx, "failed to update sync meta after fetch error", "sync_id", syncID, "error", updateErr)
+	}
+	return rl, err
+}
+
+func (s *SyncEngine) processSyncResults(ctx context.Context, notifications []github.Notification, meta *models.SyncMeta, syncID int64) error {
+	// If 304 Not Modified, notifications will be empty
+	if len(notifications) == 0 {
+		if s.logger.Enabled(ctx, slog.LevelDebug) {
+			s.logger.DebugContext(ctx, "sync: no new notifications (304 or empty)", "sync_id", syncID)
+		}
+		return nil
+	}
+
+	s.logger.InfoContext(ctx, "sync: processing new notifications",
+		"sync_id", syncID,
+		"count", len(notifications))
+
+	var triageNotifications []triage.Notification
+	for _, n := range notifications {
+		triageNotifications = append(triageNotifications, triage.Notification{
+			GitHubID:           n.ID,
+			SubjectTitle:       n.Subject.Title,
+			SubjectURL:         n.Subject.URL,
+			SubjectType:        triage.SubjectType(n.Subject.Type),
+			Reason:             n.Reason,
+			RepositoryFullName: n.Repository.FullName,
+			SubjectNodeID:      n.Subject.NodeID,
+			HTMLURL:            "", // Will be enriched in later phases if needed
+			UpdatedAt:          n.UpdatedAt,
+		})
+	}
+
+	if err := s.db.UpsertNotifications(ctx, triageNotifications); err != nil {
+		s.logger.ErrorContext(ctx, "sync: failed to batch upsert notifications", "error", err)
+		return err
+	}
+
+	return s.triggerAlerts(ctx, notifications, meta.LastSyncAt, syncID)
+}
+
+func (s *SyncEngine) triggerAlerts(ctx context.Context, notifications []github.Notification, lastSyncAt time.Time, syncID int64) error {
+	var newlyDiscoveredIDs []string
+
+	for _, n := range notifications {
+		if s.shouldTriggerAlert(ctx, n, lastSyncAt) {
+			s.sendAlert(ctx, n)
+			newlyDiscoveredIDs = append(newlyDiscoveredIDs, n.ID)
+		}
+	}
+
+	return s.markAsNotified(ctx, newlyDiscoveredIDs)
+}
+
+func (s *SyncEngine) shouldTriggerAlert(ctx context.Context, n github.Notification, lastSyncAt time.Time) bool {
+	// We only trigger alerts for notifications arriving AFTER the established baseline
+	// AND that we haven't notified for yet.
+	state, err := s.db.GetNotification(ctx, n.ID)
+	if err != nil || state == nil || state.IsNotified {
+		return false
+	}
+
+	// Alerts are sent only for truly new items (arrival > baseline sync)
+	return n.UpdatedAt.After(lastSyncAt)
+}
+
+func (s *SyncEngine) sendAlert(ctx context.Context, n github.Notification) {
+	if s.alerts == nil {
+		return
+	}
+
+	if err := s.alerts.Notify(ctx, n); err != nil {
+		s.logger.WarnContext(ctx, "failed to send alert for notification", "id", n.ID, "error", err)
+	}
+}
+
+func (s *SyncEngine) markAsNotified(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if s.logger.Enabled(ctx, slog.LevelDebug) {
+		s.logger.DebugContext(ctx, "sync: marking notifications as notified", "count", len(ids))
+	}
+
+	if err := s.db.MarkNotifiedBatch(ctx, ids); err != nil {
+		s.logger.ErrorContext(ctx, "failed to mark notifications as notified", "error", err)
+		return err
+	}
+
+	return nil
 }

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -207,37 +207,53 @@ func (s *MCPServer) handleConnection(ctx context.Context, conn net.Conn) {
 
 	s.engine.Logger.Debug("peer connected and verified via UDS")
 
-	session := newUDSSession(conn)
-	if err := s.server.RegisterSession(ctx, session); err != nil {
-		s.engine.Logger.ErrorContext(ctx, "failed to register session", "error", err)
+	session, sessionCtx, cleanup, err := s.setupSession(ctx, conn)
+	if err != nil {
+		s.engine.Logger.ErrorContext(ctx, "failed to setup session", "error", err)
 		return
 	}
-	defer s.server.UnregisterSession(ctx, session.SessionID())
-
-	sessionCtx := s.server.WithContext(ctx, session)
-	reader := bufio.NewReader(conn)
+	defer cleanup()
 
 	// Start notification dispatcher for this session
-	go func() {
-		for {
-			select {
-			case <-sessionCtx.Done():
-				return
-			case notification := <-session.notifications:
-				data, err := json.Marshal(notification)
-				if err == nil {
-					if s.verbose {
-						s.engine.Logger.Debug("MCP notification", "msg", config.RedactSecrets(string(data)))
-					}
-					session.writeMu.Lock()
-					_, _ = fmt.Fprintf(session.writer, "%s\n", data)
-					session.writeMu.Unlock()
+	go s.runNotificationDispatcher(sessionCtx, session)
+
+	// Process incoming requests
+	s.processRequestLoop(sessionCtx, session, conn)
+}
+
+func (s *MCPServer) setupSession(ctx context.Context, conn net.Conn) (*udsSession, context.Context, func(), error) {
+	session := newUDSSession(conn)
+	if err := s.server.RegisterSession(ctx, session); err != nil {
+		return nil, nil, nil, err
+	}
+
+	sessionCtx := s.server.WithContext(ctx, session)
+	cleanup := func() {
+		s.server.UnregisterSession(ctx, session.SessionID())
+	}
+
+	return session, sessionCtx, cleanup, nil
+}
+
+func (s *MCPServer) runNotificationDispatcher(ctx context.Context, session *udsSession) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case notification := <-session.notifications:
+			data, err := json.Marshal(notification)
+			if err == nil {
+				if s.verbose {
+					s.engine.Logger.Debug("MCP notification", "msg", config.RedactSecrets(string(data)))
 				}
+				s.sendJSONRPCMessage(session, data)
 			}
 		}
-	}()
+	}
+}
 
-	// Request/Response loop
+func (s *MCPServer) processRequestLoop(ctx context.Context, session *udsSession, conn io.Reader) {
+	reader := bufio.NewReader(conn)
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -247,28 +263,36 @@ func (s *MCPServer) handleConnection(ctx context.Context, conn net.Conn) {
 			break
 		}
 
-		if s.verbose {
-			s.engine.Logger.Debug("MCP request", "msg", config.RedactSecrets(line))
-		}
+		s.handleSingleMessage(ctx, session, line)
+	}
+}
 
-		var rawMessage json.RawMessage
-		if err := json.Unmarshal([]byte(line), &rawMessage); err != nil {
-			continue
-		}
+func (s *MCPServer) handleSingleMessage(ctx context.Context, session *udsSession, line string) {
+	if s.verbose {
+		s.engine.Logger.Debug("MCP request", "msg", config.RedactSecrets(line))
+	}
 
-		response := s.server.HandleMessage(sessionCtx, rawMessage)
-		if response != nil {
-			data, err := json.Marshal(response)
-			if err == nil {
-				if s.verbose {
-					s.engine.Logger.Debug("MCP response", "msg", config.RedactSecrets(string(data)))
-				}
-				session.writeMu.Lock()
-				_, _ = fmt.Fprintf(session.writer, "%s\n", data)
-				session.writeMu.Unlock()
+	var rawMessage json.RawMessage
+	if err := json.Unmarshal([]byte(line), &rawMessage); err != nil {
+		return
+	}
+
+	response := s.server.HandleMessage(ctx, rawMessage)
+	if response != nil {
+		data, err := json.Marshal(response)
+		if err == nil {
+			if s.verbose {
+				s.engine.Logger.Debug("MCP response", "msg", config.RedactSecrets(string(data)))
 			}
+			s.sendJSONRPCMessage(session, data)
 		}
 	}
+}
+
+func (s *MCPServer) sendJSONRPCMessage(session *udsSession, data []byte) {
+	session.writeMu.Lock()
+	defer session.writeMu.Unlock()
+	_, _ = fmt.Fprintf(session.writer, "%s\n", data)
 }
 
 func (s *MCPServer) registerTools() {

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -274,6 +274,9 @@ func (s *MCPServer) handleSingleMessage(ctx context.Context, session *udsSession
 
 	var rawMessage json.RawMessage
 	if err := json.Unmarshal([]byte(line), &rawMessage); err != nil {
+		if s.verbose {
+			s.engine.Logger.Debug("MCP malformed request", "error", err, "line", config.RedactSecrets(line))
+		}
 		return
 	}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -562,9 +562,27 @@ func (m *Model) handleTransitionError(msg types.ErrMsg) {
 }
 
 func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
-	switch {
-	case msg.String() == "ctrl+c":
+	if msg.String() == "ctrl+c" {
 		return []Action{ActionQuit{}}
+	}
+
+	if actions := m.handleNavigationKeys(msg); actions != nil {
+		return actions
+	}
+
+	if actions := m.handleTabKeys(msg); actions != nil {
+		return actions
+	}
+
+	if actions := m.handleFilteringKeys(msg); actions != nil {
+		return actions
+	}
+
+	return m.handlePriorityKeys(msg)
+}
+
+func (m *Model) handleNavigationKeys(msg tea.KeyMsg) []Action {
+	switch {
 	case key.Matches(msg, m.keys.Quit):
 		if !m.listView.list.Help.ShowAll {
 			return m.handleQuitTransition()
@@ -579,6 +597,16 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 		m.showHelp = !m.showHelp
 		m.help.ShowAll = m.showHelp
 		m.syncSubModelSizes()
+	case key.Matches(msg, m.keys.OpenBrowser):
+		return m.handleOpenBrowserKey()
+	case key.Matches(msg, m.keys.CheckoutPR):
+		return m.handleCheckoutPRKey()
+	}
+	return nil
+}
+
+func (m *Model) handleTabKeys(msg tea.KeyMsg) []Action {
+	switch {
 	case key.Matches(msg, m.keys.NextTab):
 		m.cycleTab(1)
 	case key.Matches(msg, m.keys.PrevTab):
@@ -591,17 +619,28 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 		m.setActiveTab(TabTriaged)
 	case key.Matches(msg, m.keys.Tab4):
 		m.setActiveTab(TabAll)
-	case key.Matches(msg, m.keys.OpenBrowser):
-		return m.handleOpenBrowserKey()
-	case key.Matches(msg, m.keys.CheckoutPR):
-		return m.handleCheckoutPRKey()
+	default:
+		return nil
+	}
+	return []Action{} // State changed, but no imperative actions
+}
+
+func (m *Model) handleFilteringKeys(msg tea.KeyMsg) []Action {
+	switch {
 	case key.Matches(msg, m.keys.FilterPR):
 		m.toggleResourceFilter(triage.SubjectPullRequest, "PRs")
 	case key.Matches(msg, m.keys.FilterIssue):
 		m.toggleResourceFilter(triage.SubjectIssue, "Issues")
 	case key.Matches(msg, m.keys.FilterDiscussion):
 		m.toggleResourceFilter(triage.SubjectDiscussion, "Discussions")
+	default:
+		return nil
+	}
+	return []Action{}
+}
 
+func (m *Model) handlePriorityKeys(msg tea.KeyMsg) []Action {
+	switch {
 	case key.Matches(msg, m.keys.PriorityUp):
 		return m.handlePriorityKey(1)
 	case key.Matches(msg, m.keys.PriorityDown):


### PR DESCRIPTION
## Objective
Reduce cognitive complexity for all remaining hotspots to < 20 to fulfill the maintainability target of #256.

- **internal/api/sync.go**: Refactored `(*SyncEngine).Sync` and decomposed into `initSyncMeta`, `shouldSkipPoll`, `handleFetchError`, and `processSyncResults`. Refactored `triggerAlerts` to modularize alert logic.
- **internal/engine/mcp.go**: Refactored `(*MCPServer).handleConnection` and decomposed into `setupSession`, `runNotificationDispatcher`, and `processRequestLoop`.
- **internal/api/enrichment.go**: Refactored `(*EnrichmentEngine).fetchByNodeIDs` and decomposed into `executeGQLBatch`, `parseNodeState` (pure function), and `updateNodeState`.
- **internal/tui/update.go**: Refactored `(*Model).handleListKey` by grouping related key matches into focused helper methods.

Resolves #267
(generated by AI)