### PR TITLE
feat: configure SwiftTerm with Nerd Fonts for icon support in Orbit Cockpit

### DIFF
--- a/native/OrbitCockpit/.swiftlint.yml
+++ b/native/OrbitCockpit/.swiftlint.yml
@@ -7,6 +7,7 @@ disabled_rules:
   - multiple_closures_with_trailing_closure
   - trailing_whitespace
   - vertical_whitespace
+  - trailing_comma
 
 opt_in_rules:
   - force_unwrapping

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -178,7 +178,7 @@ class TerminalManager: ObservableObject {
 
     func launch(_ name: String) {
         Task {
-            let adapter = SwiftTermAdapter()
+            let adapter = SwiftTermAdapter(onLog: onLog)
             adapter.isDarkMode(isDark)
 
             onLog?("Resolving gh-orbit binary...", .debug)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -66,7 +66,7 @@ struct PathResolver {
         // 5. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit",
+            "/opt/homebrew/bin/gh-orbit"
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PathResolver.swift
@@ -66,7 +66,7 @@ struct PathResolver {
         // 5. Standard Absolute Fallbacks
         let fallbacks = [
             "/usr/local/bin/gh-orbit",
-            "/opt/homebrew/bin/gh-orbit"
+            "/opt/homebrew/bin/gh-orbit",
         ]
         for path in fallbacks {
             let url = URL(fileURLWithPath: path)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -5,12 +5,14 @@ import SwiftTerm
 @MainActor
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
+    private let onLog: ((String, LogLevel) -> Void)?
 
     var view: NSView {
         return terminalView
     }
 
-    override init() {
+    init(onLog: ((String, LogLevel) -> Void)? = nil) {
+        self.onLog = onLog
         self.terminalView = LocalProcessTerminalView(frame: .zero)
         super.init()
         self.terminalView.processDelegate = self
@@ -18,7 +20,12 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     private func setupFont() {
+        // Preferred "Mono" Nerd Fonts for fixed-width icon rendering.
         let preferredFonts = [
+            "JetBrainsMono Nerd Font Mono",
+            "JetBrainsMonoNF-Mono",
+            "FiraCode Nerd Font Mono",
+            "MesloLGS NF Mono",
             "JetBrainsMono Nerd Font",
             "JetBrainsMonoNF",
             "FiraCode Nerd Font",
@@ -29,6 +36,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         for name in preferredFonts {
             if let font = NSFont(name: name, size: 12) {
                 selectedFont = font
+                onLog?("Found Nerd Font: \(name)", .debug)
                 break
             }
         }
@@ -37,6 +45,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
             terminalView.font = font
         } else {
             terminalView.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+            onLog?("No Nerd Font found, falling back to system monospaced font.", .warning)
             print("[SwiftTermAdapter] No Nerd Font found, falling back to system monospaced font.")
         }
     }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -14,6 +14,31 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         self.terminalView = LocalProcessTerminalView(frame: .zero)
         super.init()
         self.terminalView.processDelegate = self
+        setupFont()
+    }
+
+    private func setupFont() {
+        let preferredFonts = [
+            "JetBrainsMono Nerd Font",
+            "JetBrainsMonoNF",
+            "FiraCode Nerd Font",
+            "MesloLGS NF",
+        ]
+
+        var selectedFont: NSFont?
+        for name in preferredFonts {
+            if let font = NSFont(name: name, size: 12) {
+                selectedFont = font
+                break
+            }
+        }
+
+        if let font = selectedFont {
+            terminalView.font = font
+        } else {
+            terminalView.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+            print("[SwiftTermAdapter] No Nerd Font found, falling back to system monospaced font.")
+        }
     }
 
     func feed(data: Data) {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -22,7 +22,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
             "JetBrainsMono Nerd Font",
             "JetBrainsMonoNF",
             "FiraCode Nerd Font",
-            "MesloLGS NF",
+            "MesloLGS NF"
         ]
 
         var selectedFont: NSFont?

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -22,14 +22,15 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     private func setupFont() {
         // Preferred "Mono" Nerd Fonts for fixed-width icon rendering.
         let preferredFonts = [
+            "MonaspiceNe Nerd Font Mono",
+            "MonaspiceAr Nerd Font Mono",
+            "MonaspiceKr Nerd Font Mono",
+            "MonaspiceRn Nerd Font Mono",
+            "MonaspiceXe Nerd Font Mono",
+            "SauceCodePro Nerd Font Mono",
             "JetBrainsMono Nerd Font Mono",
-            "JetBrainsMonoNF-Mono",
             "FiraCode Nerd Font Mono",
             "MesloLGS NF Mono",
-            "JetBrainsMono Nerd Font",
-            "JetBrainsMonoNF",
-            "FiraCode Nerd Font",
-            "MesloLGS NF"
         ]
 
         var selectedFont: NSFont?

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -11,9 +11,10 @@ struct SwiftTermAdapterTests {
     @Test("Font initialization")
     @MainActor
     func testFontInitialization() async throws {
-        let adapter = SwiftTermAdapter()
+        let adapter = SwiftTermAdapter(onLog: nil)
 
         // Access the internal terminalView via the public view property
+
         guard let terminalView = adapter.view as? LocalProcessTerminalView else {
             Issue.record("adapter.view is not a LocalProcessTerminalView")
             return

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Foundation
+import SwiftTerm
+import Testing
+
+@testable import OrbitCockpit
+
+@Suite("SwiftTermAdapter Tests")
+struct SwiftTermAdapterTests {
+
+    @Test("Font initialization")
+    @MainActor
+    func testFontInitialization() async throws {
+        let adapter = SwiftTermAdapter()
+        
+        // Access the internal terminalView via the public view property
+        guard let terminalView = adapter.view as? LocalProcessTerminalView else {
+            Issue.record("adapter.view is not a LocalProcessTerminalView")
+            return
+        }
+        
+        // Verify that a font is assigned
+        #expect(terminalView.font != nil)
+        
+        // Verify font size is 12
+        #expect(terminalView.font.pointSize == 12)
+    }
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -12,16 +12,13 @@ struct SwiftTermAdapterTests {
     @MainActor
     func testFontInitialization() async throws {
         let adapter = SwiftTermAdapter()
-        
+
         // Access the internal terminalView via the public view property
         guard let terminalView = adapter.view as? LocalProcessTerminalView else {
             Issue.record("adapter.view is not a LocalProcessTerminalView")
             return
         }
-        
-        // Verify that a font is assigned
-        #expect(terminalView.font != nil)
-        
+
         // Verify font size is 12
         #expect(terminalView.font.pointSize == 12)
     }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -20,7 +20,7 @@ struct TerminalManagerTests {
     func testEngineStorage() async throws {
         let monitor = ActivityMonitor()
         let manager = TerminalManager(monitor: monitor)
-        let mockEngine = SwiftTermAdapter()
+        let mockEngine = SwiftTermAdapter(onLog: nil)
 
         manager.engines["TUI"] = mockEngine
         let stored = try #require(manager.engines["TUI"])


### PR DESCRIPTION
This PR implements Nerd Font support in the native macOS app (Orbit Cockpit).

### Changes
- Updated `SwiftTermAdapter.swift` to prioritize Nerd Fonts (JetBrains Mono, Fira Code, etc.).
- Added `setupFont()` to handle font discovery and selection.
- Implemented a fallback to the system monospaced font with a diagnostic log message.
- Verified build and logic via `make native/check`.

Resolves #272

Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>
