### PR TITLE
Fix Orbit Cockpit engine readiness and startup ownership

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -334,6 +334,7 @@ func runTUI() error {
 		runtimeDir = filepath.Join(home, ".local/run/gh-orbit")
 	}
 	socketPath := filepath.Join(runtimeDir, "engine.sock")
+	requireEngine := os.Getenv("GH_ORBIT_REQUIRE_ENGINE") == "1"
 
 	if _, err := os.Stat(socketPath); err == nil {
 		env.logger.Debug("detecting headless engine", "socket", socketPath)
@@ -361,10 +362,18 @@ func runTUI() error {
 				user := "mcp-user" // Placeholder until tool added
 				return launchTUIMCP(ctx, env, adapter, user)
 			}
+			if requireEngine {
+				return fmt.Errorf("cockpit-managed launch requires MCP engine initialization: %w", err)
+			}
 			env.logger.Warn("mcp handshake failed, falling back to standalone", "error", err)
 		} else {
+			if requireEngine {
+				return fmt.Errorf("cockpit-managed launch requires MCP engine connection: %w", err)
+			}
 			env.logger.Warn("failed to connect to engine UDS, falling back to standalone", "error", err)
 		}
+	} else if requireEngine {
+		return fmt.Errorf("cockpit-managed launch requires a running MCP engine at %s", socketPath)
 	}
 
 	// 2. Standalone Mode (Library access)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -1,25 +1,205 @@
 import Combine
+import Darwin
 import Foundation
+
+enum EngineOwnershipState: Equatable {
+    case idle
+    case reused
+    case spawningOwned
+    case ownedReady
+    case ownedFailed
+}
+
+enum EngineStartupResult: Equatable {
+    case reused
+    case ownedReady
+    case failed(String)
+}
+
+private let defaultProbeTimeoutNS: UInt64 = 250_000_000
+
+protocol EngineProbing: Sendable {
+    func waitUntilReady(
+        socketPath: String,
+        maxAttempts: Int,
+        baseDelayNS: UInt64
+    ) async -> Bool
+}
+
+struct MCPInitializeProbe: EngineProbing {
+    private struct RequestEnvelope: Encodable {
+        let jsonrpc = "2.0"
+        let id: Int
+        let method: String
+        let params: InitializeParams
+    }
+
+    private struct InitializeParams: Encodable {
+        let protocolVersion: String
+        let capabilities = ClientCapabilities()
+        let clientInfo: ClientInfo
+    }
+
+    private struct ClientCapabilities: Encodable {}
+
+    private struct ClientInfo: Encodable {
+        let name: String
+        let version: String
+    }
+
+    private struct ResponseEnvelope: Decodable {
+        let jsonrpc: String?
+        let id: Int?
+        let result: ResultPayload?
+        let error: ErrorPayload?
+    }
+
+    private struct ResultPayload: Decodable {
+        let protocolVersion: String?
+    }
+
+    private struct ErrorPayload: Decodable {
+        let code: Int
+        let message: String
+    }
+
+    private let protocolVersion = "2025-11-25"
+    private let ioTimeoutMS: Int = 200
+
+    func waitUntilReady(
+        socketPath: String,
+        maxAttempts: Int,
+        baseDelayNS: UInt64
+    ) async -> Bool {
+        let pathBytes = socketPath.utf8CString
+        let maxLength = MemoryLayout<sockaddr_un>.size - MemoryLayout<sa_family_t>.size
+        if pathBytes.count >= maxLength {
+            return false
+        }
+
+        for attempt in 1...maxAttempts {
+            if await attemptValidation(socketPath: socketPath) {
+                return true
+            }
+
+            let delay = UInt64(pow(2.0, Double(attempt)) * Double(baseDelayNS))
+            try? await Task.sleep(nanoseconds: delay)
+        }
+        return false
+    }
+
+    private func attemptValidation(socketPath: String) async -> Bool {
+        return await Task.detached(priority: .utility) {
+            Self.validate(socketPath: socketPath, protocolVersion: protocolVersion, ioTimeoutMS: ioTimeoutMS)
+        }.value
+    }
+
+    nonisolated private static func validate(socketPath: String, protocolVersion: String, ioTimeoutMS: Int) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        if fd < 0 {
+            return false
+        }
+        defer { close(fd) }
+
+        var timeout = timeval(tv_sec: 0, tv_usec: Int32(ioTimeoutMS * 1000))
+        _ = withUnsafePointer(to: &timeout) {
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, $0, socklen_t(MemoryLayout<timeval>.size))
+        }
+        _ = withUnsafePointer(to: &timeout) {
+            setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, $0, socklen_t(MemoryLayout<timeval>.size))
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+
+        let pathBytes = socketPath.utf8CString
+        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: maxLength) { cString in
+                for index in 0..<pathBytes.count {
+                    cString[index] = pathBytes[index]
+                }
+            }
+        }
+
+        let addrLength = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+        let connectResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, addrLength)
+            }
+        }
+        if connectResult != 0 {
+            return false
+        }
+
+        let payload = RequestEnvelope(
+            id: 1,
+            method: "initialize",
+            params: InitializeParams(
+                protocolVersion: protocolVersion,
+                clientInfo: ClientInfo(name: "orbit-cockpit", version: "1.0")
+            )
+        )
+
+        let encoder = JSONEncoder()
+        guard var data = try? encoder.encode(payload) else {
+            return false
+        }
+        data.append(0x0A)
+
+        let writeResult = data.withUnsafeBytes {
+            Darwin.write(fd, $0.baseAddress, $0.count)
+        }
+        if writeResult <= 0 {
+            return false
+        }
+
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let readCount = Darwin.read(fd, &buffer, buffer.count)
+        if readCount <= 0 {
+            return false
+        }
+
+        let responseBytes = buffer.prefix(Int(readCount)).prefix { $0 != 0x0A }
+        guard let responseData = String(bytes: responseBytes, encoding: .utf8)?.data(using: .utf8),
+            let response = try? JSONDecoder().decode(ResponseEnvelope.self, from: responseData)
+        else {
+            return false
+        }
+
+        return response.error == nil && response.id == 1 && response.result?.protocolVersion != nil
+    }
+}
 
 /// NativeEngineManager manages the persistent gh-orbit engine process.
 @MainActor
 class NativeEngineManager: ObservableObject {
     @Published var isEngineReady: Bool = false
+    @Published var ownershipState: EngineOwnershipState = .idle
 
-    private var engineSupervisor = ProcessSupervisor()
-    private var socketPath: String
+    private let engineSupervisor: EngineProcessSupervising
+    private let probe: any EngineProbing
+    private let socketPath: String
 
     private let maxAttempts: Int
     private let baseDelayNS: UInt64
+    private let probeTimeoutNS: UInt64
+    private var startupTask: Task<EngineStartupResult, Never>?
 
     init(
         socketPath: String? = nil,
         maxAttempts: Int = 10,
         baseDelayNS: UInt64 = 50_000_000,
+        probeTimeoutNS: UInt64 = defaultProbeTimeoutNS,
+        engineSupervisor: EngineProcessSupervising? = nil,
+        probe: any EngineProbing = MCPInitializeProbe(),
         onLog: ((String, LogLevel) -> Void)? = nil
     ) {
         self.maxAttempts = maxAttempts
         self.baseDelayNS = baseDelayNS
+        self.probeTimeoutNS = probeTimeoutNS
+        self.probe = probe
+        self.engineSupervisor = engineSupervisor ?? ProcessSupervisor()
 
         if let socketPath = socketPath {
             self.socketPath = socketPath
@@ -35,51 +215,119 @@ class NativeEngineManager: ObservableObject {
         }
 
         // Set the supervisor's logging closure
-        engineSupervisor.onLog = { message, level in
+        self.engineSupervisor.onLog = { message, level in
             onLog?(message, level)
         }
     }
 
-    func startEngine(executable: URL, environment: [String: String]? = nil) async {
-        guard !engineSupervisor.isRunning else { return }
-
-        do {
-            engineSupervisor.onLog?("Starting gh-orbit engine with executable: \(executable.path)", .debug)
-            // Start engine with verbose logging for debugging
-            try engineSupervisor.start(
-                executable: executable,
-                arguments: ["engine", "--socket", socketPath, "--insecure-dev"],
-                environment: environment
-            )
-
-            // Wait for socket to appear with retries
-            isEngineReady = await waitForSocket(path: socketPath)
-            if isEngineReady {
-                engineSupervisor.onLog?("Engine is ready (socket found).", .info)
-            } else {
-                engineSupervisor.onLog?("Engine failed to become ready (socket not found).", .error)
-            }
-        } catch {
-            engineSupervisor.onLog?("Failed to start engine: \(error)", .error)
-            print("Failed to start engine: \(error)")
+    func startEngine(executable: URL, environment: [String: String]? = nil) async -> EngineStartupResult {
+        if let startupTask {
+            return await startupTask.value
         }
+
+        if ownershipState == .reused || ownershipState == .ownedReady {
+            return ownershipState == .reused ? .reused : .ownedReady
+        }
+
+        let task = Task<EngineStartupResult, Never> {
+            if await self.verifyExistingEngine() {
+                return .reused
+            }
+
+            do {
+                self.ownershipState = .spawningOwned
+                self.isEngineReady = false
+                self.engineSupervisor.onLog?("Starting gh-orbit engine with executable: \(executable.path)", .debug)
+                try self.engineSupervisor.start(
+                    executable: executable,
+                    arguments: ["engine", "--socket", self.socketPath, "--insecure-dev"],
+                    environment: environment
+                )
+
+                let ready = await self.waitUntilReadyBounded(maxAttempts: self.maxAttempts)
+                if ready {
+                    self.ownershipState = .ownedReady
+                    self.isEngineReady = true
+                    self.engineSupervisor.onLog?("Engine is ready (MCP initialize verified).", .info)
+                    return .ownedReady
+                }
+
+                self.engineSupervisor.onLog?("Engine failed to become ready (MCP initialize did not succeed).", .error)
+                self.stopOwnedEngineIfNeeded()
+                self.ownershipState = .ownedFailed
+                self.isEngineReady = false
+                return .failed("Orbit Cockpit could not verify the managed gh-orbit engine.")
+            } catch {
+                self.stopOwnedEngineIfNeeded()
+                self.ownershipState = .ownedFailed
+                self.isEngineReady = false
+                self.engineSupervisor.onLog?("Failed to start engine: \(error)", .error)
+                return .failed("Orbit Cockpit could not start the gh-orbit engine: \(error.localizedDescription)")
+            }
+        }
+
+        startupTask = task
+        let result = await task.value
+        if startupTask?.isCancelled == false {
+            startupTask = nil
+        }
+        return result
     }
 
-    private func waitForSocket(path: String) async -> Bool {
-        for attempt in 1...maxAttempts {
-            if FileManager.default.fileExists(atPath: path) {
-                return true
-            }
-            // Exponential backoff
-            let delay = UInt64(pow(2.0, Double(attempt)) * Double(baseDelayNS))
-            try? await Task.sleep(nanoseconds: delay)
+    private func verifyExistingEngine() async -> Bool {
+        let isReusable = await waitUntilReadyBounded(maxAttempts: 1)
+        if isReusable {
+            ownershipState = .reused
+            isEngineReady = true
+            engineSupervisor.onLog?("Reusing existing gh-orbit engine after MCP initialize verification.", .info)
         }
-        return false
+        return isReusable
+    }
+
+    private func waitUntilReadyBounded(maxAttempts: Int) async -> Bool {
+        let probe = self.probe
+        let socketPath = self.socketPath
+        let baseDelayNS = self.baseDelayNS
+        let probeTimeoutNS = self.probeTimeoutNS
+
+        let result = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await probe.waitUntilReady(
+                    socketPath: socketPath,
+                    maxAttempts: maxAttempts,
+                    baseDelayNS: baseDelayNS
+                )
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: probeTimeoutNS)
+                return false
+            }
+
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        return result
     }
 
     func stopEngine() {
-        engineSupervisor.onLog?("Stopping gh-orbit engine.", .info)
-        engineSupervisor.stop()
         isEngineReady = false
+        switch ownershipState {
+        case .spawningOwned, .ownedReady:
+            engineSupervisor.onLog?("Stopping gh-orbit engine owned by this Cockpit session.", .info)
+            engineSupervisor.stop()
+        case .reused:
+            engineSupervisor.onLog?("Leaving reused gh-orbit engine running.", .debug)
+        case .idle, .ownedFailed:
+            break
+        }
+        ownershipState = .idle
+    }
+
+    private func stopOwnedEngineIfNeeded() {
+        if engineSupervisor.isRunning {
+            engineSupervisor.stop()
+        }
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -18,12 +18,24 @@ enum EngineStartupResult: Equatable {
 
 private let defaultProbeTimeoutNS: UInt64 = 250_000_000
 
+struct ProbeOutcome: Sendable {
+    let success: Bool
+    let detail: String
+
+    static func ok(_ detail: String) -> ProbeOutcome {
+        ProbeOutcome(success: true, detail: detail)
+    }
+
+    static func failed(_ detail: String) -> ProbeOutcome {
+        ProbeOutcome(success: false, detail: detail)
+    }
+}
+
 protocol EngineProbing: Sendable {
-    func waitUntilReady(
+    func probe(
         socketPath: String,
-        maxAttempts: Int,
-        baseDelayNS: UInt64
-    ) async -> Bool
+        phase: String
+    ) async -> ProbeOutcome
 }
 
 struct MCPInitializeProbe: EngineProbing {
@@ -66,38 +78,25 @@ struct MCPInitializeProbe: EngineProbing {
     private let protocolVersion = "2025-11-25"
     private let ioTimeoutMS: Int = 200
 
-    func waitUntilReady(
+    func probe(
         socketPath: String,
-        maxAttempts: Int,
-        baseDelayNS: UInt64
-    ) async -> Bool {
+        phase: String
+    ) async -> ProbeOutcome {
         let pathBytes = socketPath.utf8CString
         let maxLength = MemoryLayout<sockaddr_un>.size - MemoryLayout<sa_family_t>.size
         if pathBytes.count >= maxLength {
-            return false
+            return .failed("[\(phase)] socket path too long for UDS probe")
         }
 
-        for attempt in 1...maxAttempts {
-            if await attemptValidation(socketPath: socketPath) {
-                return true
-            }
-
-            let delay = UInt64(pow(2.0, Double(attempt)) * Double(baseDelayNS))
-            try? await Task.sleep(nanoseconds: delay)
-        }
-        return false
-    }
-
-    private func attemptValidation(socketPath: String) async -> Bool {
         return await Task.detached(priority: .utility) {
             Self.validate(socketPath: socketPath, protocolVersion: protocolVersion, ioTimeoutMS: ioTimeoutMS)
         }.value
     }
 
-    nonisolated private static func validate(socketPath: String, protocolVersion: String, ioTimeoutMS: Int) -> Bool {
+    nonisolated private static func validate(socketPath: String, protocolVersion: String, ioTimeoutMS: Int) -> ProbeOutcome {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         if fd < 0 {
-            return false
+            return .failed("socket() failed: errno=\(errno)")
         }
         defer { close(fd) }
 
@@ -129,7 +128,7 @@ struct MCPInitializeProbe: EngineProbing {
             }
         }
         if connectResult != 0 {
-            return false
+            return .failed("connect() failed: errno=\(errno)")
         }
 
         let payload = RequestEnvelope(
@@ -143,7 +142,7 @@ struct MCPInitializeProbe: EngineProbing {
 
         let encoder = JSONEncoder()
         guard var data = try? encoder.encode(payload) else {
-            return false
+            return .failed("failed to encode initialize payload")
         }
         data.append(0x0A)
 
@@ -151,23 +150,35 @@ struct MCPInitializeProbe: EngineProbing {
             Darwin.write(fd, $0.baseAddress, $0.count)
         }
         if writeResult <= 0 {
-            return false
+            return .failed("write() failed: errno=\(errno)")
         }
 
         var buffer = [UInt8](repeating: 0, count: 4096)
         let readCount = Darwin.read(fd, &buffer, buffer.count)
         if readCount <= 0 {
-            return false
+            return .failed("read() failed or timed out: errno=\(errno)")
         }
 
         let responseBytes = buffer.prefix(Int(readCount)).prefix { $0 != 0x0A }
         guard let responseData = String(bytes: responseBytes, encoding: .utf8)?.data(using: .utf8),
             let response = try? JSONDecoder().decode(ResponseEnvelope.self, from: responseData)
         else {
-            return false
+            let snippet = String(bytes: responseBytes.prefix(120), encoding: .utf8) ?? "<non-utf8>"
+            return .failed("failed to decode initialize response: \(snippet)")
         }
 
-        return response.error == nil && response.id == 1 && response.result?.protocolVersion != nil
+        if let error = response.error {
+            return .failed("initialize returned error: code=\(error.code) message=\(error.message)")
+        }
+
+        guard response.id == 1 else {
+            return .failed("initialize returned unexpected id: \(response.id.map(String.init) ?? "nil")")
+        }
+        guard let negotiatedVersion = response.result?.protocolVersion, !negotiatedVersion.isEmpty else {
+            return .failed("initialize response missing protocolVersion")
+        }
+
+        return .ok("initialize succeeded with protocolVersion=\(negotiatedVersion)")
     }
 }
 
@@ -230,6 +241,7 @@ class NativeEngineManager: ObservableObject {
         }
 
         let task = Task<EngineStartupResult, Never> {
+            self.engineSupervisor.onLog?("Starting engine readiness flow for socket: \(self.socketPath)", .debug)
             if await self.verifyExistingEngine() {
                 return .reused
             }
@@ -244,15 +256,15 @@ class NativeEngineManager: ObservableObject {
                     environment: environment
                 )
 
-                let ready = await self.waitUntilReadyBounded(maxAttempts: self.maxAttempts)
-                if ready {
+                let outcome = await self.waitUntilReadyBounded(maxAttempts: self.maxAttempts, phase: "owned-engine verification")
+                if outcome.success {
                     self.ownershipState = .ownedReady
                     self.isEngineReady = true
-                    self.engineSupervisor.onLog?("Engine is ready (MCP initialize verified).", .info)
+                    self.engineSupervisor.onLog?("Engine is ready (MCP initialize verified). Detail: \(outcome.detail)", .info)
                     return .ownedReady
                 }
 
-                self.engineSupervisor.onLog?("Engine failed to become ready (MCP initialize did not succeed).", .error)
+                self.engineSupervisor.onLog?("Engine failed to become ready. Detail: \(outcome.detail)", .error)
                 self.stopOwnedEngineIfNeeded()
                 self.ownershipState = .ownedFailed
                 self.isEngineReady = false
@@ -275,40 +287,57 @@ class NativeEngineManager: ObservableObject {
     }
 
     private func verifyExistingEngine() async -> Bool {
-        let isReusable = await waitUntilReadyBounded(maxAttempts: 1)
-        if isReusable {
+        let outcome = await waitUntilReadyBounded(maxAttempts: 1, phase: "existing-engine probe")
+        if outcome.success {
             ownershipState = .reused
             isEngineReady = true
-            engineSupervisor.onLog?("Reusing existing gh-orbit engine after MCP initialize verification.", .info)
+            engineSupervisor.onLog?("Reusing existing gh-orbit engine after MCP initialize verification. Detail: \(outcome.detail)", .info)
+            return true
         }
-        return isReusable
+        engineSupervisor.onLog?("Existing-engine probe did not verify a reusable engine. Detail: \(outcome.detail)", .debug)
+        return false
     }
 
-    private func waitUntilReadyBounded(maxAttempts: Int) async -> Bool {
+    private func waitUntilReadyBounded(maxAttempts: Int, phase: String) async -> ProbeOutcome {
         let probe = self.probe
         let socketPath = self.socketPath
         let baseDelayNS = self.baseDelayNS
         let probeTimeoutNS = self.probeTimeoutNS
 
-        let result = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await probe.waitUntilReady(
-                    socketPath: socketPath,
-                    maxAttempts: maxAttempts,
-                    baseDelayNS: baseDelayNS
-                )
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: probeTimeoutNS)
-                return false
+        var lastFailure = ProbeOutcome.failed("[\(phase)] probe did not run")
+        for attempt in 1...maxAttempts {
+            let outcome = await withTaskGroup(of: ProbeOutcome.self) { group in
+                group.addTask {
+                    await probe.probe(
+                        socketPath: socketPath,
+                        phase: "\(phase) attempt \(attempt)"
+                    )
+                }
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: probeTimeoutNS)
+                    return .failed("[\(phase) attempt \(attempt)] timed out after \(probeTimeoutNS / 1_000_000)ms")
+                }
+
+                let first = await group.next() ?? .failed("[\(phase) attempt \(attempt)] no probe result")
+                group.cancelAll()
+                return first
             }
 
-            let first = await group.next() ?? false
-            group.cancelAll()
-            return first
+            if outcome.success {
+                return outcome
+            }
+
+            lastFailure = outcome
+            engineSupervisor.onLog?("Probe failure: \(outcome.detail)", .debug)
+
+            if attempt < maxAttempts {
+                let delay = UInt64(pow(2.0, Double(attempt)) * Double(baseDelayNS))
+                engineSupervisor.onLog?("Retrying probe after \(delay / 1_000_000)ms backoff.", .debug)
+                try? await Task.sleep(nanoseconds: delay)
+            }
         }
 
-        return result
+        return lastFailure
     }
 
     func stopEngine() {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -1,4 +1,5 @@
 import Combine
+import AppKit
 import SwiftUI
 
 @main
@@ -20,6 +21,9 @@ struct OrbitCockpitApp: App {
             ContentView()
                 .environmentObject(activityMonitor)
                 .environmentObject(terminalManager)
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                    terminalManager.shutdown()
+                }
         }
     }
 }
@@ -149,6 +153,7 @@ class TerminalManager: ObservableObject {
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
     private var onLog: ((String, LogLevel) -> Void)?
+    private var launchTasks: [String: Task<Void, Never>] = [:]
 
     init(monitor: ActivityMonitor) {
         let logFunc: (String, LogLevel) -> Void = { msg, level in
@@ -177,7 +182,12 @@ class TerminalManager: ObservableObject {
     }
 
     func launch(_ name: String) {
-        Task {
+        if engines[name] != nil || launchTasks[name] != nil {
+            return
+        }
+
+        let task = Task {
+            defer { launchTasks[name] = nil }
             let adapter = SwiftTermAdapter(onLog: onLog)
             adapter.isDarkMode(isDark)
 
@@ -198,11 +208,19 @@ class TerminalManager: ObservableObject {
                 let home = FileManager.default.homeDirectoryForCurrentUser.path
                 env["XDG_RUNTIME_DIR"] = home + "/.local/run"
             }
+            env["GH_ORBIT_REQUIRE_ENGINE"] = "1"
 
             // 2. Ensure Engine is running
             if let engineMgr = engineManager {
                 onLog?("Delegating to NativeEngineManager to start background engine...", .debug)
-                await engineMgr.startEngine(executable: executableURL, environment: env)
+                switch await engineMgr.startEngine(executable: executableURL, environment: env) {
+                case .reused, .ownedReady:
+                    break
+                case .failed(let message):
+                    onLog?("Engine verification failed. Aborting pane launch.", .error)
+                    self.launchError = message
+                    return
+                }
             }
 
             // 3. Launch TUI
@@ -216,5 +234,14 @@ class TerminalManager: ObservableObject {
                 executable: executableURL, args: args, environment: env.map { "\($0.key)=\($0.value)" })
             engines[name] = adapter
         }
+        launchTasks[name] = task
+    }
+
+    func shutdown() {
+        for task in launchTasks.values {
+            task.cancel()
+        }
+        launchTasks.removeAll()
+        engineManager?.stopEngine()
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ProcessSupervisor.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+@MainActor
+protocol EngineProcessSupervising: AnyObject {
+    var isRunning: Bool { get }
+    var onLog: ((String, LogLevel) -> Void)? { get set }
+    func start(executable: URL, arguments: [String], environment: [String: String]?) throws
+    func stop()
+}
+
 /// ProcessSupervisor handles the lifecycle and observability of a subprocess.
 @MainActor
-class ProcessSupervisor: ObservableObject {
+class ProcessSupervisor: ObservableObject, EngineProcessSupervising {
     @Published var isRunning: Bool = false
     @Published var exitCode: Int32?
     @Published var lastError: String?

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -27,7 +27,7 @@ final class MockSupervisor: EngineProcessSupervising {
 
 actor MockProbe: EngineProbing {
     struct Step {
-        let result: Bool
+        let outcome: ProbeOutcome
         let delayNS: UInt64
     }
 
@@ -35,18 +35,19 @@ actor MockProbe: EngineProbing {
     private(set) var callCount = 0
 
     init(results: [Bool]) {
-        self.steps = results.map { Step(result: $0, delayNS: 0) }
+        self.steps = results.map {
+            Step(outcome: $0 ? .ok("mock success") : .failed("mock failure"), delayNS: 0)
+        }
     }
 
     init(steps: [Step]) {
         self.steps = steps
     }
 
-    func waitUntilReady(
+    func probe(
         socketPath: String,
-        maxAttempts: Int,
-        baseDelayNS: UInt64
-    ) async -> Bool {
+        phase: String
+    ) async -> ProbeOutcome {
         let index = callCount
         callCount += 1
         if index < steps.count {
@@ -54,9 +55,9 @@ actor MockProbe: EngineProbing {
             if step.delayNS > 0 {
                 try? await Task.sleep(nanoseconds: step.delayNS)
             }
-            return step.result
+            return step.outcome
         }
-        return false
+        return .failed("mock default failure")
     }
 }
 
@@ -160,8 +161,8 @@ struct LifecycleTests {
     @Test("NativeEngineManager bounds stalled probe handling")
     func testStalledProbeTimesOut() async throws {
         let probe = MockProbe(steps: [
-            .init(result: false, delayNS: 1_000_000_000),
-            .init(result: false, delayNS: 1_000_000_000),
+            .init(outcome: .failed("slow failure"), delayNS: 1_000_000_000),
+            .init(outcome: .failed("slow failure"), delayNS: 1_000_000_000),
         ])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
@@ -187,8 +188,8 @@ struct LifecycleTests {
     @Test("NativeEngineManager shares inflight startup across concurrent callers")
     func testConcurrentStartSharesSingleStartupTask() async throws {
         let probe = MockProbe(steps: [
-            .init(result: false, delayNS: 0),
-            .init(result: true, delayNS: 50_000_000),
+            .init(outcome: .failed("not ready yet"), delayNS: 0),
+            .init(outcome: .ok("ready"), delayNS: 50_000_000),
         ])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -3,6 +3,63 @@ import Testing
 
 @testable import OrbitCockpit
 
+@MainActor
+final class MockSupervisor: EngineProcessSupervising {
+    var isRunning = false
+    var onLog: ((String, LogLevel) -> Void)?
+    var startCalls = 0
+    var stopCalls = 0
+    var startError: Error?
+
+    func start(executable: URL, arguments: [String], environment: [String: String]?) throws {
+        startCalls += 1
+        if let startError {
+            throw startError
+        }
+        isRunning = true
+    }
+
+    func stop() {
+        stopCalls += 1
+        isRunning = false
+    }
+}
+
+actor MockProbe: EngineProbing {
+    struct Step {
+        let result: Bool
+        let delayNS: UInt64
+    }
+
+    var steps: [Step]
+    private(set) var callCount = 0
+
+    init(results: [Bool]) {
+        self.steps = results.map { Step(result: $0, delayNS: 0) }
+    }
+
+    init(steps: [Step]) {
+        self.steps = steps
+    }
+
+    func waitUntilReady(
+        socketPath: String,
+        maxAttempts: Int,
+        baseDelayNS: UInt64
+    ) async -> Bool {
+        let index = callCount
+        callCount += 1
+        if index < steps.count {
+            let step = steps[index]
+            if step.delayNS > 0 {
+                try? await Task.sleep(nanoseconds: step.delayNS)
+            }
+            return step.result
+        }
+        return false
+    }
+}
+
 struct MockFileSystem: FileSystem {
     var exists: Set<String> = []
     var currentPath: String = "/test/project"
@@ -43,22 +100,135 @@ struct LifecycleTests {
 
     @Test("NativeEngineManager UDS retry logic failure")
     func testUDSRetryLogicFailure() async throws {
-        // Use a path that will never exist to test timeout/retry failure
-        let fakeSocket = "/tmp/non_existent_orbit_\(UUID().uuidString).sock"
-        // Optimize: use 1ms base delay and 5 attempts for fast testing (~60ms total)
-        let manager = NativeEngineManager(socketPath: fakeSocket, maxAttempts: 5, baseDelayNS: 1_000_000)
+        let probe = MockProbe(results: [false, false])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/non_existent_orbit.sock",
+            maxAttempts: 5,
+            baseDelayNS: 1_000_000,
+            probeTimeoutNS: 50_000_000,
+            engineSupervisor: supervisor,
+            probe: probe
+        )
 
+        let result = await manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+
+        #expect(result == .failed("Orbit Cockpit could not verify the managed gh-orbit engine."))
         #expect(!manager.isEngineReady)
+        #expect(manager.ownershipState == .ownedFailed)
+        #expect(supervisor.startCalls == 1)
+        #expect(supervisor.stopCalls == 1)
+    }
 
-        let trueURL = URL(fileURLWithPath: "/usr/bin/true")
+    @Test("NativeEngineManager reuses healthy external engine")
+    func testReusesHealthyEngine() async throws {
+        let probe = MockProbe(results: [true])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/reused.sock",
+            engineSupervisor: supervisor,
+            probe: probe
+        )
 
-        let startTime = Date()
-        await manager.startEngine(executable: trueURL)
-        let duration = Date().timeIntervalSince(startTime)
+        let result = await manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
 
+        #expect(result == .reused)
+        #expect(manager.isEngineReady)
+        #expect(manager.ownershipState == .reused)
+        #expect(supervisor.startCalls == 0)
+    }
+
+    @Test("NativeEngineManager marks owned engine ready after verification")
+    func testOwnedEngineReady() async throws {
+        let probe = MockProbe(results: [false, true])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/owned.sock",
+            engineSupervisor: supervisor,
+            probe: probe
+        )
+
+        let result = await manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+
+        #expect(result == .ownedReady)
+        #expect(manager.isEngineReady)
+        #expect(manager.ownershipState == .ownedReady)
+        #expect(supervisor.startCalls == 1)
+        #expect(supervisor.stopCalls == 0)
+    }
+
+    @Test("NativeEngineManager bounds stalled probe handling")
+    func testStalledProbeTimesOut() async throws {
+        let probe = MockProbe(steps: [
+            .init(result: false, delayNS: 1_000_000_000),
+            .init(result: false, delayNS: 1_000_000_000),
+        ])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/stalled.sock",
+            maxAttempts: 5,
+            baseDelayNS: 1_000_000,
+            probeTimeoutNS: 50_000_000,
+            engineSupervisor: supervisor,
+            probe: probe
+        )
+
+        let start = Date()
+        let result = await manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+        let duration = Date().timeIntervalSince(start)
+
+        #expect(result == .failed("Orbit Cockpit could not verify the managed gh-orbit engine."))
+        #expect(duration < 0.25)
+        #expect(supervisor.startCalls == 1)
+        #expect(supervisor.stopCalls == 1)
+        #expect(manager.ownershipState == .ownedFailed)
+    }
+
+    @Test("NativeEngineManager shares inflight startup across concurrent callers")
+    func testConcurrentStartSharesSingleStartupTask() async throws {
+        let probe = MockProbe(steps: [
+            .init(result: false, delayNS: 0),
+            .init(result: true, delayNS: 50_000_000),
+        ])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/concurrent.sock",
+            maxAttempts: 5,
+            baseDelayNS: 1_000_000,
+            probeTimeoutNS: 500_000_000,
+            engineSupervisor: supervisor,
+            probe: probe
+        )
+
+        async let first = manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+        async let second = manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+        let firstResult = await first
+        let secondResult = await second
+
+        #expect(firstResult == .ownedReady)
+        #expect(secondResult == .ownedReady)
+        #expect(supervisor.startCalls == 1)
+        #expect(await probe.callCount == 2)
+        #expect(manager.ownershipState == .ownedReady)
+        #expect(manager.isEngineReady)
+    }
+
+    @Test("stopEngine leaves reused engine untouched")
+    func testStopEngineDoesNotKillReusedEngine() async throws {
+        let probe = MockProbe(results: [true])
+        let supervisor = MockSupervisor()
+        let manager = NativeEngineManager(
+            socketPath: "/tmp/reused.sock",
+            engineSupervisor: supervisor,
+            probe: probe
+        )
+
+        _ = await manager.startEngine(executable: URL(fileURLWithPath: "/usr/bin/true"))
+        manager.stopEngine()
+
+        #expect(supervisor.stopCalls == 0)
+        #expect(manager.ownershipState == .idle)
         #expect(!manager.isEngineReady)
-        // 5 attempts with 1ms base should take at least ~60ms (2+4+8+16+32)
-        #expect(duration > 0.05)
     }
 
     @Test("PathResolver binary discovery logic")

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -47,4 +47,16 @@ struct TerminalManagerTests {
         #expect(didFire)
         cancellable.cancel()
     }
+
+    @Test("Shutdown clears ready state")
+    @MainActor
+    func testShutdownClearsEngineReadiness() async throws {
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
+
+        manager.engineManager?.isEngineReady = true
+        manager.shutdown()
+
+        #expect(manager.engineManager?.isEngineReady == false)
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #274.

This changes Orbit Cockpit startup so cockpit-managed panes only launch after a verified MCP-backed engine is available, and prevents duplicate engine startup across concurrent pane launches.

## What changed
- Replace Cockpit's socket-file readiness heuristic with a bounded MCP `initialize` probe.
- Reuse an existing healthy engine when possible instead of spawning a duplicate process.
- Track engine ownership state so Cockpit only stops engines it started.
- Fail closed for cockpit-managed pane launches via `GH_ORBIT_REQUIRE_ENGINE`, while keeping plain `gh orbit` CLI fallback behavior unchanged.
- Share a single in-flight engine startup task across concurrent pane launches.
- Add deterministic native lifecycle tests for reuse, owned startup success/failure, bounded stalled-probe handling, and concurrent startup sharing.

## Verification
- `go test ./cmd/gh-orbit`
- `swift test --disable-sandbox --build-path /Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-build`

## Notes
- Reviewer sign-off completed in `.agents/feedback.md`.
- Direct `gh orbit` launches still retain standalone fallback semantics because fail-closed behavior is scoped to Cockpit-managed launches only.
