### PR TITLE
Fix TUI shutdown nil-safe optional subsystem handling

### DIFF
--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestNewModel_Guards(t *testing.T) {
@@ -62,4 +63,24 @@ func TestNewModel_Guards(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "alerter is required")
 	})
+}
+
+func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic = nil
+	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(mock.Anything).Return().Once()
+	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(mock.Anything).Return().Once()
+	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(mock.Anything).Return().Once()
+
+	m.Shutdown()
+}
+
+func TestModel_Shutdown_StandaloneModeShutsDownAllSubsystems(t *testing.T) {
+	m := newTestModel(t)
+	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(mock.Anything).Return().Once()
+	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(mock.Anything).Return().Once()
+	m.traffic.(*mocks.MockTrafficController).EXPECT().Shutdown(mock.Anything).Return().Once()
+	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(mock.Anything).Return().Once()
+
+	m.Shutdown()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -281,10 +281,18 @@ func (m *Model) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	m.sync.Shutdown(ctx)
-	m.enrich.Shutdown(ctx)
-	m.traffic.Shutdown(ctx)
-	m.alerter.Shutdown(ctx)
+	if m.sync != nil {
+		m.sync.Shutdown(ctx)
+	}
+	if m.enrich != nil {
+		m.enrich.Shutdown(ctx)
+	}
+	if m.traffic != nil {
+		m.traffic.Shutdown(ctx)
+	}
+	if m.alerter != nil {
+		m.alerter.Shutdown(ctx)
+	}
 }
 
 func (m *Model) submitTask(priority int, fn types.TaskFunc) tea.Cmd {


### PR DESCRIPTION
## Summary
- make `Model.Shutdown()` tolerate the connected-mode `Traffic == nil` case
- preserve normal standalone shutdown calls for non-nil subsystems
- add paired shutdown regression tests for connected and standalone behavior

## Testing
- `env GOCACHE=$(pwd)/tmp/go-cache TMPDIR=$(pwd)/tmp go test ./internal/tui ./cmd/gh-orbit`

Closes #280