### PR TITLE
Handle skip-auth request construction errors

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -102,7 +102,10 @@ func NewTestClient(http *http.Client, baseURL string) Client {
 // CurrentUser retrieves the authenticated user's information.
 func (c *ghClient) CurrentUser(ctx context.Context) (*User, error) {
 	if os.Getenv("GH_ORBIT_SKIP_AUTH") == "1" {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"user", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"user", nil)
+		if err != nil {
+			return nil, err
+		}
 		resp, err := c.http.Do(req) // #nosec G704: Trusted E2E mock URL
 		if err != nil {
 			return nil, err
@@ -141,7 +144,10 @@ func (c *ghClient) CurrentUser(ctx context.Context) (*User, error) {
 func (c *ghClient) MarkThreadAsRead(ctx context.Context, threadID string) error {
 	if os.Getenv("GH_ORBIT_SKIP_AUTH") == "1" {
 		path := fmt.Sprintf("%snotifications/threads/%s", c.baseURL, threadID)
-		req, _ := http.NewRequestWithContext(ctx, http.MethodPatch, path, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, path, nil)
+		if err != nil {
+			return err
+		}
 		resp, err := c.http.Do(req) // #nosec G704: Trusted E2E mock URL
 		if err != nil {
 			return err

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -30,6 +30,15 @@ func TestGHClient_Methods(t *testing.T) {
 		assert.Equal(t, expectedUser.Login, user.Login)
 	})
 
+	t.Run("CurrentUser returns request construction error for malformed base URL", func(t *testing.T) {
+		t.Setenv("GH_ORBIT_SKIP_AUTH", "1")
+
+		client := NewTestClient(http.DefaultClient, "://bad-base/")
+		user, err := client.CurrentUser(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, user)
+	})
+
 	t.Run("MarkThreadAsRead", func(t *testing.T) {
 		t.Setenv("GH_ORBIT_SKIP_AUTH", "1")
 
@@ -43,6 +52,14 @@ func TestGHClient_Methods(t *testing.T) {
 		client := NewTestClient(ts.Client(), ts.URL+"/")
 		err := client.MarkThreadAsRead(context.Background(), "123")
 		require.NoError(t, err)
+	})
+
+	t.Run("MarkThreadAsRead returns request construction error for malformed base URL", func(t *testing.T) {
+		t.Setenv("GH_ORBIT_SKIP_AUTH", "1")
+
+		client := NewTestClient(http.DefaultClient, "://bad-base/")
+		err := client.MarkThreadAsRead(context.Background(), "123")
+		require.Error(t, err)
 	})
 
 	t.Run("RateLimit Reporting", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- return `http.NewRequestWithContext(...)` errors in the skip-auth `CurrentUser(...)` and `MarkThreadAsRead(...)` paths
- keep successful skip-auth behavior unchanged
- add focused malformed-base-URL coverage for both affected methods

## Testing
- `env GOCACHE=$(pwd)/tmp/go-cache TMPDIR=$(pwd)/tmp go test ./internal/github`

Closes #279