### PR TITLE
Implement MCP enrichment for connected mode

### DIFF
--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -123,7 +123,21 @@ func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) e
 
 // No-ops for client mode (Engine is authority)
 func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
-	return nil
+	_, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "enrich_notification",
+			Arguments: map[string]any{
+				"id":                 id,
+				"node_id":            nodeID,
+				"body":               body,
+				"author":             author,
+				"html_url":           htmlURL,
+				"resource_state":     resourceState,
+				"resource_sub_state": resourceSubState,
+			},
+		},
+	})
+	return err
 }
 
 func (a *MCPAdapter) UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, resourceSubState string) error {
@@ -192,11 +206,61 @@ func (a *MCPAdapter) BridgeStatus() types.BridgeStatus { return types.StatusHeal
 // --- types.Enricher Implementation ---
 
 func (a *MCPAdapter) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
-	return models.EnrichmentResult{}, nil
+	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "fetch_detail",
+			Arguments: map[string]any{
+				"url":          u,
+				"subject_type": subjectType,
+				"force":        force,
+			},
+		},
+	})
+	if err != nil {
+		return models.EnrichmentResult{}, err
+	}
+
+	if resp.IsError {
+		content, _ := resp.Content[0].(mcp.TextContent)
+		return models.EnrichmentResult{}, fmt.Errorf("fetch detail error: %s", content.Text)
+	}
+
+	var result models.EnrichmentResult
+	if len(resp.Content) > 0 {
+		if text, ok := resp.Content[0].(mcp.TextContent); ok {
+			if err := json.Unmarshal([]byte(text.Text), &result); err != nil {
+				return models.EnrichmentResult{}, err
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func (a *MCPAdapter) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
-	return nil
+	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "fetch_hybrid_batch",
+			Arguments: map[string]any{
+				"notifications": notifications,
+				"force":         force,
+			},
+		},
+	})
+	if err != nil || resp == nil || resp.IsError {
+		return nil
+	}
+
+	var results map[string]models.EnrichmentResult
+	if len(resp.Content) > 0 {
+		if text, ok := resp.Content[0].(mcp.TextContent); ok {
+			if err := json.Unmarshal([]byte(text.Text), &results); err != nil {
+				return nil
+			}
+		}
+	}
+
+	return results
 }
 
 // --- api.Alerter Implementation ---

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/engine/transport"
+	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -391,6 +392,120 @@ func (s *MCPServer) registerTools() {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to set priority: %v", err)), nil
 		}
 		return mcp.NewToolResultText("Priority updated"), nil
+	})
+
+	// 4. Fetch Detail Tool
+	fetchDetailTool := mcp.NewTool("fetch_detail",
+		mcp.WithDescription("Fetch enriched detail for a single notification subject"),
+		mcp.WithString("url", mcp.Required(), mcp.Description("The GitHub API subject URL")),
+		mcp.WithString("subject_type", mcp.Required(), mcp.Description("The GitHub subject type")),
+		mcp.WithBoolean("force", mcp.Description("Whether to bypass freshness checks")),
+	)
+
+	s.server.AddTool(fetchDetailTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid arguments format"), nil
+		}
+
+		url, _ := args["url"].(string)
+		subjectType, _ := args["subject_type"].(string)
+		if url == "" || subjectType == "" {
+			return mcp.NewToolResultError("url and subject_type are required"), nil
+		}
+
+		force := false
+		if f, ok := args["force"].(bool); ok {
+			force = f
+		}
+
+		res, err := s.engine.Enrich.FetchDetail(ctx, url, subjectType, force)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch detail: %v", err)), nil
+		}
+
+		data, _ := json.Marshal(res)
+		return mcp.NewToolResultText(string(data)), nil
+	})
+
+	// 5. Batch Enrichment Tool
+	batchEnrichTool := mcp.NewTool("fetch_hybrid_batch",
+		mcp.WithDescription("Fetch enrichment state for a batch of notifications"),
+		mcp.WithArray("notifications",
+			mcp.Required(),
+			mcp.Description("Notification records to enrich; response is keyed by subject_node_id"),
+			mcp.Items(map[string]any{"type": "object"}),
+		),
+		mcp.WithBoolean("force", mcp.Description("Whether to bypass freshness checks")),
+	)
+
+	s.server.AddTool(batchEnrichTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid arguments format"), nil
+		}
+
+		rawNotifications, ok := args["notifications"]
+		if !ok {
+			return mcp.NewToolResultError("notifications is required"), nil
+		}
+
+		payload, err := json.Marshal(rawNotifications)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to parse notifications: %v", err)), nil
+		}
+
+		var notifications []triage.NotificationWithState
+		if err := json.Unmarshal(payload, &notifications); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to decode notifications: %v", err)), nil
+		}
+
+		force := false
+		if f, ok := args["force"].(bool); ok {
+			force = f
+		}
+
+		// Keep the response keyed by SubjectNodeID to match the TUI batch update contract.
+		results := s.engine.Enrich.FetchHybridBatch(ctx, notifications, force)
+		data, _ := json.Marshal(results)
+		return mcp.NewToolResultText(string(data)), nil
+	})
+
+	// 6. Enrichment Persistence Tool
+	enrichNotificationTool := mcp.NewTool("enrich_notification",
+		mcp.WithDescription("Persist enriched notification fields through the engine-backed repository"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The GitHub notification ID")),
+		mcp.WithString("node_id", mcp.Description("The GitHub subject node ID")),
+		mcp.WithString("body", mcp.Description("The enriched body text")),
+		mcp.WithString("author", mcp.Description("The enriched author login")),
+		mcp.WithString("html_url", mcp.Description("The canonical GitHub HTML URL")),
+		mcp.WithString("resource_state", mcp.Description("The enriched resource state")),
+		mcp.WithString("resource_sub_state", mcp.Description("The enriched resource sub state")),
+	)
+
+	s.server.AddTool(enrichNotificationTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid arguments format"), nil
+		}
+
+		id, _ := args["id"].(string)
+		if id == "" {
+			return mcp.NewToolResultError("id is required"), nil
+		}
+
+		nodeID, _ := args["node_id"].(string)
+		body, _ := args["body"].(string)
+		author, _ := args["author"].(string)
+		htmlURL, _ := args["html_url"].(string)
+		resourceState, _ := args["resource_state"].(string)
+		resourceSubState, _ := args["resource_sub_state"].(string)
+
+		if err := s.engine.DB.EnrichNotification(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to persist enrichment: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText("Notification enrichment persisted"), nil
 	})
 }
 

--- a/internal/engine/mcp_enrichment_test.go
+++ b/internal/engine/mcp_enrichment_test.go
@@ -1,0 +1,269 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/triage"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	clienttransport "github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newInMemoryMCPClient(t *testing.T, srv *MCPServer) *mcpclient.Client {
+	t.Helper()
+
+	serverReader, clientWriter := io.Pipe()
+	clientReader, serverWriter := io.Pipe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		stdioServer := mcpserver.NewStdioServer(srv.server)
+		_ = stdioServer.Listen(ctx, serverReader, serverWriter)
+	}()
+
+	var logBuf bytes.Buffer
+	transport := clienttransport.NewIO(clientReader, clientWriter, io.NopCloser(&logBuf))
+	require.NoError(t, transport.Start(ctx))
+
+	client := mcpclient.NewClient(transport)
+	var initReq mcp.InitializeRequest
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	_, err := client.Initialize(ctx, initReq)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = transport.Close()
+		cancel()
+		_ = serverWriter.Close()
+		_ = serverReader.Close()
+		_ = clientWriter.Close()
+		_ = clientReader.Close()
+		wg.Wait()
+	})
+
+	return client
+}
+
+func newTestMCPServerForEnrichment(t *testing.T) (*MCPServer, *mocks.MockRepository, *mocks.MockEnricher) {
+	t.Helper()
+
+	mockRepo := mocks.NewMockRepository(t)
+	mockEnrich := mocks.NewMockEnricher(t)
+	mockGH := mocks.NewMockGitHubClient(t)
+	mockSync := mocks.NewMockSyncer(t)
+
+	engine := &CoreEngine{
+		DB:     mockRepo,
+		Enrich: mockEnrich,
+		Client: mockGH,
+		Sync:   mockSync,
+	}
+
+	return NewMCPServer(engine, "/tmp/test.sock", true, false), mockRepo, mockEnrich
+}
+
+func decodeTextResult[T any](t *testing.T, resp *mcp.CallToolResult) T {
+	t.Helper()
+
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError)
+	require.NotEmpty(t, resp.Content)
+
+	text, ok := resp.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	var out T
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &out))
+	return out
+}
+
+func TestMCPServer_EnrichmentTools(t *testing.T) {
+	srv, mockRepo, mockEnrich := newTestMCPServerForEnrichment(t)
+	client := newInMemoryMCPClient(t, srv)
+
+	t.Run("fetch_detail returns a real enrichment payload", func(t *testing.T) {
+		expected := models.EnrichmentResult{
+			SubjectNodeID:    "node-1",
+			Body:             "detail body",
+			HTMLURL:          "https://github.com/o/r/pull/1",
+			Author:           "hirakiuc",
+			ResourceState:    "OPEN",
+			ResourceSubState: "APPROVED",
+		}
+		mockEnrich.EXPECT().
+			FetchDetail(mock.Anything, "https://api.github.com/repos/o/r/pulls/1", "PullRequest", true).
+			Return(expected, nil).
+			Once()
+
+		resp, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "fetch_detail",
+				Arguments: map[string]any{
+					"url":          "https://api.github.com/repos/o/r/pulls/1",
+					"subject_type": "PullRequest",
+					"force":        true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		got := decodeTextResult[models.EnrichmentResult](t, resp)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("fetch_hybrid_batch returns a node-id keyed map", func(t *testing.T) {
+		notifications := []triage.NotificationWithState{
+			{
+				Notification: triage.Notification{
+					GitHubID:      "1",
+					SubjectNodeID: "node-1",
+					SubjectType:   triage.SubjectPullRequest,
+				},
+			},
+		}
+		expected := map[string]models.EnrichmentResult{
+			"node-1": {
+				ResourceState:    "MERGED",
+				ResourceSubState: "APPROVED",
+			},
+		}
+		mockEnrich.EXPECT().
+			FetchHybridBatch(mock.Anything, notifications, true).
+			Return(expected).
+			Once()
+
+		resp, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "fetch_hybrid_batch",
+				Arguments: map[string]any{
+					"notifications": notifications,
+					"force":         true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		got := decodeTextResult[map[string]models.EnrichmentResult](t, resp)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("enrich_notification persists enriched fields", func(t *testing.T) {
+		mockRepo.EXPECT().
+			EnrichNotification(mock.Anything, "1", "node-1", "detail body", "hirakiuc", "https://github.com/o/r/pull/1", "OPEN", "APPROVED").
+			Return(nil).
+			Once()
+
+		resp, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "enrich_notification",
+				Arguments: map[string]any{
+					"id":                 "1",
+					"node_id":            "node-1",
+					"body":               "detail body",
+					"author":             "hirakiuc",
+					"html_url":           "https://github.com/o/r/pull/1",
+					"resource_state":     "OPEN",
+					"resource_sub_state": "APPROVED",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.False(t, resp.IsError)
+	})
+}
+
+func TestMCPAdapter_FetchDetail_ThroughMCP(t *testing.T) {
+	srv, _, mockEnrich := newTestMCPServerForEnrichment(t)
+	client := newInMemoryMCPClient(t, srv)
+	adapter := NewMCPAdapter(client)
+
+	expected := models.EnrichmentResult{
+		SubjectNodeID: "node-2",
+		Body:          "adapter detail body",
+		Author:        "reviewer",
+		HTMLURL:       "https://github.com/o/r/issues/2",
+	}
+	mockEnrich.EXPECT().
+		FetchDetail(mock.Anything, "https://api.github.com/repos/o/r/issues/2", "Issue", false).
+		Return(expected, nil).
+		Once()
+
+	got, err := adapter.FetchDetail(context.Background(), "https://api.github.com/repos/o/r/issues/2", "Issue", false)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestMCPAdapter_FetchHybridBatch_ThroughMCP(t *testing.T) {
+	srv, _, mockEnrich := newTestMCPServerForEnrichment(t)
+	client := newInMemoryMCPClient(t, srv)
+	adapter := NewMCPAdapter(client)
+
+	notifications := []triage.NotificationWithState{
+		{
+			Notification: triage.Notification{
+				GitHubID:      "2",
+				SubjectNodeID: "node-2",
+				SubjectType:   triage.SubjectIssue,
+			},
+		},
+	}
+	expected := map[string]models.EnrichmentResult{
+		"node-2": {
+			ResourceState:    "CLOSED",
+			ResourceSubState: "COMPLETED",
+		},
+	}
+	mockEnrich.EXPECT().
+		FetchHybridBatch(mock.Anything, notifications, false).
+		Return(expected).
+		Once()
+
+	got := adapter.FetchHybridBatch(context.Background(), notifications, false)
+	assert.Equal(t, expected, got)
+}
+
+func TestMCPAdapter_SingleItemEnrichmentFlow_ThroughMCP(t *testing.T) {
+	srv, mockRepo, mockEnrich := newTestMCPServerForEnrichment(t)
+	client := newInMemoryMCPClient(t, srv)
+	adapter := NewMCPAdapter(client)
+
+	expected := models.EnrichmentResult{
+		SubjectNodeID:    "node-3",
+		Body:             "persisted detail body",
+		Author:           "octocat",
+		HTMLURL:          "https://github.com/o/r/pull/3",
+		ResourceState:    "OPEN",
+		ResourceSubState: "REVIEW_REQUIRED",
+	}
+	mockEnrich.EXPECT().
+		FetchDetail(mock.Anything, "https://api.github.com/repos/o/r/pulls/3", "PullRequest", true).
+		Return(expected, nil).
+		Once()
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-3", "node-3", "persisted detail body", "octocat", "https://github.com/o/r/pull/3", "OPEN", "REVIEW_REQUIRED").
+		Return(nil).
+		Once()
+
+	result, err := adapter.FetchDetail(context.Background(), "https://api.github.com/repos/o/r/pulls/3", "PullRequest", true)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+
+	err = adapter.EnrichNotification(context.Background(), "notif-3", result.SubjectNodeID, result.Body, result.Author, result.HTMLURL, result.ResourceState, result.ResourceSubState)
+	require.NoError(t, err)
+}

--- a/internal/engine/mcp_registration_test.go
+++ b/internal/engine/mcp_registration_test.go
@@ -29,11 +29,15 @@ func TestMCPServer_Registration_Coverage(t *testing.T) {
 
 	t.Run("Initialization coverage", func(t *testing.T) {
 		assert.NotNil(t, s.server)
-		
+
 		// This exercises registration closures
 		s.registerTools()
 		s.registerResources()
-		
-		assert.Greater(t, len(s.server.ListTools()), 0)
+
+		tools := s.server.ListTools()
+		assert.Greater(t, len(tools), 0)
+		assert.Contains(t, tools, "fetch_detail")
+		assert.Contains(t, tools, "fetch_hybrid_batch")
+		assert.Contains(t, tools, "enrich_notification")
 	})
 }


### PR DESCRIPTION
## Summary
- expose connected-mode enrichment over MCP with single-item fetch, batch enrichment, and persistence tools
- wire `MCPAdapter` through those tools for detail loading, batched enrichment, and `EnrichNotification(...)`
- add focused in-memory MCP tests covering server behavior and adapter decoding/forwarding

## Testing
- `env GOCACHE=$(pwd)/tmp/go-cache TMPDIR=$(pwd)/tmp go test ./internal/engine`
- `env GOCACHE=$(pwd)/tmp/go-cache TMPDIR=$(pwd)/tmp go test ./cmd/gh-orbit ./internal/engine`

Closes #281