### PR TITLE
Run Swift CodeQL weekly and manually

### DIFF
--- a/.github/workflows/codeql-swift.yml
+++ b/.github/workflows/codeql-swift.yml
@@ -1,11 +1,7 @@
-name: CodeQL (swift)
+# Swift CodeQL is intentionally limited to scheduled and manual runs.
+name: CodeQL (swift weekly/manual)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - "native/**"
   schedule:
     - cron: "0 0 * * 6"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- remove the push trigger from the Swift CodeQL workflow
- keep the weekly schedule and existing workflow_dispatch manual run path
- make the scheduled/manual-only policy explicit in the workflow file

## Verification
- confirmed `.github/workflows/codeql-swift.yml` now only uses `schedule` and `workflow_dispatch`
- confirmed the Swift CodeQL job body remains unchanged

Closes #306
