### PR TITLE
Fix traffic controller shutdown rate-limit panic

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -420,7 +420,7 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 
 func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.CoreEngine, userID string) error {
 	// Step 6.15: Connect Client to TrafficController for intelligent rate limit propagation
-	eng.Client.SetRateLimitUpdates(eng.Traffic.RateLimitUpdates())
+	eng.Client.SetRateLimitReporter(eng.Traffic.ReportRateLimit)
 
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,

--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -86,8 +86,14 @@ func (c *APITrafficController) Remaining() int {
 	return c.rlInfo.Load().Remaining
 }
 
-func (c *APITrafficController) RateLimitUpdates() chan models.RateLimitInfo {
-	return c.rateLimitUpdates
+func (c *APITrafficController) ReportRateLimit(info models.RateLimitInfo) {
+	select {
+	case <-c.done:
+		// Drop late updates after shutdown starts.
+	case c.rateLimitUpdates <- info:
+	default:
+		// Drop update if channel is full.
+	}
 }
 
 func (c *APITrafficController) Submit(priority int, fn types.TaskFunc) (<-chan any, error) {
@@ -255,8 +261,6 @@ func (c *APITrafficController) rateLimitListener() {
 
 func (c *APITrafficController) Shutdown(ctx context.Context) {
 	close(c.done)
-	// Ensure listener goroutine stops
-	close(c.rateLimitUpdates)
 
 	// Drain remaining tasks to unblock any callers
 	c.drainQueue(c.high)

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -21,11 +21,11 @@ func TestAPITrafficController_Background(t *testing.T) {
 		defer tc.Shutdown(ctx)
 
 		// 1. RateLimitListener scaling
-		tc.RateLimitUpdates() <- models.RateLimitInfo{Remaining: 100}
+		tc.ReportRateLimit(models.RateLimitInfo{Remaining: 100})
 		synctest.Wait()
 		assert.Equal(t, int32(1), atomic.LoadInt32(&tc.workerLimit))
 
-		tc.RateLimitUpdates() <- models.RateLimitInfo{Remaining: 1000}
+		tc.ReportRateLimit(models.RateLimitInfo{Remaining: 1000})
 		synctest.Wait()
 		assert.Equal(t, int32(3), atomic.LoadInt32(&tc.workerLimit))
 
@@ -70,5 +70,19 @@ func TestAPITrafficController_Shutdown_Channels(t *testing.T) {
 		_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "shutdown")
+	})
+}
+
+func TestAPITrafficController_ReportRateLimit_AfterShutdownDoesNotPanic(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+
+		tc.Shutdown(ctx)
+		synctest.Wait()
+
+		assert.NotPanics(t, func() {
+			tc.ReportRateLimit(models.RateLimitInfo{Remaining: 42})
+		})
 	})
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -16,27 +16,24 @@ import (
 
 // ghClient wraps the GitHub REST and GQL API clients.
 type ghClient struct {
-	rest             *gh.RESTClient
-	gql              *gh.GraphQLClient
-	http             *http.Client
-	host             string
-	baseURL          string
-	rateLimitUpdates chan models.RateLimitInfo
+	rest              *gh.RESTClient
+	gql               *gh.GraphQLClient
+	http              *http.Client
+	host              string
+	baseURL           string
+	rateLimitReporter func(models.RateLimitInfo)
 }
 
-func (c *ghClient) SetRateLimitUpdates(ch chan models.RateLimitInfo) {
-	c.rateLimitUpdates = ch
+func (c *ghClient) SetRateLimitReporter(fn func(models.RateLimitInfo)) {
+	c.rateLimitReporter = fn
 }
 
 func (c *ghClient) ReportRateLimit(info models.RateLimitInfo) {
-	if c.rateLimitUpdates == nil {
+	if c.rateLimitReporter == nil {
 		return
 	}
-	select {
-	case c.rateLimitUpdates <- info:
-	default:
-		// Drop update if channel is full or nobody is listening
-	}
+
+	c.rateLimitReporter(info)
 }
 
 // NewClient initializes a new GitHub API client using go-gh.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -64,7 +64,11 @@ func TestGHClient_Methods(t *testing.T) {
 
 	t.Run("RateLimit Reporting", func(t *testing.T) {
 		updates := make(chan models.RateLimitInfo, 1)
-		client := &ghClient{rateLimitUpdates: updates}
+		client := &ghClient{
+			rateLimitReporter: func(info models.RateLimitInfo) {
+				updates <- info
+			},
+		}
 
 		info := models.RateLimitInfo{Remaining: 100}
 		client.ReportRateLimit(info)
@@ -75,6 +79,13 @@ func TestGHClient_Methods(t *testing.T) {
 		default:
 			t.Fatal("expected rate limit update")
 		}
+	})
+
+	t.Run("RateLimit Reporting Without Reporter Is Noop", func(t *testing.T) {
+		client := &ghClient{}
+		assert.NotPanics(t, func() {
+			client.ReportRateLimit(models.RateLimitInfo{Remaining: 100})
+		})
 	})
 }
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -48,7 +48,7 @@ type Client interface {
 	GQL() GraphQLClient
 	HTTP() *http.Client
 	BaseURL() string
-	SetRateLimitUpdates(ch chan models.RateLimitInfo)
+	SetRateLimitReporter(fn func(models.RateLimitInfo))
 	ReportRateLimit(info models.RateLimitInfo)
 }
 

--- a/internal/mocks/mock_client.go
+++ b/internal/mocks/mock_client.go
@@ -350,35 +350,35 @@ func (_c *MockClient_ReportRateLimit_Call) RunAndReturn(run func(models.RateLimi
 	return _c
 }
 
-// SetRateLimitUpdates provides a mock function with given fields: ch
-func (_m *MockClient) SetRateLimitUpdates(ch chan models.RateLimitInfo) {
-	_m.Called(ch)
+// SetRateLimitReporter provides a mock function with given fields: fn
+func (_m *MockClient) SetRateLimitReporter(fn func(models.RateLimitInfo)) {
+	_m.Called(fn)
 }
 
-// MockClient_SetRateLimitUpdates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRateLimitUpdates'
-type MockClient_SetRateLimitUpdates_Call struct {
+// MockClient_SetRateLimitReporter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRateLimitReporter'
+type MockClient_SetRateLimitReporter_Call struct {
 	*mock.Call
 }
 
-// SetRateLimitUpdates is a helper method to define mock.On call
-//   - ch chan models.RateLimitInfo
-func (_e *MockClient_Expecter) SetRateLimitUpdates(ch interface{}) *MockClient_SetRateLimitUpdates_Call {
-	return &MockClient_SetRateLimitUpdates_Call{Call: _e.mock.On("SetRateLimitUpdates", ch)}
+// SetRateLimitReporter is a helper method to define mock.On call
+//   - fn func(models.RateLimitInfo)
+func (_e *MockClient_Expecter) SetRateLimitReporter(fn interface{}) *MockClient_SetRateLimitReporter_Call {
+	return &MockClient_SetRateLimitReporter_Call{Call: _e.mock.On("SetRateLimitReporter", fn)}
 }
 
-func (_c *MockClient_SetRateLimitUpdates_Call) Run(run func(ch chan models.RateLimitInfo)) *MockClient_SetRateLimitUpdates_Call {
+func (_c *MockClient_SetRateLimitReporter_Call) Run(run func(fn func(models.RateLimitInfo))) *MockClient_SetRateLimitReporter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(chan models.RateLimitInfo))
+		run(args[0].(func(models.RateLimitInfo)))
 	})
 	return _c
 }
 
-func (_c *MockClient_SetRateLimitUpdates_Call) Return() *MockClient_SetRateLimitUpdates_Call {
+func (_c *MockClient_SetRateLimitReporter_Call) Return() *MockClient_SetRateLimitReporter_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockClient_SetRateLimitUpdates_Call) RunAndReturn(run func(chan models.RateLimitInfo)) *MockClient_SetRateLimitUpdates_Call {
+func (_c *MockClient_SetRateLimitReporter_Call) RunAndReturn(run func(func(models.RateLimitInfo))) *MockClient_SetRateLimitReporter_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/mocks/mock_git_hub_client.go
+++ b/internal/mocks/mock_git_hub_client.go
@@ -350,35 +350,35 @@ func (_c *MockGitHubClient_ReportRateLimit_Call) RunAndReturn(run func(models.Ra
 	return _c
 }
 
-// SetRateLimitUpdates provides a mock function with given fields: ch
-func (_m *MockGitHubClient) SetRateLimitUpdates(ch chan models.RateLimitInfo) {
-	_m.Called(ch)
+// SetRateLimitReporter provides a mock function with given fields: fn
+func (_m *MockGitHubClient) SetRateLimitReporter(fn func(models.RateLimitInfo)) {
+	_m.Called(fn)
 }
 
-// MockGitHubClient_SetRateLimitUpdates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRateLimitUpdates'
-type MockGitHubClient_SetRateLimitUpdates_Call struct {
+// MockGitHubClient_SetRateLimitReporter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRateLimitReporter'
+type MockGitHubClient_SetRateLimitReporter_Call struct {
 	*mock.Call
 }
 
-// SetRateLimitUpdates is a helper method to define mock.On call
-//   - ch chan models.RateLimitInfo
-func (_e *MockGitHubClient_Expecter) SetRateLimitUpdates(ch interface{}) *MockGitHubClient_SetRateLimitUpdates_Call {
-	return &MockGitHubClient_SetRateLimitUpdates_Call{Call: _e.mock.On("SetRateLimitUpdates", ch)}
+// SetRateLimitReporter is a helper method to define mock.On call
+//   - fn func(models.RateLimitInfo)
+func (_e *MockGitHubClient_Expecter) SetRateLimitReporter(fn interface{}) *MockGitHubClient_SetRateLimitReporter_Call {
+	return &MockGitHubClient_SetRateLimitReporter_Call{Call: _e.mock.On("SetRateLimitReporter", fn)}
 }
 
-func (_c *MockGitHubClient_SetRateLimitUpdates_Call) Run(run func(ch chan models.RateLimitInfo)) *MockGitHubClient_SetRateLimitUpdates_Call {
+func (_c *MockGitHubClient_SetRateLimitReporter_Call) Run(run func(fn func(models.RateLimitInfo))) *MockGitHubClient_SetRateLimitReporter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(chan models.RateLimitInfo))
+		run(args[0].(func(models.RateLimitInfo)))
 	})
 	return _c
 }
 
-func (_c *MockGitHubClient_SetRateLimitUpdates_Call) Return() *MockGitHubClient_SetRateLimitUpdates_Call {
+func (_c *MockGitHubClient_SetRateLimitReporter_Call) Return() *MockGitHubClient_SetRateLimitReporter_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockGitHubClient_SetRateLimitUpdates_Call) RunAndReturn(run func(chan models.RateLimitInfo)) *MockGitHubClient_SetRateLimitUpdates_Call {
+func (_c *MockGitHubClient_SetRateLimitReporter_Call) RunAndReturn(run func(func(models.RateLimitInfo))) *MockGitHubClient_SetRateLimitReporter_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/mocks/mock_traffic_controller.go
+++ b/internal/mocks/mock_traffic_controller.go
@@ -24,53 +24,6 @@ func (_m *MockTrafficController) EXPECT() *MockTrafficController_Expecter {
 	return &MockTrafficController_Expecter{mock: &_m.Mock}
 }
 
-// RateLimitUpdates provides a mock function with no fields
-func (_m *MockTrafficController) RateLimitUpdates() chan models.RateLimitInfo {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for RateLimitUpdates")
-	}
-
-	var r0 chan models.RateLimitInfo
-	if rf, ok := ret.Get(0).(func() chan models.RateLimitInfo); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(chan models.RateLimitInfo)
-		}
-	}
-
-	return r0
-}
-
-// MockTrafficController_RateLimitUpdates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RateLimitUpdates'
-type MockTrafficController_RateLimitUpdates_Call struct {
-	*mock.Call
-}
-
-// RateLimitUpdates is a helper method to define mock.On call
-func (_e *MockTrafficController_Expecter) RateLimitUpdates() *MockTrafficController_RateLimitUpdates_Call {
-	return &MockTrafficController_RateLimitUpdates_Call{Call: _e.mock.On("RateLimitUpdates")}
-}
-
-func (_c *MockTrafficController_RateLimitUpdates_Call) Run(run func()) *MockTrafficController_RateLimitUpdates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockTrafficController_RateLimitUpdates_Call) Return(_a0 chan models.RateLimitInfo) *MockTrafficController_RateLimitUpdates_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockTrafficController_RateLimitUpdates_Call) RunAndReturn(run func() chan models.RateLimitInfo) *MockTrafficController_RateLimitUpdates_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Remaining provides a mock function with no fields
 func (_m *MockTrafficController) Remaining() int {
 	ret := _m.Called()
@@ -116,6 +69,39 @@ func (_c *MockTrafficController_Remaining_Call) RunAndReturn(run func() int) *Mo
 	return _c
 }
 
+// ReportRateLimit provides a mock function with given fields: info
+func (_m *MockTrafficController) ReportRateLimit(info models.RateLimitInfo) {
+	_m.Called(info)
+}
+
+// MockTrafficController_ReportRateLimit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReportRateLimit'
+type MockTrafficController_ReportRateLimit_Call struct {
+	*mock.Call
+}
+
+// ReportRateLimit is a helper method to define mock.On call
+//   - info models.RateLimitInfo
+func (_e *MockTrafficController_Expecter) ReportRateLimit(info interface{}) *MockTrafficController_ReportRateLimit_Call {
+	return &MockTrafficController_ReportRateLimit_Call{Call: _e.mock.On("ReportRateLimit", info)}
+}
+
+func (_c *MockTrafficController_ReportRateLimit_Call) Run(run func(info models.RateLimitInfo)) *MockTrafficController_ReportRateLimit_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(models.RateLimitInfo))
+	})
+	return _c
+}
+
+func (_c *MockTrafficController_ReportRateLimit_Call) Return() *MockTrafficController_ReportRateLimit_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockTrafficController_ReportRateLimit_Call) RunAndReturn(run func(models.RateLimitInfo)) *MockTrafficController_ReportRateLimit_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Shutdown provides a mock function with given fields: ctx
 func (_m *MockTrafficController) Shutdown(ctx context.Context) {
 	_m.Called(ctx)
@@ -150,23 +136,23 @@ func (_c *MockTrafficController_Shutdown_Call) RunAndReturn(run func(context.Con
 }
 
 // Submit provides a mock function with given fields: priority, fn
-func (_m *MockTrafficController) Submit(priority int, fn types.TaskFunc) (<-chan any, error) {
+func (_m *MockTrafficController) Submit(priority int, fn types.TaskFunc) (<-chan interface{}, error) {
 	ret := _m.Called(priority, fn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Submit")
 	}
 
-	var r0 <-chan any
+	var r0 <-chan interface{}
 	var r1 error
-	if rf, ok := ret.Get(0).(func(int, types.TaskFunc) (<-chan any, error)); ok {
+	if rf, ok := ret.Get(0).(func(int, types.TaskFunc) (<-chan interface{}, error)); ok {
 		return rf(priority, fn)
 	}
-	if rf, ok := ret.Get(0).(func(int, types.TaskFunc) <-chan any); ok {
+	if rf, ok := ret.Get(0).(func(int, types.TaskFunc) <-chan interface{}); ok {
 		r0 = rf(priority, fn)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan any)
+			r0 = ret.Get(0).(<-chan interface{})
 		}
 	}
 
@@ -198,12 +184,12 @@ func (_c *MockTrafficController_Submit_Call) Run(run func(priority int, fn types
 	return _c
 }
 
-func (_c *MockTrafficController_Submit_Call) Return(_a0 <-chan any, _a1 error) *MockTrafficController_Submit_Call {
+func (_c *MockTrafficController_Submit_Call) Return(_a0 <-chan interface{}, _a1 error) *MockTrafficController_Submit_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTrafficController_Submit_Call) RunAndReturn(run func(int, types.TaskFunc) (<-chan any, error)) *MockTrafficController_Submit_Call {
+func (_c *MockTrafficController_Submit_Call) RunAndReturn(run func(int, types.TaskFunc) (<-chan interface{}, error)) *MockTrafficController_Submit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -105,7 +105,7 @@ type TrafficController interface {
 	Submit(priority int, fn TaskFunc) (<-chan any, error)
 	UpdateRateLimit(ctx context.Context, info models.RateLimitInfo)
 	Remaining() int
-	RateLimitUpdates() chan models.RateLimitInfo
+	ReportRateLimit(info models.RateLimitInfo)
 	Shutdown(ctx context.Context)
 }
 


### PR DESCRIPTION
## Summary
- replace the producer-writable rate-limit channel handoff with a controller-owned reporting callback
- stop closing a producer-facing channel during traffic-controller shutdown
- add regression coverage for post-shutdown rate-limit reporting and update interface/mock fallout

## Verification
- `go test ./internal/api ./internal/github`

Closes #290
