### PR TITLE
Make sandbox-safe HTTP tests avoid listeners

### DIFF
--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -3,10 +3,10 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +19,30 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newHTTPClient(t *testing.T, fn roundTripFunc) *http.Client {
+	t.Helper()
+
+	return &http.Client{Transport: fn}
+}
+
+func newJSONResponse(status int, body string, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = make(http.Header)
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
 
 func TestSyncEngine_Sync(t *testing.T) {
 	ctx := context.Background()
@@ -208,17 +232,17 @@ func TestNewSyncEngine_Guards(t *testing.T) {
 }
 
 func TestConditionalRequest(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := github.NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.Header.Get("If-None-Match") == "etag-123" {
-			w.WriteHeader(http.StatusNotModified)
-			return
+			return newJSONResponse(http.StatusNotModified, "", nil), nil
 		}
-		w.Header().Set("ETag", "etag-123")
-		_ = json.NewEncoder(w).Encode([]github.Notification{})
-	}))
-	defer ts.Close()
+		headers := make(http.Header)
+		headers.Set("ETag", "etag-123")
 
-	client := github.NewTestClient(ts.Client(), ts.URL+"/")
+		body, err := json.Marshal([]github.Notification{})
+		require.NoError(t, err)
+		return newJSONResponse(http.StatusOK, string(body), headers), nil
+	}), "https://api.test/")
 	fetcher := github.NewNotificationFetcher(client, slog.Default())
 	meta := &models.SyncMeta{ETag: "etag-123"}
 
@@ -228,13 +252,14 @@ func TestConditionalRequest(t *testing.T) {
 
 func TestETagSanitization(t *testing.T) {
 	t.Run("Fetcher Ignores Invalid ETags", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("ETag", `W/""`) // Corrupted header
-			_ = json.NewEncoder(w).Encode([]github.Notification{})
-		}))
-		defer ts.Close()
+		client := github.NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+			headers := make(http.Header)
+			headers.Set("ETag", `W/""`) // Corrupted header
 
-		client := github.NewTestClient(ts.Client(), ts.URL+"/")
+			body, err := json.Marshal([]github.Notification{})
+			require.NoError(t, err)
+			return newJSONResponse(http.StatusOK, string(body), headers), nil
+		}), "https://api.test/")
 		fetcher := github.NewNotificationFetcher(client, slog.Default())
 
 		_, newMeta, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)
@@ -244,17 +269,20 @@ func TestETagSanitization(t *testing.T) {
 }
 
 func TestPagination(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := github.NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path == "/notifications" {
-			w.Header().Set("Link", fmt.Sprintf(`<%s/page2>; rel="next"`, "http://"+r.Host))
-			_ = json.NewEncoder(w).Encode([]github.Notification{{ID: "1"}, {ID: "2"}})
-		} else {
-			_ = json.NewEncoder(w).Encode([]github.Notification{{ID: "3"}})
+			headers := make(http.Header)
+			headers.Set("Link", `<https://api.test/page2>; rel="next"`)
+			body, err := json.Marshal([]github.Notification{{ID: "1"}, {ID: "2"}})
+			require.NoError(t, err)
+			return newJSONResponse(http.StatusOK, string(body), headers), nil
 		}
-	}))
-	defer ts.Close()
 
-	client := github.NewTestClient(ts.Client(), ts.URL+"/")
+		assert.Equal(t, "/page2", r.URL.Path)
+		body, err := json.Marshal([]github.Notification{{ID: "3"}})
+		require.NoError(t, err)
+		return newJSONResponse(http.StatusOK, string(body), nil), nil
+	}), "https://api.test/")
 	fetcher := github.NewNotificationFetcher(client, slog.Default())
 
 	notifs, _, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)
@@ -263,12 +291,9 @@ func TestPagination(t *testing.T) {
 }
 
 func TestFetcher_ErrorHandling(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer ts.Close()
-
-	client := github.NewTestClient(ts.Client(), ts.URL+"/")
+	client := github.NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		return newJSONResponse(http.StatusUnauthorized, "", nil), nil
+	}), "https://api.test/")
 	fetcher := github.NewNotificationFetcher(client, slog.Default())
 
 	_, _, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -17,14 +16,15 @@ func TestGHClient_Methods(t *testing.T) {
 		t.Setenv("GH_ORBIT_SKIP_AUTH", "1")
 
 		expectedUser := &User{Login: "test-user"}
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 			assert.Equal(t, "/user", r.URL.Path)
-			w.Header().Set("X-RateLimit-Remaining", "4999")
-			_ = json.NewEncoder(w).Encode(expectedUser)
-		}))
-		defer ts.Close()
+			headers := make(http.Header)
+			headers.Set("X-RateLimit-Remaining", "4999")
 
-		client := NewTestClient(ts.Client(), ts.URL+"/")
+			body, err := json.Marshal(expectedUser)
+			require.NoError(t, err)
+			return newJSONResponse(http.StatusOK, string(body), headers), nil
+		}), "https://api.test/")
 		user, err := client.CurrentUser(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, expectedUser.Login, user.Login)
@@ -42,14 +42,12 @@ func TestGHClient_Methods(t *testing.T) {
 	t.Run("MarkThreadAsRead", func(t *testing.T) {
 		t.Setenv("GH_ORBIT_SKIP_AUTH", "1")
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 			assert.Equal(t, http.MethodPatch, r.Method)
 			assert.Equal(t, "/notifications/threads/123", r.URL.Path)
-			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer ts.Close()
+			return newJSONResponse(http.StatusNoContent, "", nil), nil
+		}), "https://api.test/")
 
-		client := NewTestClient(ts.Client(), ts.URL+"/")
 		err := client.MarkThreadAsRead(context.Background(), "123")
 		require.NoError(t, err)
 	})

--- a/internal/github/fetcher_test.go
+++ b/internal/github/fetcher_test.go
@@ -3,10 +3,8 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -16,20 +14,24 @@ import (
 
 func TestNotificationFetcher_FetchNotifications(t *testing.T) {
 	t.Run("Successful Fetch with Pagination", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 			if r.URL.Path == "/notifications" {
-				w.Header().Set("Link", fmt.Sprintf(`<%s/page2>; rel="next"`, "http://"+r.Host))
-				w.Header().Set("ETag", "etag-1")
-				w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 MST")
-				w.Header().Set("X-Poll-Interval", "30")
-				_ = json.NewEncoder(w).Encode([]Notification{{ID: "1"}, {ID: "2"}})
-			} else {
-				_ = json.NewEncoder(w).Encode([]Notification{{ID: "3"}})
-			}
-		}))
-		defer ts.Close()
+				headers := make(http.Header)
+				headers.Set("Link", `<https://api.test/page2>; rel="next"`)
+				headers.Set("ETag", "etag-1")
+				headers.Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 MST")
+				headers.Set("X-Poll-Interval", "30")
 
-		client := NewTestClient(ts.Client(), ts.URL+"/")
+				body, err := json.Marshal([]Notification{{ID: "1"}, {ID: "2"}})
+				require.NoError(t, err)
+				return newJSONResponse(http.StatusOK, string(body), headers), nil
+			}
+
+			assert.Equal(t, "/page2", r.URL.Path)
+			body, err := json.Marshal([]Notification{{ID: "3"}})
+			require.NoError(t, err)
+			return newJSONResponse(http.StatusOK, string(body), nil), nil
+		}), "https://api.test/")
 		fetcher := NewNotificationFetcher(client, slog.Default())
 
 		notifs, newMeta, rl, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)
@@ -41,13 +43,11 @@ func TestNotificationFetcher_FetchNotifications(t *testing.T) {
 	})
 
 	t.Run("304 Not Modified", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 			assert.Equal(t, "etag-old", r.Header.Get("If-None-Match"))
-			w.WriteHeader(http.StatusNotModified)
-		}))
-		defer ts.Close()
+			return newJSONResponse(http.StatusNotModified, "", nil), nil
+		}), "https://api.test/")
 
-		client := NewTestClient(ts.Client(), ts.URL+"/")
 		fetcher := NewNotificationFetcher(client, slog.Default())
 		meta := &models.SyncMeta{ETag: "etag-old"}
 
@@ -58,13 +58,14 @@ func TestNotificationFetcher_FetchNotifications(t *testing.T) {
 	})
 
 	t.Run("Corrupted ETag Sanitization", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("ETag", `W/""`)
-			_ = json.NewEncoder(w).Encode([]Notification{})
-		}))
-		defer ts.Close()
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+			headers := make(http.Header)
+			headers.Set("ETag", `W/""`)
 
-		client := NewTestClient(ts.Client(), ts.URL+"/")
+			body, err := json.Marshal([]Notification{})
+			require.NoError(t, err)
+			return newJSONResponse(http.StatusOK, string(body), headers), nil
+		}), "https://api.test/")
 		fetcher := NewNotificationFetcher(client, slog.Default())
 
 		_, newMeta, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)
@@ -73,12 +74,9 @@ func TestNotificationFetcher_FetchNotifications(t *testing.T) {
 	})
 
 	t.Run("API Error Handling", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
-		}))
-		defer ts.Close()
-
-		client := NewTestClient(ts.Client(), ts.URL+"/")
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+			return newJSONResponse(http.StatusUnauthorized, "", nil), nil
+		}), "https://api.test/")
 		fetcher := NewNotificationFetcher(client, slog.Default())
 
 		_, _, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)

--- a/internal/github/http_test_helpers_test.go
+++ b/internal/github/http_test_helpers_test.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newHTTPClient(t *testing.T, fn roundTripFunc) *http.Client {
+	t.Helper()
+
+	return &http.Client{Transport: fn}
+}
+
+func newJSONResponse(status int, body string, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = make(http.Header)
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}


### PR DESCRIPTION
## Summary
- replace unnecessary `httptest.NewServer(...)` usage in sandbox-blocking API and GitHub tests
- use fake `http.RoundTripper` transports for request/response simulation while preserving assertions
- keep routine package verification for `internal/api` and `internal/github` runnable inside the sandbox

## Verification
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/api ./internal/github`

Closes #309
