### PR TITLE
Fail fast when API traffic queues are full

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -19,6 +20,8 @@ const (
 	PriorityUser
 )
 
+var ErrTrafficQueueFull = errors.New("traffic controller queue full")
+
 type apiTask struct {
 	id       uint64
 	priority int
@@ -32,6 +35,7 @@ type APITrafficController struct {
 	ctx    context.Context // Application root context
 	logger *slog.Logger
 	userMu sync.Mutex // Serializes PriorityUser tasks to prevent out-of-order writes
+	stateMu sync.RWMutex // Prevents new submissions from racing with shutdown admission cutoff
 
 	taskCounter uint64
 
@@ -51,6 +55,8 @@ type APITrafficController struct {
 	workerWG           sync.WaitGroup
 
 	rateLimitUpdates chan models.RateLimitInfo
+
+	submitBeforeLockHook func()
 }
 
 func NewAPITrafficController(ctx context.Context, logger *slog.Logger) *APITrafficController {
@@ -105,22 +111,37 @@ func (c *APITrafficController) Submit(priority int, fn types.TaskFunc) (<-chan a
 		ctx:      c.ctx,
 	}
 
+	if c.submitBeforeLockHook != nil {
+		c.submitBeforeLockHook()
+	}
+
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
+
 	select {
 	case <-c.done:
 		return nil, fmt.Errorf("traffic controller shutdown")
 	default:
 	}
 
+	queue := c.queueForPriority(priority)
+	select {
+	case queue <- task:
+		return task.resp, nil
+	default:
+		return nil, ErrTrafficQueueFull
+	}
+}
+
+func (c *APITrafficController) queueForPriority(priority int) chan *apiTask {
 	switch priority {
 	case PriorityUser:
-		c.high <- task
+		return c.high
 	case PrioritySync:
-		c.med <- task
+		return c.med
 	default:
-		c.low <- task
+		return c.low
 	}
-
-	return task.resp, nil
 }
 
 func (c *APITrafficController) UpdateRateLimit(ctx context.Context, info models.RateLimitInfo) {
@@ -260,12 +281,14 @@ func (c *APITrafficController) rateLimitListener() {
 }
 
 func (c *APITrafficController) Shutdown(ctx context.Context) {
+	c.stateMu.Lock()
 	close(c.done)
 
 	// Drain remaining tasks to unblock any callers
 	c.drainQueue(c.high)
 	c.drainQueue(c.med)
 	c.drainQueue(c.low)
+	c.stateMu.Unlock()
 
 	// Wait for all background goroutines (supervisor, listener, and active workers)
 	c.workerWG.Wait()

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync/atomic"
 	"testing"
@@ -84,5 +85,59 @@ func TestAPITrafficController_ReportRateLimit_AfterShutdownDoesNotPanic(t *testi
 		assert.NotPanics(t, func() {
 			tc.ReportRateLimit(models.RateLimitInfo{Remaining: 42})
 		})
+	})
+}
+
+func TestAPITrafficController_ShutdownTakesPrecedenceOverQueueFull(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+
+		atomic.StoreInt32(&tc.workerLimit, 0)
+		synctest.Wait()
+
+		for i := 0; i < cap(tc.high); i++ {
+			_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+			assert.NoError(t, err)
+		}
+
+		tc.Shutdown(ctx)
+		synctest.Wait()
+
+		_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrTrafficQueueFull))
+		assert.Contains(t, err.Error(), "shutdown")
+	})
+}
+
+func TestAPITrafficController_ShutdownWinsDuringSubmitRace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+
+		enteredHook := make(chan struct{}, 1)
+		releaseHook := make(chan struct{})
+		tc.submitBeforeLockHook = func() {
+			close(enteredHook)
+			<-releaseHook
+		}
+
+		result := make(chan error, 1)
+		go func() {
+			_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+			result <- err
+		}()
+
+		<-enteredHook
+		tc.Shutdown(ctx)
+		close(releaseHook)
+		synctest.Wait()
+
+		err := <-result
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrTrafficQueueFull))
+		assert.Contains(t, err.Error(), "shutdown")
+		assert.Equal(t, 0, len(tc.high))
 	})
 }

--- a/internal/api/traffic_test.go
+++ b/internal/api/traffic_test.go
@@ -177,3 +177,54 @@ func TestTrafficController_ScalingStress(t *testing.T) {
 		cancel()
 	})
 }
+
+func TestTrafficController_SubmitReturnsQueueFullInsteadOfBlocking(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			priority int
+			capacity int
+		}{
+			{name: "user", priority: PriorityUser, capacity: 10},
+			{name: "sync", priority: PrioritySync, capacity: 50},
+			{name: "enrich", priority: PriorityEnrich, capacity: 100},
+		}
+
+		for _, tcDef := range testCases {
+			ctx, cancel := context.WithCancel(context.Background())
+			tc := NewAPITrafficController(ctx, slog.Default())
+
+			atomic.StoreInt32(&tc.workerLimit, 0)
+			synctest.Wait()
+
+			for i := 0; i < tcDef.capacity; i++ {
+				resChan, err := tc.Submit(tcDef.priority, func(ctx context.Context) any { return nil })
+				assert.NoErrorf(t, err, "%s queue should accept task %d within capacity", tcDef.name, i)
+				assert.NotNilf(t, resChan, "%s queue should return response channel within capacity", tcDef.name)
+			}
+
+			resChan, err := tc.Submit(tcDef.priority, func(ctx context.Context) any { return nil })
+			assert.Nilf(t, resChan, "%s queue should reject task when full", tcDef.name)
+			assert.ErrorIsf(t, err, ErrTrafficQueueFull, "%s queue should fail fast when full", tcDef.name)
+
+			tc.Shutdown(ctx)
+			cancel()
+		}
+	})
+}
+
+func TestTrafficController_SubmitStillEnqueuesWhenCapacityAvailable(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		resChan, err := tc.Submit(PrioritySync, func(ctx context.Context) any {
+			return "ok"
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "ok", <-resChan)
+	})
+}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -115,6 +115,22 @@ func TestInterpreter_Execute_UpdateRateLimitStandaloneMode(t *testing.T) {
 	assert.Equal(t, 123, m.RateLimit.Remaining)
 }
 
+func TestModel_submitTask_SubmitErrorReturnsErrMsg(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic.(*mocks.MockTrafficController).EXPECT().
+		Submit(api.PrioritySync, mock.Anything).
+		Return(nil, api.ErrTrafficQueueFull).
+		Once()
+
+	cmd := m.submitTask(api.PrioritySync, func(ctx context.Context) any { return "unreachable" })
+	require.NotNil(t, cmd)
+
+	msg := executeCmd(cmd)
+	errMsg, ok := msg.(types.ErrMsg)
+	require.True(t, ok)
+	assert.ErrorIs(t, errMsg.Err, api.ErrTrafficQueueFull)
+}
+
 func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	m := newTestModel(t)
 	m.client = nil


### PR DESCRIPTION
## Summary
- make APITrafficController submit fail fast with an explicit queue-full error instead of blocking indefinitely
- ensure shutdown wins admission races by coordinating submit and shutdown with a lifecycle lock
- add regression coverage for queue saturation, shutdown precedence, and TUI error propagation

## Verification
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/api ./internal/tui`

Closes #286
