### PR TITLE
Bound connected-mode sync requests

### DIFF
--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -173,6 +173,12 @@ func (a *MCPAdapter) UnmuteThread(ctx context.Context, id string) error    { ret
 // --- types.Syncer Implementation ---
 
 func (a *MCPAdapter) Sync(ctx context.Context, userID string, force bool) (models.RateLimitInfo, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, types.ConnectedSyncTimeout)
+		defer cancel()
+	}
+
 	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "sync",

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -1,0 +1,156 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/types"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingMCPClient struct {
+	callTool func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)
+}
+
+var _ client.MCPClient = (*blockingMCPClient)(nil)
+
+func (c *blockingMCPClient) Initialize(ctx context.Context, request mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) Ping(ctx context.Context) error { return nil }
+
+func (c *blockingMCPClient) ListResourcesByPage(ctx context.Context, request mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListResources(ctx context.Context, request mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListResourceTemplatesByPage(ctx context.Context, request mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListResourceTemplates(ctx context.Context, request mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ReadResource(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) Subscribe(ctx context.Context, request mcp.SubscribeRequest) error { return nil }
+
+func (c *blockingMCPClient) Unsubscribe(ctx context.Context, request mcp.UnsubscribeRequest) error {
+	return nil
+}
+
+func (c *blockingMCPClient) ListPromptsByPage(ctx context.Context, request mcp.ListPromptsRequest) (*mcp.ListPromptsResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListPrompts(ctx context.Context, request mcp.ListPromptsRequest) (*mcp.ListPromptsResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) GetPrompt(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListToolsByPage(ctx context.Context, request mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) ListTools(ctx context.Context, request mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if c.callTool != nil {
+		return c.callTool(ctx, request)
+	}
+	return nil, nil
+}
+
+func (c *blockingMCPClient) SetLevel(ctx context.Context, request mcp.SetLevelRequest) error { return nil }
+
+func (c *blockingMCPClient) Complete(ctx context.Context, request mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	return nil, nil
+}
+
+func (c *blockingMCPClient) Close() error { return nil }
+
+func (c *blockingMCPClient) OnNotification(handler func(notification mcp.JSONRPCNotification)) {}
+
+func TestMCPAdapter_SyncAddsFallbackTimeoutWhenCallerHasNoDeadline(t *testing.T) {
+	originalTimeout := types.ConnectedSyncTimeout
+	types.ConnectedSyncTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		types.ConnectedSyncTimeout = originalTimeout
+	})
+
+	var sawDeadline bool
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, sawDeadline = ctx.Deadline()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	_, err := adapter.Sync(context.Background(), "user-1", true)
+	require.Error(t, err)
+	assert.True(t, sawDeadline)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestMCPAdapter_SyncRespectsCallerDeadline(t *testing.T) {
+	originalTimeout := types.ConnectedSyncTimeout
+	types.ConnectedSyncTimeout = 200 * time.Millisecond
+	t.Cleanup(func() {
+		types.ConnectedSyncTimeout = originalTimeout
+	})
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	parentDeadline, ok := parentCtx.Deadline()
+	require.True(t, ok)
+
+	var seenDeadline time.Time
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var hasDeadline bool
+			seenDeadline, hasDeadline = ctx.Deadline()
+			require.True(t, hasDeadline)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	_, err := adapter.Sync(parentCtx, "user-1", true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, parentDeadline, seenDeadline)
+}
+
+func TestMCPAdapter_SyncPassesThroughSuccessfulResponse(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.NewTextContent(`{"remaining":123}`),
+				},
+			}, nil
+		},
+	})
+
+	rl, err := adapter.Sync(context.Background(), "user-1", true)
+	require.NoError(t, err)
+	assert.Equal(t, models.RateLimitInfo{Remaining: 123}, rl)
+}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -131,6 +131,38 @@ func TestModel_submitTask_SubmitErrorReturnsErrMsg(t *testing.T) {
 	assert.ErrorIs(t, errMsg.Err, api.ErrTrafficQueueFull)
 }
 
+func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic = nil
+	m.ui.SetSyncing(true)
+
+	originalTimeout := types.ConnectedSyncTimeout
+	types.ConnectedSyncTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		types.ConnectedSyncTimeout = originalTimeout
+	})
+
+	m.sync.(*mocks.MockSyncer).EXPECT().
+		Sync(mock.Anything, "test-user", true).
+		RunAndReturn(func(ctx context.Context, userID string, force bool) (models.RateLimitInfo, error) {
+			<-ctx.Done()
+			return models.RateLimitInfo{}, ctx.Err()
+		}).
+		Once()
+
+	cmd := m.syncNotificationsWithForce(true)
+	require.NotNil(t, cmd)
+
+	msg := executeCmd(cmd)
+	errMsg, ok := msg.(types.ErrMsg)
+	require.True(t, ok)
+	assert.ErrorIs(t, errMsg.Err, context.DeadlineExceeded)
+
+	m.handleTransitionError(errMsg)
+	assert.False(t, m.ui.syncing)
+	assert.ErrorIs(t, m.err, context.DeadlineExceeded)
+}
+
 func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	m := newTestModel(t)
 	m.client = nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -323,9 +324,22 @@ func (m *Model) loadNotifications(isInitial bool, isForced bool) tea.Cmd {
 }
 
 func (m *Model) syncNotificationsWithForce(force bool) tea.Cmd {
+	if m.traffic == nil {
+		return func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), types.ConnectedSyncTimeout)
+			defer cancel()
+
+			rl, err := m.sync.Sync(ctx, m.userID, force)
+			if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
+				return types.ErrMsg{Err: err}
+			}
+			return syncCompleteMsg{rateLimit: rl, IsForced: force}
+		}
+	}
+
 	return m.submitTask(api.PrioritySync, func(ctx context.Context) any {
 		rl, err := m.sync.Sync(ctx, m.userID, force)
-		if err != nil && err != types.ErrSyncIntervalNotReached {
+		if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
 			return types.ErrMsg{Err: err}
 		}
 		return syncCompleteMsg{rateLimit: rl, IsForced: force}

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -18,6 +18,10 @@ var (
 	ErrNetworkTimeout         = errors.New("github: network timeout")
 )
 
+// ConnectedSyncTimeout bounds connected/native sync requests so stalled MCP calls
+// surface a recoverable error instead of leaving the UI in a permanent syncing state.
+var ConnectedSyncTimeout = 15 * time.Second
+
 // BridgeStatus represents the functional state of the native system bridge.
 type BridgeStatus string
 


### PR DESCRIPTION
## Summary
- bound connected-mode manual sync requests with a shared timeout instead of allowing unbounded MCP sync calls
- add an adapter-level fallback timeout only for callers that provide no deadline
- add regressions for connected-mode timeout behavior and adapter deadline handling

## Verification
- GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/tui ./internal/engine -run "TestMCPAdapter_|TestModel_SyncNotificationsWithForce_"

Closes #291
