### PR TITLE
Align agent commit attribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ This project uses the extension's standard "Workbench" files:
 - **PR Requirement**: No Pull Request will be merged unless `make check` passes 100%.
 - **Resilience**: Locally, gates may skip specific tools with a warning if they are missing, but the CI pipeline is strict and will block on any failure.
 
+### 1.4 Commit Attribution
+
+- **Repo-wide Policy**: AI-authored commits MUST include an explicit attribution trailer in the commit message.
+- **Agent Identity**: Agent-specific instruction files may define the exact attribution string for that agent. If an agent-specific file does not override the trailer text, use the agent identity required by the active instruction set for that tool.
+- **Consistency Goal**: Shared attribution policy belongs in `AGENTS.md`; agent-specific files should only supply the identity-specific footer value or stricter overlays.
+
 ## 2. Sandbox & Environment Constraints (macOS Seatbelt)
 
 AI agents operate in a restricted sandbox. You MUST adhere to these path redirections and environment settings:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,7 +10,9 @@ Refer to [AGENTS.md](AGENTS.md) for core project principles, tech stack, and dev
 
 ### 2.1 Commit Attribution
 
-Always include the following co-authored-by footer in commit messages:
+Follow the repo-wide commit-attribution policy in [AGENTS.md](AGENTS.md#14-commit-attribution).
+
+For Gemini-authored commits, always include the following co-authored-by footer in commit messages:
 `Co-authored-by: Gemini CLI <gemini-cli+noreply@google.com>`
 
 ### 2.2 Shell Safety


### PR DESCRIPTION
## Summary
- move the baseline AI commit-attribution requirement into AGENTS.md as shared repo policy
- keep GEMINI.md aligned by pointing to the shared policy and retaining the Gemini-specific footer identity

## Verification
- manually verified that AGENTS.md now defines the repo-wide rule and GEMINI.md references it without contradiction
- markdownlint AGENTS.md GEMINI.md produced no output in this environment

Closes #315
