### PR TITLE
Preserve MCP sync sentinel semantics

### DIFF
--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -16,6 +16,18 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+type syncToolStatus string
+
+const (
+	syncToolStatusOK                 syncToolStatus = "ok"
+	syncToolStatusIntervalNotReached syncToolStatus = "interval_not_reached"
+)
+
+type syncToolResult struct {
+	Status    syncToolStatus       `json:"status"`
+	RateLimit models.RateLimitInfo `json:"rate_limit,omitempty"`
+}
+
 // MCPAdapter implements core interfaces by proxying to an MCP server.
 type MCPAdapter struct {
 	client client.MCPClient
@@ -191,6 +203,17 @@ func (a *MCPAdapter) Sync(ctx context.Context, userID string, force bool) (model
 		return models.RateLimitInfo{}, err
 	}
 
+	if payload, ok := decodeSyncToolResult(resp); ok {
+		switch payload.Status {
+		case syncToolStatusOK:
+			return payload.RateLimit, nil
+		case syncToolStatusIntervalNotReached:
+			return payload.RateLimit, types.ErrSyncIntervalNotReached
+		default:
+			return models.RateLimitInfo{}, fmt.Errorf("sync error: invalid sync tool status %q", payload.Status)
+		}
+	}
+
 	if resp.IsError {
 		content, _ := resp.Content[0].(mcp.TextContent)
 		return models.RateLimitInfo{}, fmt.Errorf("sync error: %s", content.Text)
@@ -204,6 +227,27 @@ func (a *MCPAdapter) Sync(ctx context.Context, userID string, force bool) (model
 	}
 
 	return rl, nil
+}
+
+func decodeSyncToolResult(resp *mcp.CallToolResult) (syncToolResult, bool) {
+	if resp == nil || resp.StructuredContent == nil {
+		return syncToolResult{}, false
+	}
+
+	raw, err := json.Marshal(resp.StructuredContent)
+	if err != nil {
+		return syncToolResult{}, false
+	}
+
+	var payload syncToolResult
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return syncToolResult{}, false
+	}
+	if payload.Status == "" {
+		return syncToolResult{}, false
+	}
+
+	return payload, true
 }
 
 func (a *MCPAdapter) Shutdown(ctx context.Context)     {}

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -143,6 +143,10 @@ func TestMCPAdapter_SyncPassesThroughSuccessfulResponse(t *testing.T) {
 	adapter := NewMCPAdapter(&blockingMCPClient{
 		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
+				StructuredContent: syncToolResult{
+					Status:    syncToolStatusOK,
+					RateLimit: models.RateLimitInfo{Remaining: 123},
+				},
 				Content: []mcp.Content{
 					mcp.NewTextContent(`{"remaining":123}`),
 				},
@@ -153,4 +157,76 @@ func TestMCPAdapter_SyncPassesThroughSuccessfulResponse(t *testing.T) {
 	rl, err := adapter.Sync(context.Background(), "user-1", true)
 	require.NoError(t, err)
 	assert.Equal(t, models.RateLimitInfo{Remaining: 123}, rl)
+}
+
+func TestMCPAdapter_SyncReconstructsIntervalNotReachedFromStructuredResult(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				StructuredContent: syncToolResult{
+					Status:    syncToolStatusIntervalNotReached,
+					RateLimit: models.RateLimitInfo{Remaining: 456},
+				},
+				Content: []mcp.Content{
+					mcp.NewTextContent(`sync interval not reached`),
+				},
+			}, nil
+		},
+	})
+
+	rl, err := adapter.Sync(context.Background(), "user-1", false)
+	assert.Equal(t, models.RateLimitInfo{Remaining: 456}, rl)
+	assert.ErrorIs(t, err, types.ErrSyncIntervalNotReached)
+}
+
+func TestMCPAdapter_SyncFallsBackToLegacySuccessParsingWithoutStructuredContent(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.NewTextContent(`{"remaining":789}`),
+				},
+			}, nil
+		},
+	})
+
+	rl, err := adapter.Sync(context.Background(), "user-1", true)
+	require.NoError(t, err)
+	assert.Equal(t, models.RateLimitInfo{Remaining: 789}, rl)
+}
+
+func TestMCPAdapter_SyncFallsBackToLegacyErrorWithoutStructuredContent(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					mcp.NewTextContent(`sync failed: boom`),
+				},
+			}, nil
+		},
+	})
+
+	_, err := adapter.Sync(context.Background(), "user-1", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sync error: sync failed: boom")
+}
+
+func TestMCPAdapter_SyncRejectsInvalidStructuredContract(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				StructuredContent: map[string]any{
+					"status": "unknown",
+				},
+				Content: []mcp.Content{
+					mcp.NewTextContent(`{"remaining":123}`),
+				},
+			}, nil
+		},
+	})
+
+	_, err := adapter.Sync(context.Background(), "user-1", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid sync tool status "unknown"`)
 }

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/engine/transport"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -326,11 +327,22 @@ func (s *MCPServer) registerTools() {
 
 		rl, err := s.engine.Sync.Sync(ctx, user.Login, force)
 		if err != nil {
+			if errors.Is(err, types.ErrSyncIntervalNotReached) {
+				payload := syncToolResult{
+					Status:    syncToolStatusIntervalNotReached,
+					RateLimit: rl,
+				}
+				return mcp.NewToolResultStructured(payload, "sync interval not reached"), nil
+			}
 			return mcp.NewToolResultError(fmt.Sprintf("sync failed: %v", err)), nil
 		}
 
+		payload := syncToolResult{
+			Status:    syncToolStatusOK,
+			RateLimit: rl,
+		}
 		data, _ := json.Marshal(rl)
-		return mcp.NewToolResultText(string(data)), nil
+		return mcp.NewToolResultStructured(payload, string(data)), nil
 	})
 
 	// 2. Mark Read Tool

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -163,6 +163,30 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *t
 	assert.ErrorIs(t, m.err, context.DeadlineExceeded)
 }
 
+func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedAsBenign(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic = nil
+	m.ui.SetSyncing(true)
+
+	m.sync.(*mocks.MockSyncer).EXPECT().
+		Sync(mock.Anything, "test-user", false).
+		Return(models.RateLimitInfo{Remaining: 999}, types.ErrSyncIntervalNotReached).
+		Once()
+
+	cmd := m.syncNotificationsWithForce(false)
+	require.NotNil(t, cmd)
+
+	msg := executeCmd(cmd)
+	syncMsg, ok := msg.(syncCompleteMsg)
+	require.True(t, ok)
+	assert.Equal(t, models.RateLimitInfo{Remaining: 999}, syncMsg.rateLimit)
+	assert.False(t, syncMsg.IsForced)
+
+	actions := m.handleSyncComplete(syncMsg)
+	assert.False(t, m.ui.syncing)
+	assert.Contains(t, actions, ActionLoadNotifications{IsInitial: false, IsForced: false})
+}
+
 func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	m := newTestModel(t)
 	m.client = nil


### PR DESCRIPTION
## Summary
- preserve ErrSyncIntervalNotReached semantics across the MCP sync transport using a structured sync outcome contract
- reconstruct the benign sentinel in the adapter while keeping explicit legacy fallback behavior for mixed-version responses
- add regressions for structured success, interval-not-reached, real errors, and connected-mode TUI handling

## Verification
- GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/engine ./internal/tui -run "TestMCPAdapter_|TestModel_SyncNotificationsWithForce_"

Closes #293
