### PR TITLE
Fix EventBus subscriber lifecycle leak

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -511,7 +511,8 @@ func initEnvironment(ctx context.Context, sink io.Writer) (*environment, context
 	}
 
 	tracer := config.GetTracer()
-	ctx, span := tracer.Start(ctx, "session",
+	ctx, span := tracer.Start(
+		ctx, "session",
 		trace.WithAttributes(
 			attribute.String("version", buildinfo.Version),
 			attribute.String("os", runtime.GOOS),

--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -102,7 +102,8 @@ func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectTyp
 
 	val, err, _ := e.sf.Do(sfKey, func() (any, error) {
 		tracer := config.GetTracer()
-		ctx, span := tracer.Start(ctx, "enrichment.fetch_detail",
+		ctx, span := tracer.Start(
+			ctx, "enrichment.fetch_detail",
 			trace.WithAttributes(
 				attribute.String("url", u),
 				attribute.String("type", subjectType),

--- a/internal/api/notifier_darwin.go
+++ b/internal/api/notifier_darwin.go
@@ -30,7 +30,8 @@ func NewDarwinNotifier(executor types.CommandExecutor, logger *slog.Logger) *Dar
 }
 
 func (n *DarwinNotifier) Notify(ctx context.Context, title, subtitle, body, url string, priority int) error {
-	script := fmt.Sprintf(`display notification "%s" with title "%s" subtitle "%s"`,
+	script := fmt.Sprintf(
+		`display notification "%s" with title "%s" subtitle "%s"`,
 		escapeAppleScript(body),
 		escapeAppleScript(title),
 		escapeAppleScript(subtitle),

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -75,7 +75,8 @@ func (s *SyncEngine) Sync(ctx context.Context, userID string, force bool) (model
 	}
 
 	tracer := config.GetTracer()
-	ctx, span := tracer.Start(ctx, "sync.notifications",
+	ctx, span := tracer.Start(
+		ctx, "sync.notifications",
 		trace.WithAttributes(
 			attribute.String("user_id", userID),
 			attribute.Bool("force", force),

--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -32,9 +32,9 @@ type apiTask struct {
 
 // APITrafficController ensures prioritized access to the GitHub API.
 type APITrafficController struct {
-	ctx    context.Context // Application root context
-	logger *slog.Logger
-	userMu sync.Mutex // Serializes PriorityUser tasks to prevent out-of-order writes
+	ctx     context.Context // Application root context
+	logger  *slog.Logger
+	userMu  sync.Mutex   // Serializes PriorityUser tasks to prevent out-of-order writes
 	stateMu sync.RWMutex // Prevents new submissions from racing with shutdown admission cutoff
 
 	taskCounter uint64

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -135,7 +135,8 @@ func (db *DB) UpsertNotifications(ctx context.Context, notifications []triage.No
 	defer func() { _ = stmtState.Close() }()
 
 	for _, n := range notifications {
-		if _, err := stmtNotifications.ExecContext(ctx,
+		if _, err := stmtNotifications.ExecContext(
+			ctx,
 			n.GitHubID, n.SubjectTitle, n.SubjectURL, n.SubjectType, n.Reason,
 			n.RepositoryFullName, n.HTMLURL, n.SubjectNodeID, n.UpdatedAt,
 		); err != nil {

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -45,7 +45,9 @@ func (c *blockingMCPClient) ReadResource(ctx context.Context, request mcp.ReadRe
 	return nil, nil
 }
 
-func (c *blockingMCPClient) Subscribe(ctx context.Context, request mcp.SubscribeRequest) error { return nil }
+func (c *blockingMCPClient) Subscribe(ctx context.Context, request mcp.SubscribeRequest) error {
+	return nil
+}
 
 func (c *blockingMCPClient) Unsubscribe(ctx context.Context, request mcp.UnsubscribeRequest) error {
 	return nil
@@ -78,7 +80,9 @@ func (c *blockingMCPClient) CallTool(ctx context.Context, request mcp.CallToolRe
 	return nil, nil
 }
 
-func (c *blockingMCPClient) SetLevel(ctx context.Context, request mcp.SetLevelRequest) error { return nil }
+func (c *blockingMCPClient) SetLevel(ctx context.Context, request mcp.SetLevelRequest) error {
+	return nil
+}
 
 func (c *blockingMCPClient) Complete(ctx context.Context, request mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 	return nil, nil

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -24,14 +24,37 @@ func NewEventBus() *EventBus {
 	}
 }
 
-// Subscribe returns a channel that receives a signal when the event occurs.
-func (b *EventBus) Subscribe(event EngineEvent) <-chan struct{} {
+// Subscribe returns a channel that receives a signal when the event occurs
+// along with an idempotent function that removes the subscriber.
+func (b *EventBus) Subscribe(event EngineEvent) (<-chan struct{}, func()) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	ch := make(chan struct{}, 1)
 	b.subscribers[event] = append(b.subscribers[event], ch)
-	return ch
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+
+			subs := b.subscribers[event]
+			for i, sub := range subs {
+				if sub != ch {
+					continue
+				}
+
+				b.subscribers[event] = append(subs[:i], subs[i+1:]...)
+				if len(b.subscribers[event]) == 0 {
+					delete(b.subscribers, event)
+				}
+				return
+			}
+		})
+	}
+
+	return ch, unsubscribe
 }
 
 // Publish signals all subscribers of an event.

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -26,7 +26,8 @@ func TestEventBus_Stress(t *testing.T) {
 			wg.Add(1)
 			go func(id int) {
 				defer wg.Done()
-				ch := bus.Subscribe(EventNotificationsChanged)
+				ch, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+				defer unsubscribe()
 
 				for {
 					select {
@@ -52,7 +53,8 @@ func TestEventBus_Stress(t *testing.T) {
 					bus.Publish(EventNotificationsChanged)
 					if j%10 == 0 {
 						// Mix in some random subs during active publishing
-						bus.Subscribe(EventEnrichmentUpdated)
+						_, unsubscribe := bus.Subscribe(EventEnrichmentUpdated)
+						unsubscribe()
 					}
 				}
 			}(i)
@@ -84,7 +86,8 @@ func TestEventBus_DeadlockDetection(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				bus.Subscribe(EventNotificationsChanged)
+				_, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+				unsubscribe()
 			}
 		}()
 
@@ -102,7 +105,8 @@ func TestEventBus_DeadlockDetection(t *testing.T) {
 func TestEventBus_BufferSaturation(t *testing.T) {
 	bus := NewEventBus()
 	// Channel is buffered at size 1
-	ch := bus.Subscribe(EventNotificationsChanged)
+	ch, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+	defer unsubscribe()
 
 	// Publish twice without reading
 	bus.Publish(EventNotificationsChanged)
@@ -128,11 +132,45 @@ func TestEventBus_BufferSaturation(t *testing.T) {
 func BenchmarkEventBus_Publish(b *testing.B) {
 	bus := NewEventBus()
 	for i := 0; i < 10; i++ {
-		bus.Subscribe(EventNotificationsChanged)
+		_, _ = bus.Subscribe(EventNotificationsChanged)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bus.Publish(EventNotificationsChanged)
 	}
+}
+
+func TestEventBus_UnsubscribeRemovesSubscriber(t *testing.T) {
+	bus := NewEventBus()
+
+	ch1, unsubscribe1 := bus.Subscribe(EventNotificationsChanged)
+	_, unsubscribe2 := bus.Subscribe(EventNotificationsChanged)
+
+	assert.Len(t, bus.subscribers[EventNotificationsChanged], 2)
+
+	unsubscribe1()
+
+	assert.Len(t, bus.subscribers[EventNotificationsChanged], 1)
+
+	select {
+	case <-ch1:
+		t.Fatal("unsubscribed channel should not receive events")
+	default:
+	}
+
+	bus.Publish(EventNotificationsChanged)
+
+	select {
+	case <-ch1:
+		t.Fatal("unsubscribed channel should not receive events")
+	default:
+	}
+
+	unsubscribe1()
+	assert.Len(t, bus.subscribers[EventNotificationsChanged], 1)
+
+	unsubscribe2()
+	_, ok := bus.subscribers[EventNotificationsChanged]
+	assert.False(t, ok, "event subscriber entry should be removed when empty")
 }

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -146,8 +146,10 @@ func (s *MCPServer) Serve(ctx context.Context) error {
 }
 
 func (s *MCPServer) eventLoop(ctx context.Context) {
-	notifCh := s.engine.Bus.Subscribe(EventNotificationsChanged)
-	enrichCh := s.engine.Bus.Subscribe(EventEnrichmentUpdated)
+	notifCh, unsubscribeNotif := s.engine.Bus.Subscribe(EventNotificationsChanged)
+	enrichCh, unsubscribeEnrich := s.engine.Bus.Subscribe(EventEnrichmentUpdated)
+	defer unsubscribeNotif()
+	defer unsubscribeEnrich()
 
 	for {
 		select {
@@ -302,9 +304,11 @@ func (s *MCPServer) sendJSONRPCMessage(session *udsSession, data []byte) {
 
 func (s *MCPServer) registerTools() {
 	// 1. Sync Tool
-	syncTool := mcp.NewTool("sync",
+	syncTool := mcp.NewTool(
+		"sync",
 		mcp.WithDescription("Trigger a background synchronization with GitHub"),
-		mcp.WithBoolean("force",
+		mcp.WithBoolean(
+			"force",
 			mcp.Description("Force a cold sync even if interval not reached"),
 		),
 	)
@@ -346,12 +350,15 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 2. Mark Read Tool
-	markReadTool := mcp.NewTool("mark_read",
+	markReadTool := mcp.NewTool(
+		"mark_read",
 		mcp.WithDescription("Mark a notification thread as read"),
-		mcp.WithString("id",
+		mcp.WithString(
+			"id",
 			mcp.Description("The GitHub notification ID"),
 		),
-		mcp.WithBoolean("read",
+		mcp.WithBoolean(
+			"read",
 			mcp.Description("Whether to mark as read or unread"),
 		),
 	)
@@ -384,7 +391,8 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 3. Set Priority Tool
-	setPriorityTool := mcp.NewTool("set_priority",
+	setPriorityTool := mcp.NewTool(
+		"set_priority",
 		mcp.WithDescription("Update the priority of a notification"),
 		mcp.WithString("id", mcp.Description("The GitHub notification ID")),
 		mcp.WithNumber("level", mcp.Description("Priority level (0-3)")),
@@ -407,7 +415,8 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 4. Fetch Detail Tool
-	fetchDetailTool := mcp.NewTool("fetch_detail",
+	fetchDetailTool := mcp.NewTool(
+		"fetch_detail",
 		mcp.WithDescription("Fetch enriched detail for a single notification subject"),
 		mcp.WithString("url", mcp.Required(), mcp.Description("The GitHub API subject URL")),
 		mcp.WithString("subject_type", mcp.Required(), mcp.Description("The GitHub subject type")),
@@ -441,9 +450,11 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 5. Batch Enrichment Tool
-	batchEnrichTool := mcp.NewTool("fetch_hybrid_batch",
+	batchEnrichTool := mcp.NewTool(
+		"fetch_hybrid_batch",
 		mcp.WithDescription("Fetch enrichment state for a batch of notifications"),
-		mcp.WithArray("notifications",
+		mcp.WithArray(
+			"notifications",
 			mcp.Required(),
 			mcp.Description("Notification records to enrich; response is keyed by subject_node_id"),
 			mcp.Items(map[string]any{"type": "object"}),
@@ -484,7 +495,8 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 6. Enrichment Persistence Tool
-	enrichNotificationTool := mcp.NewTool("enrich_notification",
+	enrichNotificationTool := mcp.NewTool(
+		"enrich_notification",
 		mcp.WithDescription("Persist enriched notification fields through the engine-backed repository"),
 		mcp.WithString("id", mcp.Required(), mcp.Description("The GitHub notification ID")),
 		mcp.WithString("node_id", mcp.Description("The GitHub subject node ID")),
@@ -523,7 +535,8 @@ func (s *MCPServer) registerTools() {
 
 func (s *MCPServer) registerResources() {
 	// Notifications Resource Template
-	tpl := mcp.NewResourceTemplate("gh-orbit://notifications/{category}", "Notifications List",
+	tpl := mcp.NewResourceTemplate(
+		"gh-orbit://notifications/{category}", "Notifications List",
 		mcp.WithTemplateDescription("List of notifications by category (unread, all)"),
 	)
 

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -219,4 +220,52 @@ func TestMCPAdapter_Debounce(t *testing.T) {
 		// Expect only 1 mutation signal after 5 rapid triggers
 		assert.Equal(t, int32(1), finalCount, "Should debounce multiple rapid updates into a single mutation signal")
 	})
+}
+
+func TestMCPServer_EventLoopUnsubscribesOnShutdown(t *testing.T) {
+	bus := NewEventBus()
+	mcpServer := server.NewMCPServer(
+		"gh-orbit",
+		"0.1.0",
+		server.WithResourceCapabilities(true, false),
+		server.WithToolCapabilities(true),
+	)
+	s := &MCPServer{
+		engine: &CoreEngine{Bus: bus},
+		server: mcpServer,
+	}
+
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.eventLoop(ctx)
+		}()
+
+		require.Eventually(t, func() bool {
+			bus.mu.RLock()
+			defer bus.mu.RUnlock()
+			return len(bus.subscribers[EventNotificationsChanged]) == 1 &&
+				len(bus.subscribers[EventEnrichmentUpdated]) == 1
+		}, time.Second, 10*time.Millisecond)
+
+		cancel()
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
+
+		bus.mu.RLock()
+		_, notifOK := bus.subscribers[EventNotificationsChanged]
+		_, enrichOK := bus.subscribers[EventEnrichmentUpdated]
+		bus.mu.RUnlock()
+
+		assert.False(t, notifOK, "notification subscribers should return to baseline after shutdown")
+		assert.False(t, enrichOK, "enrichment subscribers should return to baseline after shutdown")
+	}
 }

--- a/internal/github/fetcher.go
+++ b/internal/github/fetcher.go
@@ -32,7 +32,8 @@ func NewNotificationFetcher(client Client, logger *slog.Logger) *NotificationFet
 
 func (f *NotificationFetcher) FetchNotifications(ctx context.Context, meta *models.SyncMeta, force bool) ([]Notification, *models.SyncMeta, models.RateLimitInfo, error) {
 	tracer := config.GetTracer()
-	ctx, span := tracer.Start(ctx, "api.fetch_notifications",
+	ctx, span := tracer.Start(
+		ctx, "api.fetch_notifications",
 		trace.WithAttributes(
 			attribute.Bool("force", force),
 			attribute.String("etag", meta.ETag),

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -38,7 +38,8 @@ func TestCLI_Bootstrap(t *testing.T) {
 
 	// 3. Run 'gh-orbit doctor'
 	cmd := exec.Command(binPath, "doctor") // #nosec G204: Trusted E2E test binary
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"HOME="+tmpHome,
 		"GH_HOST=localhost",
 		"GH_TOKEN=mock-token",
@@ -90,7 +91,8 @@ func TestCLI_Sync(t *testing.T) {
 	binPath := filepath.Join("..", "..", "bin", "gh-orbit")
 
 	cmd := exec.Command(binPath, "--gh-orbit-test-mode") // #nosec G204: Trusted E2E test binary
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"HOME="+tmpHome,
 		"GH_HOST=localhost",
 		"GH_TOKEN=mock-token",

--- a/tests/e2e/engine_test.go
+++ b/tests/e2e/engine_test.go
@@ -58,7 +58,8 @@ func spawnEngine(t *testing.T, tmpHome string) *testEngine {
 	cmd := exec.CommandContext(ctx, binPath, "engine", "--socket", socketPath, "--insecure-dev")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"HOME="+tmpHome,
 		"GH_TOKEN=mock-token",
 		"GH_ORBIT_SKIP_AUTH=1",


### PR DESCRIPTION
## Summary
- add explicit unsubscribe semantics to EventBus subscriptions
- unregister MCP event-loop subscribers on shutdown
- add regression coverage for subscriber-count shrinkage and repeated event-loop teardown stability

## Verification
- `env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/engine -run 'TestEventBus_|TestMCPServer_EventLoopUnsubscribesOnShutdown'
- `env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make go/check` (still hits pre-existing sandbox-sensitive UDS/e2e failures outside this change)

Closes #298
