### PR TITLE
Fix request-scoped traffic controller cancellation

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -28,11 +28,13 @@ type apiTask struct {
 	fn       types.TaskFunc
 	resp     chan any
 	ctx      context.Context
+	cleanup  func()
 }
 
 // APITrafficController ensures prioritized access to the GitHub API.
 type APITrafficController struct {
-	ctx     context.Context // Application root context
+	ctx     context.Context // Controller lifetime context
+	cancel  context.CancelFunc
 	logger  *slog.Logger
 	userMu  sync.Mutex   // Serializes PriorityUser tasks to prevent out-of-order writes
 	stateMu sync.RWMutex // Prevents new submissions from racing with shutdown admission cutoff
@@ -60,8 +62,10 @@ type APITrafficController struct {
 }
 
 func NewAPITrafficController(ctx context.Context, logger *slog.Logger) *APITrafficController {
+	controllerCtx, cancel := context.WithCancel(ctx)
 	c := &APITrafficController{
-		ctx:              ctx,
+		ctx:              controllerCtx,
+		cancel:           cancel,
 		logger:           logger,
 		high:             make(chan *apiTask, 10),
 		med:              make(chan *apiTask, 50),
@@ -102,13 +106,15 @@ func (c *APITrafficController) ReportRateLimit(info models.RateLimitInfo) {
 	}
 }
 
-func (c *APITrafficController) Submit(priority int, fn types.TaskFunc) (<-chan any, error) {
+func (c *APITrafficController) Submit(ctx context.Context, priority int, fn types.TaskFunc) (<-chan any, error) {
+	taskCtx, cleanup := c.composeTaskContext(ctx)
 	task := &apiTask{
 		id:       atomic.AddUint64(&c.taskCounter, 1),
 		priority: priority,
 		fn:       fn,
 		resp:     make(chan any, 1),
-		ctx:      c.ctx,
+		ctx:      taskCtx,
+		cleanup:  cleanup,
 	}
 
 	if c.submitBeforeLockHook != nil {
@@ -120,16 +126,53 @@ func (c *APITrafficController) Submit(priority int, fn types.TaskFunc) (<-chan a
 
 	select {
 	case <-c.done:
+		task.cleanup()
 		return nil, fmt.Errorf("traffic controller shutdown")
 	default:
 	}
 
+	if taskCtx.Err() != nil {
+		task.cleanup()
+		task.resp <- nil
+		return task.resp, nil
+	}
+
 	queue := c.queueForPriority(priority)
 	select {
+	case <-taskCtx.Done():
+		task.cleanup()
+		task.resp <- nil
+		return task.resp, nil
 	case queue <- task:
 		return task.resp, nil
 	default:
+		task.cleanup()
 		return nil, ErrTrafficQueueFull
+	}
+}
+
+func (c *APITrafficController) composeTaskContext(requestCtx context.Context) (context.Context, func()) {
+	if requestCtx == nil {
+		requestCtx = context.Background()
+	}
+
+	var (
+		taskCtx context.Context
+		cancel  context.CancelFunc
+	)
+	if deadline, ok := requestCtx.Deadline(); ok {
+		taskCtx, cancel = context.WithDeadline(c.ctx, deadline)
+	} else {
+		taskCtx, cancel = context.WithCancel(c.ctx)
+	}
+
+	stop := context.AfterFunc(requestCtx, cancel)
+	if requestCtx.Err() != nil {
+		cancel()
+	}
+	return taskCtx, func() {
+		stop()
+		cancel()
 	}
 }
 
@@ -237,6 +280,12 @@ func (c *APITrafficController) spawnTask(t *apiTask) {
 
 func (c *APITrafficController) runTask(t *apiTask) {
 	defer atomic.AddInt32(&c.activeWorkersCount, -1)
+	defer t.cleanup()
+
+	if t.ctx.Err() != nil {
+		t.resp <- nil
+		return
+	}
 
 	// Check lockout
 	if until := c.lockoutUntil.Load(); until != nil && time.Now().Before(*until) {
@@ -282,6 +331,7 @@ func (c *APITrafficController) rateLimitListener() {
 
 func (c *APITrafficController) Shutdown(ctx context.Context) {
 	c.stateMu.Lock()
+	c.cancel()
 	close(c.done)
 
 	// Drain remaining tasks to unblock any callers
@@ -299,6 +349,7 @@ func (c *APITrafficController) drainQueue(q chan *apiTask) {
 	for {
 		select {
 		case t := <-q:
+			t.cleanup()
 			t.resp <- nil
 		default:
 			return

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -35,14 +35,14 @@ func TestAPITrafficController_Background(t *testing.T) {
 		tc.UpdateRateLimit(ctx, models.RateLimitInfo{Remaining: 0, Reset: reset})
 
 		highDone := make(chan bool, 1)
-		_, _ = tc.Submit(PriorityUser, func(ctx context.Context) any {
+		_, _ = tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any {
 			highDone <- true
 			return nil
 		})
 		synctest.Wait()
 		assert.True(t, <-highDone, "User task should bypass lockout")
 
-		res, _ := tc.Submit(PriorityEnrich, func(ctx context.Context) any {
+		res, _ := tc.Submit(context.Background(), PriorityEnrich, func(ctx context.Context) any {
 			return "should-not-run"
 		})
 		synctest.Wait()
@@ -50,7 +50,7 @@ func TestAPITrafficController_Background(t *testing.T) {
 
 		// 3. Dynamic Throttling low quota
 		tc.UpdateRateLimit(ctx, models.RateLimitInfo{Remaining: 499})
-		res, _ = tc.Submit(PriorityEnrich, func(ctx context.Context) any {
+		res, _ = tc.Submit(context.Background(), PriorityEnrich, func(ctx context.Context) any {
 			return "should-not-run"
 		})
 		synctest.Wait()
@@ -68,7 +68,7 @@ func TestAPITrafficController_Shutdown_Channels(t *testing.T) {
 		synctest.Wait()
 
 		// Verify Submit returns error after shutdown
-		_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+		_, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any { return nil })
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "shutdown")
 	})
@@ -97,14 +97,14 @@ func TestAPITrafficController_ShutdownTakesPrecedenceOverQueueFull(t *testing.T)
 		synctest.Wait()
 
 		for i := 0; i < cap(tc.high); i++ {
-			_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+			_, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any { return nil })
 			assert.NoError(t, err)
 		}
 
 		tc.Shutdown(ctx)
 		synctest.Wait()
 
-		_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+		_, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any { return nil })
 		assert.Error(t, err)
 		assert.False(t, errors.Is(err, ErrTrafficQueueFull))
 		assert.Contains(t, err.Error(), "shutdown")
@@ -125,7 +125,7 @@ func TestAPITrafficController_ShutdownWinsDuringSubmitRace(t *testing.T) {
 
 		result := make(chan error, 1)
 		go func() {
-			_, err := tc.Submit(PriorityUser, func(ctx context.Context) any { return nil })
+			_, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any { return nil })
 			result <- err
 		}()
 
@@ -139,5 +139,26 @@ func TestAPITrafficController_ShutdownWinsDuringSubmitRace(t *testing.T) {
 		assert.False(t, errors.Is(err, ErrTrafficQueueFull))
 		assert.Contains(t, err.Error(), "shutdown")
 		assert.Equal(t, 0, len(tc.high))
+	})
+}
+
+func TestAPITrafficController_ShutdownCancelsRunningTaskContext(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+
+		started := make(chan struct{})
+		resChan, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+		assert.NoError(t, err)
+
+		<-started
+		tc.Shutdown(ctx)
+		synctest.Wait()
+
+		assert.ErrorIs(t, (<-resChan).(error), context.Canceled)
 	})
 }

--- a/internal/api/traffic_test.go
+++ b/internal/api/traffic_test.go
@@ -32,7 +32,7 @@ func TestTrafficController_Concurrency(t *testing.T) {
 		for i := 0; i < taskCount; i++ {
 			go func(id int) {
 				defer wg.Done()
-				resChan, err := tc.Submit(PriorityEnrich, func(ctx context.Context) any {
+				resChan, err := tc.Submit(context.Background(), PriorityEnrich, func(ctx context.Context) any {
 					time.Sleep(50 * time.Millisecond) // Simulate API latency
 					return nil
 				})
@@ -65,7 +65,7 @@ func TestTrafficController_UserPriorityPreemption(t *testing.T) {
 
 		// 1. Flood with low priority slow tasks
 		for i := 0; i < 10; i++ {
-			_, _ = tc.Submit(PriorityEnrich, func(ctx context.Context) any {
+			_, _ = tc.Submit(context.Background(), PriorityEnrich, func(ctx context.Context) any {
 				time.Sleep(100 * time.Millisecond)
 				return nil
 			})
@@ -75,7 +75,7 @@ func TestTrafficController_UserPriorityPreemption(t *testing.T) {
 		start := time.Now()
 		highDone := make(chan struct{})
 		go func() {
-			resChan, err := tc.Submit(PriorityUser, func(ctx context.Context) any {
+			resChan, err := tc.Submit(context.Background(), PriorityUser, func(ctx context.Context) any {
 				return nil
 			})
 			assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestTrafficController_ScalingStress(t *testing.T) {
 				case <-stopTasks:
 					return
 				default:
-					_, err := tc.Submit(PriorityEnrich, func(ctx context.Context) any {
+					_, err := tc.Submit(context.Background(), PriorityEnrich, func(ctx context.Context) any {
 						time.Sleep(10 * time.Millisecond)
 						atomic.AddInt64(&tasksCompleted, 1)
 						return nil
@@ -198,12 +198,12 @@ func TestTrafficController_SubmitReturnsQueueFullInsteadOfBlocking(t *testing.T)
 			synctest.Wait()
 
 			for i := 0; i < tcDef.capacity; i++ {
-				resChan, err := tc.Submit(tcDef.priority, func(ctx context.Context) any { return nil })
+				resChan, err := tc.Submit(context.Background(), tcDef.priority, func(ctx context.Context) any { return nil })
 				assert.NoErrorf(t, err, "%s queue should accept task %d within capacity", tcDef.name, i)
 				assert.NotNilf(t, resChan, "%s queue should return response channel within capacity", tcDef.name)
 			}
 
-			resChan, err := tc.Submit(tcDef.priority, func(ctx context.Context) any { return nil })
+			resChan, err := tc.Submit(context.Background(), tcDef.priority, func(ctx context.Context) any { return nil })
 			assert.Nilf(t, resChan, "%s queue should reject task when full", tcDef.name)
 			assert.ErrorIsf(t, err, ErrTrafficQueueFull, "%s queue should fail fast when full", tcDef.name)
 
@@ -221,10 +221,85 @@ func TestTrafficController_SubmitStillEnqueuesWhenCapacityAvailable(t *testing.T
 		tc := NewAPITrafficController(ctx, slog.Default())
 		defer tc.Shutdown(ctx)
 
-		resChan, err := tc.Submit(PrioritySync, func(ctx context.Context) any {
+		resChan, err := tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
 			return "ok"
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, "ok", <-resChan)
+	})
+}
+
+func TestTrafficController_SubmitAlreadyCanceledContextSkipsExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		atomic.StoreInt32(&tc.workerLimit, 0)
+		synctest.Wait()
+
+		taskCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		executed := make(chan struct{}, 1)
+		resChan, err := tc.Submit(taskCtx, PrioritySync, func(ctx context.Context) any {
+			close(executed)
+			return "unexpected"
+		})
+		assert.NoError(t, err)
+		synctest.Wait()
+
+		assert.Equal(t, 0, len(tc.med), "already-canceled tasks should not occupy the queue")
+		assert.Nil(t, <-resChan)
+		assert.Empty(t, executed)
+	})
+}
+
+func TestTrafficController_QueuedCanceledContextSkipsExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		atomic.StoreInt32(&tc.workerLimit, 0)
+		synctest.Wait()
+
+		taskCtx, cancel := context.WithCancel(context.Background())
+		executed := make(chan struct{}, 1)
+		resChan, err := tc.Submit(taskCtx, PrioritySync, func(ctx context.Context) any {
+			close(executed)
+			return "unexpected"
+		})
+		assert.NoError(t, err)
+
+		cancel()
+		atomic.StoreInt32(&tc.workerLimit, 1)
+		synctest.Wait()
+
+		assert.Nil(t, <-resChan)
+		assert.Empty(t, executed)
+	})
+}
+
+func TestTrafficController_RunningTaskObservesRequestCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		taskCtx, cancel := context.WithCancel(context.Background())
+		started := make(chan struct{})
+		resChan, err := tc.Submit(taskCtx, PriorityUser, func(ctx context.Context) any {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+		assert.NoError(t, err)
+
+		<-started
+		cancel()
+		synctest.Wait()
+
+		assert.ErrorIs(t, (<-resChan).(error), context.Canceled)
 	})
 }

--- a/internal/mocks/mock_traffic_controller.go
+++ b/internal/mocks/mock_traffic_controller.go
@@ -164,8 +164,8 @@ func (_c *MockTrafficController_Shutdown_Call) RunAndReturn(run func(ctx context
 }
 
 // Submit provides a mock function for the type MockTrafficController
-func (_mock *MockTrafficController) Submit(priority int, fn types.TaskFunc) (<-chan any, error) {
-	ret := _mock.Called(priority, fn)
+func (_mock *MockTrafficController) Submit(ctx context.Context, priority int, fn types.TaskFunc) (<-chan any, error) {
+	ret := _mock.Called(ctx, priority, fn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Submit")
@@ -173,18 +173,18 @@ func (_mock *MockTrafficController) Submit(priority int, fn types.TaskFunc) (<-c
 
 	var r0 <-chan any
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, types.TaskFunc) (<-chan any, error)); ok {
-		return returnFunc(priority, fn)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, types.TaskFunc) (<-chan any, error)); ok {
+		return returnFunc(ctx, priority, fn)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, types.TaskFunc) <-chan any); ok {
-		r0 = returnFunc(priority, fn)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, types.TaskFunc) <-chan any); ok {
+		r0 = returnFunc(ctx, priority, fn)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan any)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, types.TaskFunc) error); ok {
-		r1 = returnFunc(priority, fn)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, types.TaskFunc) error); ok {
+		r1 = returnFunc(ctx, priority, fn)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -197,25 +197,31 @@ type MockTrafficController_Submit_Call struct {
 }
 
 // Submit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - priority int
 //   - fn types.TaskFunc
-func (_e *MockTrafficController_Expecter) Submit(priority interface{}, fn interface{}) *MockTrafficController_Submit_Call {
-	return &MockTrafficController_Submit_Call{Call: _e.mock.On("Submit", priority, fn)}
+func (_e *MockTrafficController_Expecter) Submit(ctx interface{}, priority interface{}, fn interface{}) *MockTrafficController_Submit_Call {
+	return &MockTrafficController_Submit_Call{Call: _e.mock.On("Submit", ctx, priority, fn)}
 }
 
-func (_c *MockTrafficController_Submit_Call) Run(run func(priority int, fn types.TaskFunc)) *MockTrafficController_Submit_Call {
+func (_c *MockTrafficController_Submit_Call) Run(run func(ctx context.Context, priority int, fn types.TaskFunc)) *MockTrafficController_Submit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 types.TaskFunc
+		var arg1 int
 		if args[1] != nil {
-			arg1 = args[1].(types.TaskFunc)
+			arg1 = args[1].(int)
+		}
+		var arg2 types.TaskFunc
+		if args[2] != nil {
+			arg2 = args[2].(types.TaskFunc)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -226,7 +232,7 @@ func (_c *MockTrafficController_Submit_Call) Return(vCh <-chan any, err error) *
 	return _c
 }
 
-func (_c *MockTrafficController_Submit_Call) RunAndReturn(run func(priority int, fn types.TaskFunc) (<-chan any, error)) *MockTrafficController_Submit_Call {
+func (_c *MockTrafficController_Submit_Call) RunAndReturn(run func(ctx context.Context, priority int, fn types.TaskFunc) (<-chan any, error)) *MockTrafficController_Submit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -12,6 +13,14 @@ import (
 )
 
 var _ = slog.LevelInfo
+
+func enrichmentBatchScope(chunk []triage.NotificationWithState) string {
+	ids := make([]string, 0, len(chunk))
+	for _, n := range chunk {
+		ids = append(ids, n.GitHubID)
+	}
+	return "enrich:batch:" + strings.Join(ids, ",")
+}
 
 // MarkReadByID marks a notification as read using only its ID.
 func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
@@ -26,7 +35,7 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 	m.applyFilters()
 
 	// 2. Persistent Local & Remote Update via Traffic Controller
-	return m.submitTask(api.PriorityUser, func(ctx context.Context) any {
+	return m.submitTask("read:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
 		err := m.db.MarkReadLocally(ctx, id, read)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "failed to update local read state", "error", err)
@@ -46,7 +55,7 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 
 // setPriorityByID updates the priority of a notification using only its ID.
 func (m *Model) setPriorityByID(id string, priority int) tea.Cmd {
-	return m.submitTask(api.PriorityUser, func(ctx context.Context) any {
+	return m.submitTask("priority:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
 		err := m.db.SetPriority(ctx, id, priority)
 		if err != nil {
 			return types.ErrMsg{Err: err}
@@ -104,7 +113,7 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState, force bool)
 	// We use PriorityEnrich for proactive discovery to avoid blocking user actions
 	for _, n := range discovery {
 		id, url, st := n.GitHubID, n.SubjectURL, n.SubjectType
-		cmds = append(cmds, m.submitTask(api.PriorityEnrich, func(ctx context.Context) any {
+		cmds = append(cmds, m.submitTask("enrich:detail:"+id, 0, api.PriorityEnrich, func(ctx context.Context) any {
 			res, err := m.enrich.FetchDetail(ctx, url, string(st), force)
 			if err != nil {
 				return types.ErrMsg{Err: err}
@@ -133,7 +142,7 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState, force bool)
 		}
 		chunk := batch[i:end]
 
-		cmds = append(cmds, m.submitTask(api.PriorityEnrich, func(ctx context.Context) any {
+		cmds = append(cmds, m.submitTask(enrichmentBatchScope(chunk), 0, api.PriorityEnrich, func(ctx context.Context) any {
 			results := m.enrich.FetchHybridBatch(ctx, chunk, force)
 			return enrichmentBatchCompleteMsg{Results: results}
 		}))
@@ -151,7 +160,7 @@ func (m *Model) ToggleRead(i item) tea.Cmd {
 }
 
 func (m *Model) FetchDetailCmd(id, u string, subjectType triage.SubjectType, force bool) tea.Cmd {
-	return m.submitTask(api.PriorityUser, func(ctx context.Context) any {
+	return m.submitTask("detail:view", 0, api.PriorityUser, func(ctx context.Context) any {
 		res, err := m.enrich.FetchDetail(ctx, u, string(subjectType), force)
 		if err != nil {
 			return types.ErrMsg{Err: err}

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -117,7 +117,7 @@ func (i *Interpreter) executeOpenBrowser(u string) tea.Cmd {
 		}
 	}
 
-	return i.model.submitTask(api.PriorityUser, func(ctx context.Context) any {
+	return i.model.submitTask("browser:"+u, 0, api.PriorityUser, func(ctx context.Context) any {
 		i.model.logger.InfoContext(ctx, "opening browser", "url", u)
 		b := browser.New("", nil, nil)
 		if err := b.Browse(u); err != nil {
@@ -210,7 +210,7 @@ func (i *Interpreter) executeGHView(ghCmd, repo, arg string) tea.Cmd {
 		return func() tea.Msg { return types.ErrMsg{Err: fmt.Errorf("invalid number: %s", arg)} }
 	}
 
-	return i.model.submitTask(api.PriorityUser, func(ctx context.Context) any {
+	return i.model.submitTask("gh-view:"+ghCmd+":"+repo+":"+arg, 0, api.PriorityUser, func(ctx context.Context) any {
 		i.model.logger.InfoContext(ctx, "executing gh view", "command", ghCmd, "repo", repo, "arg", arg)
 		if err := i.model.executor.Run(ctx, "gh", ghCmd, "view", arg, "-R", repo, "--web"); err != nil {
 			i.model.logger.ErrorContext(ctx, "gh view command failed", "command", ghCmd, "error", err)

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -47,7 +47,7 @@ func TestInterpreter_Execute(t *testing.T) {
 	interp := NewInterpreter(m)
 
 	// Mock Submit for all actions that use it
-	m.traffic.(*mocks.MockTrafficController).EXPECT().Submit(mock.Anything, mock.Anything).Return(make(chan any), nil).Maybe()
+	m.traffic.(*mocks.MockTrafficController).EXPECT().Submit(mock.Anything, mock.Anything, mock.Anything).Return(make(chan any), nil).Maybe()
 	m.traffic.(*mocks.MockTrafficController).EXPECT().UpdateRateLimit(mock.Anything, mock.Anything).Return().Maybe()
 
 	mockExecutor := m.executor.(*mocks.MockCommandExecutor)
@@ -118,11 +118,11 @@ func TestInterpreter_Execute_UpdateRateLimitStandaloneMode(t *testing.T) {
 func TestModel_submitTask_SubmitErrorReturnsErrMsg(t *testing.T) {
 	m := newTestModel(t)
 	m.traffic.(*mocks.MockTrafficController).EXPECT().
-		Submit(api.PrioritySync, mock.Anything).
+		Submit(mock.Anything, api.PrioritySync, mock.Anything).
 		Return(nil, api.ErrTrafficQueueFull).
 		Once()
 
-	cmd := m.submitTask(api.PrioritySync, func(ctx context.Context) any { return "unreachable" })
+	cmd := m.submitTask("sync:test", 0, api.PrioritySync, func(ctx context.Context) any { return "unreachable" })
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
@@ -161,6 +161,31 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *t
 	m.handleTransitionError(errMsg)
 	assert.False(t, m.ui.syncing)
 	assert.ErrorIs(t, m.err, context.DeadlineExceeded)
+}
+
+func TestModel_submitTaskScopedRequestCancelsPreviousTask(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic = nil
+
+	started := make(chan struct{})
+	firstDone := make(chan tea.Msg, 1)
+	first := m.submitTask("shared-scope", 0, api.PrioritySync, func(ctx context.Context) any {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	go func() {
+		firstDone <- executeCmd(first)
+	}()
+
+	<-started
+	second := m.submitTask("shared-scope", 0, api.PrioritySync, func(ctx context.Context) any {
+		return "second"
+	})
+	require.NotNil(t, second)
+	assert.Equal(t, "second", executeCmd(second))
+	assert.ErrorIs(t, (<-firstDone).(error), context.Canceled)
 }
 
 func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedAsBenign(t *testing.T) {
@@ -212,10 +237,10 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	m.client.(*mocks.MockClient).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
 	m.traffic.(*mocks.MockTrafficController).EXPECT().
-		Submit(api.PriorityUser, mock.Anything).
-		RunAndReturn(func(priority int, fn types.TaskFunc) (<-chan any, error) {
+		Submit(mock.Anything, api.PriorityUser, mock.Anything).
+		RunAndReturn(func(ctx context.Context, priority int, fn types.TaskFunc) (<-chan any, error) {
 			ch := make(chan any, 1)
-			ch <- fn(context.Background())
+			ch <- fn(ctx)
 			return ch, nil
 		}).
 		Once()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"charm.land/bubbles/v2/help"
@@ -109,11 +110,19 @@ type Model struct {
 
 	// Enrichment Management
 	inflightEnrichments map[string]time.Time
+	taskCancelMu        sync.Mutex
+	taskCancelSeq       uint64
+	taskCancels         map[string]scopedTaskCancel
 
 	lastQuitPress time.Time
 	executor      types.CommandExecutor
 
 	syncStarted bool
+}
+
+type scopedTaskCancel struct {
+	id     uint64
+	cancel context.CancelFunc
 }
 
 // Option defines a functional option for Model configuration.
@@ -230,6 +239,7 @@ func NewModel(p ModelParams) (*Model, error) {
 		heartbeatInterval:   time.Duration(p.Config.Notifications.SyncInterval) * time.Second,
 		clockInterval:       1 * time.Minute,
 		inflightEnrichments: make(map[string]time.Time),
+		taskCancels:         make(map[string]scopedTaskCancel),
 		executor:            api.NewOSCommandExecutor(), // Default executor
 	}
 
@@ -281,6 +291,7 @@ func (m *Model) tickEnrich() tea.Cmd {
 func (m *Model) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	m.cancelScopedTasks()
 
 	if m.sync != nil {
 		m.sync.Shutdown(ctx)
@@ -296,14 +307,20 @@ func (m *Model) Shutdown() {
 	}
 }
 
-func (m *Model) submitTask(priority int, fn types.TaskFunc) tea.Cmd {
+func (m *Model) submitTask(scope string, timeout time.Duration, priority int, fn types.TaskFunc) tea.Cmd {
 	return func() tea.Msg {
+		ctx, release := m.newTaskContext(scope, timeout)
+		defer release()
+
 		if m.traffic == nil {
 			// In MCP mode or if traffic controller is missing, execute immediately
-			return fn(context.Background())
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fn(ctx)
 		}
 
-		resChan, err := m.traffic.Submit(priority, fn)
+		resChan, err := m.traffic.Submit(ctx, priority, fn)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
@@ -311,9 +328,58 @@ func (m *Model) submitTask(priority int, fn types.TaskFunc) tea.Cmd {
 	}
 }
 
+func (m *Model) newTaskContext(scope string, timeout time.Duration) (context.Context, func()) {
+	base := context.Background()
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(base, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(base)
+	}
+
+	if scope == "" {
+		return ctx, cancel
+	}
+
+	m.taskCancelMu.Lock()
+	m.taskCancelSeq++
+	id := m.taskCancelSeq
+	if prev, ok := m.taskCancels[scope]; ok {
+		prev.cancel()
+	}
+	m.taskCancels[scope] = scopedTaskCancel{id: id, cancel: cancel}
+	m.taskCancelMu.Unlock()
+
+	return ctx, func() {
+		cancel()
+		m.taskCancelMu.Lock()
+		if current, ok := m.taskCancels[scope]; ok && current.id == id {
+			delete(m.taskCancels, scope)
+		}
+		m.taskCancelMu.Unlock()
+	}
+}
+
+func (m *Model) cancelScopedTasks() {
+	m.taskCancelMu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(m.taskCancels))
+	for _, scoped := range m.taskCancels {
+		cancels = append(cancels, scoped.cancel)
+	}
+	clear(m.taskCancels)
+	m.taskCancelMu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
 // loadNotifications loads the full list of notifications from local database.
 func (m *Model) loadNotifications(isInitial bool, isForced bool) tea.Cmd {
-	return m.submitTask(api.PrioritySync, func(ctx context.Context) any {
+	return m.submitTask("notifications:load", 0, api.PrioritySync, func(ctx context.Context) any {
 		notifs, err := m.db.ListNotifications(ctx)
 		if err != nil {
 			return types.ErrMsg{Err: err}
@@ -324,20 +390,7 @@ func (m *Model) loadNotifications(isInitial bool, isForced bool) tea.Cmd {
 }
 
 func (m *Model) syncNotificationsWithForce(force bool) tea.Cmd {
-	if m.traffic == nil {
-		return func() tea.Msg {
-			ctx, cancel := context.WithTimeout(context.Background(), types.ConnectedSyncTimeout)
-			defer cancel()
-
-			rl, err := m.sync.Sync(ctx, m.userID, force)
-			if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
-				return types.ErrMsg{Err: err}
-			}
-			return syncCompleteMsg{rateLimit: rl, IsForced: force}
-		}
-	}
-
-	return m.submitTask(api.PrioritySync, func(ctx context.Context) any {
+	return m.submitTask("notifications:sync", types.ConnectedSyncTimeout, api.PrioritySync, func(ctx context.Context) any {
 		rl, err := m.sync.Sync(ctx, m.userID, force)
 		if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
 			return types.ErrMsg{Err: err}

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -106,7 +106,7 @@ type TaskFunc func(context.Context) any
 
 // TrafficController defines the interface for serialized API access.
 type TrafficController interface {
-	Submit(priority int, fn TaskFunc) (<-chan any, error)
+	Submit(ctx context.Context, priority int, fn TaskFunc) (<-chan any, error)
 	UpdateRateLimit(ctx context.Context, info models.RateLimitInfo)
 	Remaining() int
 	ReportRateLimit(info models.RateLimitInfo)


### PR DESCRIPTION
## Summary
- add request-scoped cancellation to `APITrafficController.Submit` while preserving controller-shutdown cancellation for in-flight work
- short-circuit already-canceled tasks before queue admission and add regression coverage for canceled queued/running work
- wire scoped request contexts through TUI submission paths so superseded sync/detail/enrichment actions cancel older work in the same scope

## Verification
- `go test ./internal/api/... ./internal/tui/...`
- `golangci-lint run ./internal/api/... ./internal/tui/...`

## Notes
- Closes #289.
- `make check` was not fully green in this sandbox because unrelated engine/e2e tests require socket or listener binding that is blocked here; focused API/TUI verification passed locally and CI will validate the full suite.
