### PR TITLE
Clear stale traffic controller lockout state

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -209,6 +209,8 @@ func (c *APITrafficController) UpdateRateLimit(ctx context.Context, info models.
 	// Check for lockout (primary fallback)
 	if info.Remaining == 0 && !info.Reset.IsZero() {
 		c.lockoutUntil.Store(&info.Reset)
+	} else if info.Remaining > 0 {
+		c.lockoutUntil.Store(nil)
 	}
 }
 

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -58,6 +58,35 @@ func TestAPITrafficController_Background(t *testing.T) {
 	})
 }
 
+func TestAPITrafficController_LockoutClearsAfterHealthyRecovery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		reset := time.Now().Add(time.Hour)
+		tc.UpdateRateLimit(ctx, models.RateLimitInfo{Remaining: 0, Reset: reset})
+
+		res, err := tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
+			return "should-not-run"
+		})
+		assert.NoError(t, err)
+		synctest.Wait()
+		assert.Nil(t, <-res, "sync task should be skipped while lockout is active")
+
+		tc.UpdateRateLimit(ctx, models.RateLimitInfo{Remaining: 1000, Reset: reset})
+
+		res, err = tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
+			return "recovered"
+		})
+		assert.NoError(t, err)
+		synctest.Wait()
+		assert.Equal(t, "recovered", <-res, "healthy update should clear stale lockout state")
+	})
+}
+
 func TestAPITrafficController_Shutdown_Channels(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
## Summary
- clear stale `lockoutUntil` when a later rate-limit update reports recovered quota
- add a regression test that uses `PrioritySync` with recovered quota to isolate lockout recovery from the separate low-quota enrichment throttle

## Verification
- `go test ./internal/api/...`
- `golangci-lint run ./internal/api/...`

## Notes
- Closes #287.
