### PR TITLE
Clean up MCP adapter shutdown lifecycle

### DIFF
--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/api"
@@ -37,6 +38,7 @@ type MCPAdapter struct {
 
 	debounceTimer *time.Timer
 	debounceMu    sync.Mutex
+	shutdown      atomic.Bool
 }
 
 func NewMCPAdapter(c client.MCPClient) *MCPAdapter {
@@ -62,14 +64,25 @@ func (a *MCPAdapter) OnMutation(fn func()) {
 }
 
 func (a *MCPAdapter) handleResourceUpdate(n mcp.JSONRPCNotification) {
+	if a.shutdown.Load() {
+		return
+	}
+
 	a.debounceMu.Lock()
 	defer a.debounceMu.Unlock()
+
+	if a.shutdown.Load() {
+		return
+	}
 
 	if a.debounceTimer != nil {
 		a.debounceTimer.Stop()
 	}
 
 	a.debounceTimer = time.AfterFunc(200*time.Millisecond, func() {
+		if a.shutdown.Load() {
+			return
+		}
 		a.mu.RLock()
 		if a.onMutation != nil {
 			a.onMutation()
@@ -250,7 +263,17 @@ func decodeSyncToolResult(resp *mcp.CallToolResult) (syncToolResult, bool) {
 	return payload, true
 }
 
-func (a *MCPAdapter) Shutdown(ctx context.Context)     {}
+func (a *MCPAdapter) Shutdown(ctx context.Context) {
+	a.shutdown.Store(true)
+
+	a.debounceMu.Lock()
+	defer a.debounceMu.Unlock()
+
+	if a.debounceTimer != nil {
+		a.debounceTimer.Stop()
+		a.debounceTimer = nil
+	}
+}
 func (a *MCPAdapter) BridgeStatus() types.BridgeStatus { return types.StatusHealthy }
 
 // --- types.Enricher Implementation ---

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -222,6 +222,79 @@ func TestMCPAdapter_Debounce(t *testing.T) {
 	})
 }
 
+func TestMCPAdapter_ShutdownStopsPendingDebounceTimer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := NewMCPAdapter(nil)
+		var count int32
+
+		a.OnMutation(func() {
+			atomic.AddInt32(&count, 1)
+		})
+
+		a.handleResourceUpdate(mcp.JSONRPCNotification{})
+		time.Sleep(100 * time.Millisecond)
+		a.Shutdown(context.Background())
+		time.Sleep(300 * time.Millisecond)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&count), "shutdown should stop pending debounce delivery")
+	})
+}
+
+func TestMCPAdapter_PostShutdownNotificationsAreNoOp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := NewMCPAdapter(nil)
+		var count int32
+
+		a.OnMutation(func() {
+			atomic.AddInt32(&count, 1)
+		})
+
+		a.Shutdown(context.Background())
+		a.handleResourceUpdate(mcp.JSONRPCNotification{})
+		time.Sleep(300 * time.Millisecond)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&count), "notifications after shutdown should not arm callbacks")
+	})
+}
+
+func TestMCPAdapter_ShutdownDoesNotWaitForRunningCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := NewMCPAdapter(nil)
+		var startedCount int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		a.OnMutation(func() {
+			if atomic.AddInt32(&startedCount, 1) == 1 {
+				close(started)
+			}
+			<-release
+		})
+
+		a.handleResourceUpdate(mcp.JSONRPCNotification{})
+		time.Sleep(250 * time.Millisecond)
+		<-started
+
+		shutdownDone := make(chan struct{})
+		go func() {
+			a.Shutdown(context.Background())
+			close(shutdownDone)
+		}()
+
+		select {
+		case <-shutdownDone:
+		case <-time.After(time.Second):
+			t.Fatal("shutdown should not block on an already-running callback")
+		}
+
+		a.handleResourceUpdate(mcp.JSONRPCNotification{})
+		close(release)
+		time.Sleep(300 * time.Millisecond)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&startedCount), "no new callbacks should start after shutdown")
+	})
+}
+
 func TestMCPServer_EventLoopUnsubscribesOnShutdown(t *testing.T) {
 	bus := NewEventBus()
 	mcpServer := server.NewMCPServer(


### PR DESCRIPTION
## Summary
- publish MCP adapter shutdown state and stop any pending debounce timer during teardown
- reject post-shutdown notification scheduling and post-shutdown timer callback entry
- add focused teardown tests for pending timer cancellation, post-shutdown notification no-op behavior, and non-blocking shutdown while a callback is already running

## Verification
- \ok  	github.com/hirakiuc/gh-orbit/internal/engine	0.335s
- \0 issues.

## Notes
- Closes #297.
- \ok  	github.com/hirakiuc/gh-orbit/internal/engine	1.168s
ok  	github.com/hirakiuc/gh-orbit/internal/engine/transport	0.260s still hits existing MCP socket-test failures in this sandbox outside this diff.