### PR TITLE
Improve TUI manual sync feedback

### DIFF
--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -30,7 +30,8 @@ type ActionQuit struct{}
 func (a ActionQuit) Type() string { return "quit" }
 
 type ActionSyncNotifications struct {
-	Force bool
+	Force    bool
+	IsManual bool
 }
 
 func (a ActionSyncNotifications) Type() string { return "sync_notifications" }
@@ -106,6 +107,7 @@ func (a ActionEnrichItems) Type() string { return "enrich_items" }
 type ActionLoadNotifications struct {
 	IsInitial bool
 	IsForced  bool
+	IsManual  bool
 }
 
 func (a ActionLoadNotifications) Type() string { return "load_notifications" }

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -37,7 +37,7 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 	}
 
 	if a, ok := action.(ActionSyncNotifications); ok {
-		return i.model.syncNotificationsWithForce(a.Force)
+		return i.model.syncNotificationsWithForce(a.Force, a.IsManual)
 	}
 
 	if a, ok := action.(ActionMarkRead); ok {
@@ -69,7 +69,7 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 	}
 
 	if a, ok := action.(ActionLoadNotifications); ok {
-		return i.model.loadNotifications(a.IsInitial, a.IsForced)
+		return i.model.loadNotifications(a.IsInitial, a.IsForced, a.IsManual)
 	}
 
 	if a, ok := action.(ActionUpdateRateLimit); ok {

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -65,13 +65,13 @@ func TestInterpreter_Execute(t *testing.T) {
 	actions := []Action{
 		ActionQuit{},
 		ActionShowToast{Message: "msg"},
-		ActionSyncNotifications{Force: true},
+		ActionSyncNotifications{Force: true, IsManual: false},
 		ActionMarkRead{ID: "1", Read: true},
 		ActionSetPriority{ID: "1", Priority: 1},
 		ActionViewWeb{Notification: notif},
 		ActionCheckoutPR{Repository: "o/r", Number: "1"},
 		ActionEnrichItems{Notifications: []triage.NotificationWithState{notif}},
-		ActionLoadNotifications{IsInitial: true},
+		ActionLoadNotifications{IsInitial: true, IsManual: false},
 		ActionUpdateRateLimit{Info: models.RateLimitInfo{Remaining: 100}},
 		ActionScheduleTick{TickType: TickHeartbeat, Interval: time.Millisecond},
 		ActionScheduleTick{TickType: TickClock, Interval: time.Millisecond},
@@ -150,7 +150,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *t
 		}).
 		Once()
 
-	cmd := m.syncNotificationsWithForce(true)
+	cmd := m.syncNotificationsWithForce(true, false)
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
@@ -158,7 +158,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *t
 	require.True(t, ok)
 	assert.ErrorIs(t, errMsg.Err, context.DeadlineExceeded)
 
-	m.handleTransitionError(errMsg)
+	_ = m.handleTransitionError(errMsg)
 	assert.False(t, m.ui.syncing)
 	assert.ErrorIs(t, m.err, context.DeadlineExceeded)
 }
@@ -198,7 +198,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedA
 		Return(models.RateLimitInfo{Remaining: 999}, types.ErrSyncIntervalNotReached).
 		Once()
 
-	cmd := m.syncNotificationsWithForce(false)
+	cmd := m.syncNotificationsWithForce(false, false)
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
@@ -209,7 +209,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedA
 
 	actions := m.handleSyncComplete(syncMsg)
 	assert.False(t, m.ui.syncing)
-	assert.Contains(t, actions, ActionLoadNotifications{IsInitial: false, IsForced: false})
+	assert.Contains(t, actions, ActionLoadNotifications{IsInitial: false, IsForced: false, IsManual: false})
 }
 
 func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
@@ -269,8 +269,52 @@ func TestModel_Transition_EdgeCases(t *testing.T) {
 
 	// 3. Sync Complete
 	actions = m.Transition(syncCompleteMsg{rateLimit: models.RateLimitInfo{Remaining: 500}}, 0)
-	assert.Contains(t, actions, ActionLoadNotifications{IsInitial: false})
+	assert.Contains(t, actions, ActionLoadNotifications{IsInitial: false, IsManual: false})
 	assert.Equal(t, 500, m.RateLimit.Remaining)
+}
+
+func TestModel_HandleSyncKey_AlreadyRunningShowsToast(t *testing.T) {
+	m := newTestModel(t)
+	m.ui.SetSyncing(true)
+
+	actions := m.handleSyncKey()
+	assert.Contains(t, actions, ActionShowToast{Message: "Sync already in progress"})
+}
+
+func TestModel_HandleNotificationsLoaded_ManualNoChangeShowsToast(t *testing.T) {
+	m := newTestModel(t)
+	notifs := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}
+	m.manualSyncPending = true
+	m.manualSyncSnapshot = notificationStateSignature(notifs)
+
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifs, IsManual: true})
+	assert.Contains(t, actions, ActionShowToast{Message: "No new notifications"})
+	assert.False(t, m.manualSyncPending)
+	assert.Empty(t, m.manualSyncSnapshot)
+}
+
+func TestModel_HandleNotificationsLoaded_ManualUpdatedShowsToast(t *testing.T) {
+	m := newTestModel(t)
+	before := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}
+	after := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "2"}}}
+	m.manualSyncPending = true
+	m.manualSyncSnapshot = notificationStateSignature(before)
+
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: after, IsManual: true})
+	assert.Contains(t, actions, ActionShowToast{Message: "Sync complete"})
+	assert.False(t, m.manualSyncPending)
+	assert.Empty(t, m.manualSyncSnapshot)
+}
+
+func TestModel_HandleTransitionError_ManualSyncShowsFailureToast(t *testing.T) {
+	m := newTestModel(t)
+	m.manualSyncPending = true
+	m.manualSyncSnapshot = "snapshot"
+
+	actions := m.handleTransitionError(types.ErrMsg{Err: context.DeadlineExceeded})
+	assert.Contains(t, actions, ActionShowToast{Message: "Sync failed"})
+	assert.False(t, m.manualSyncPending)
+	assert.Empty(t, m.manualSyncSnapshot)
 }
 
 func TestModel_Transition_Navigation(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -113,6 +113,8 @@ type Model struct {
 	taskCancelMu        sync.Mutex
 	taskCancelSeq       uint64
 	taskCancels         map[string]scopedTaskCancel
+	manualSyncPending   bool
+	manualSyncSnapshot  string
 
 	lastQuitPress time.Time
 	executor      types.CommandExecutor
@@ -257,7 +259,7 @@ func NewModel(p ModelParams) (*Model, error) {
 // Init sets up initial application state and background workers.
 func (m *Model) Init() tea.Cmd {
 	return tea.Batch(
-		m.loadNotifications(true, false),
+		m.loadNotifications(true, false, false),
 		m.tickClock(),
 		m.checkFocusMode(),
 	)
@@ -378,24 +380,24 @@ func (m *Model) cancelScopedTasks() {
 }
 
 // loadNotifications loads the full list of notifications from local database.
-func (m *Model) loadNotifications(isInitial bool, isForced bool) tea.Cmd {
+func (m *Model) loadNotifications(isInitial bool, isForced bool, isManual bool) tea.Cmd {
 	return m.submitTask("notifications:load", 0, api.PrioritySync, func(ctx context.Context) any {
 		notifs, err := m.db.ListNotifications(ctx)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 		// Initial load triggers initial enrichment
-		return notificationsLoadedMsg{notifications: notifs, IsInitial: isInitial, IsForced: isForced}
+		return notificationsLoadedMsg{notifications: notifs, IsInitial: isInitial, IsForced: isForced, IsManual: isManual}
 	})
 }
 
-func (m *Model) syncNotificationsWithForce(force bool) tea.Cmd {
+func (m *Model) syncNotificationsWithForce(force bool, isManual bool) tea.Cmd {
 	return m.submitTask("notifications:sync", types.ConnectedSyncTimeout, api.PrioritySync, func(ctx context.Context) any {
 		rl, err := m.sync.Sync(ctx, m.userID, force)
 		if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
 			return types.ErrMsg{Err: err}
 		}
-		return syncCompleteMsg{rateLimit: rl, IsForced: force}
+		return syncCompleteMsg{rateLimit: rl, IsForced: force, IsManual: isManual}
 	})
 }
 
@@ -421,6 +423,7 @@ type notificationsLoadedMsg struct {
 	notifications []triage.NotificationWithState
 	IsInitial     bool
 	IsForced      bool
+	IsManual      bool
 }
 
 type priorityUpdatedMsg struct {
@@ -431,6 +434,7 @@ type priorityUpdatedMsg struct {
 type syncCompleteMsg struct {
 	rateLimit models.RateLimitInfo
 	IsForced  bool
+	IsManual  bool
 }
 type detailLoadedMsg struct {
 	GitHubID         string
@@ -456,3 +460,7 @@ type (
 	pollTickMsg  struct{ ID uint64 }
 	clockTickMsg struct{ ID uint64 }
 )
+
+func notificationStateSignature(notifications []triage.NotificationWithState) string {
+	return fmt.Sprintf("%#v", notifications)
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -85,7 +85,7 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		}
 		return []Action{ActionEnrichItems{Notifications: m.getVisibleNotifications(false)}}
 	case types.ErrMsg:
-		m.handleTransitionError(msg)
+		return m.handleTransitionError(msg)
 	}
 
 	return nil
@@ -428,6 +428,16 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 		ActionEnrichItems{Notifications: m.getVisibleNotifications(msg.IsForced), Force: msg.IsForced},
 	}
 
+	if msg.IsManual {
+		toast := "Sync complete"
+		if notificationStateSignature(msg.notifications) == m.manualSyncSnapshot {
+			toast = "No new notifications"
+		}
+		m.manualSyncPending = false
+		m.manualSyncSnapshot = ""
+		actions = append(actions, ActionShowToast{Message: toast})
+	}
+
 	if msg.IsInitial && !m.syncStarted {
 		m.syncStarted = true
 		actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
@@ -449,7 +459,7 @@ func (m *Model) handleSyncComplete(msg syncCompleteMsg) []Action {
 	m.updateQuotaResetStatus()
 	return []Action{
 		ActionUpdateRateLimit{Info: msg.rateLimit},
-		ActionLoadNotifications{IsInitial: false, IsForced: msg.IsForced},
+		ActionLoadNotifications{IsInitial: false, IsForced: msg.IsForced, IsManual: msg.IsManual},
 	}
 }
 
@@ -539,7 +549,7 @@ func (m *Model) handlePollTick(msg pollTickMsg) []Action {
 	}
 
 	m.ui.SetSyncing(true)
-	return append(actions, ActionSyncNotifications{Force: false})
+	return append(actions, ActionSyncNotifications{Force: false, IsManual: false})
 }
 
 func (m *Model) handleClockTick(msg clockTickMsg) []Action {
@@ -553,12 +563,20 @@ func (m *Model) handleClockTick(msg clockTickMsg) []Action {
 	}
 }
 
-func (m *Model) handleTransitionError(msg types.ErrMsg) {
+func (m *Model) handleTransitionError(msg types.ErrMsg) []Action {
 	m.err = msg.Err
 	m.ui.SetSyncing(false)
 	m.ui.SetFetching(false)
 	// Clear inflight on error to allow retry
 	m.inflightEnrichments = make(map[string]time.Time)
+
+	if m.manualSyncPending {
+		m.manualSyncPending = false
+		m.manualSyncSnapshot = ""
+		return []Action{ActionShowToast{Message: "Sync failed"}}
+	}
+
+	return nil
 }
 
 func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
@@ -653,10 +671,12 @@ func (m *Model) handlePriorityKeys(msg tea.KeyMsg) []Action {
 
 func (m *Model) handleSyncKey() []Action {
 	if m.ui.syncing {
-		return nil
+		return []Action{ActionShowToast{Message: "Sync already in progress"}}
 	}
+	m.manualSyncPending = true
+	m.manualSyncSnapshot = notificationStateSignature(m.allNotifications)
 	m.ui.SetSyncing(true)
-	return []Action{ActionSyncNotifications{Force: true}}
+	return []Action{ActionSyncNotifications{Force: true, IsManual: true}}
 }
 
 func (m *Model) handleToggleDetailKey() []Action {


### PR DESCRIPTION
## Summary
- thread manual sync intent through the existing TUI action and message flow
- surface direct feedback when manual sync is already in progress
- resolve manual sync outcomes after the post-sync reload as `Sync complete`, `No new notifications`, or `Sync failed` based on pre/post notification state and the existing error path

## Verification
- `go test ./internal/tui/...`
- `golangci-lint run ./internal/tui/...`

## Notes
- Closes #292.
