### PR TITLE
Fix TUI sync status repaint timing

### DIFF
--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -97,6 +97,18 @@ type ActionShowToast struct {
 
 func (a ActionShowToast) Type() string { return "show_toast" }
 
+type ActionSetSyncing struct {
+	Enabled bool
+}
+
+func (a ActionSetSyncing) Type() string { return "set_syncing" }
+
+type ActionSetFetching struct {
+	Enabled bool
+}
+
+func (a ActionSetFetching) Type() string { return "set_fetching" }
+
 type ActionEnrichItems struct {
 	Notifications []triage.NotificationWithState
 	Force         bool

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -36,6 +36,14 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 		return i.model.ui.SetToast(a.Message)
 	}
 
+	if a, ok := action.(ActionSetSyncing); ok {
+		return i.model.ui.SetSyncing(a.Enabled)
+	}
+
+	if a, ok := action.(ActionSetFetching); ok {
+		return i.model.ui.SetFetching(a.Enabled)
+	}
+
 	if a, ok := action.(ActionSyncNotifications); ok {
 		return i.model.syncNotificationsWithForce(a.Force, a.IsManual)
 	}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -65,6 +65,8 @@ func TestInterpreter_Execute(t *testing.T) {
 	actions := []Action{
 		ActionQuit{},
 		ActionShowToast{Message: "msg"},
+		ActionSetSyncing{Enabled: true},
+		ActionSetFetching{Enabled: true},
 		ActionSyncNotifications{Force: true, IsManual: false},
 		ActionMarkRead{ID: "1", Read: true},
 		ActionSetPriority{ID: "1", Priority: 1},
@@ -273,12 +275,40 @@ func TestModel_Transition_EdgeCases(t *testing.T) {
 	assert.Equal(t, 500, m.RateLimit.Remaining)
 }
 
+func TestModel_HandlePollTick_StartsSyncingViaAction(t *testing.T) {
+	m := newTestModel(t)
+	m.heartbeatID = 7
+	m.LastSyncAt = time.Now().Add(-time.Duration(m.PollInterval+1) * time.Second)
+
+	actions := m.handlePollTick(pollTickMsg{ID: 7})
+	assert.Contains(t, actions, ActionSetSyncing{Enabled: true})
+	assert.Contains(t, actions, ActionSyncNotifications{Force: false, IsManual: false})
+}
+
+func TestModel_HandlePollTick_WithinIntervalDoesNotStartSyncing(t *testing.T) {
+	m := newTestModel(t)
+	m.heartbeatID = 7
+	m.LastSyncAt = time.Now()
+
+	actions := m.handlePollTick(pollTickMsg{ID: 7})
+	assert.NotContains(t, actions, ActionSetSyncing{Enabled: true})
+	assert.NotContains(t, actions, ActionSyncNotifications{Force: false, IsManual: false})
+}
+
 func TestModel_HandleSyncKey_AlreadyRunningShowsToast(t *testing.T) {
 	m := newTestModel(t)
 	m.ui.SetSyncing(true)
 
 	actions := m.handleSyncKey()
 	assert.Contains(t, actions, ActionShowToast{Message: "Sync already in progress"})
+}
+
+func TestModel_HandleSyncKey_StartsSyncingViaAction(t *testing.T) {
+	m := newTestModel(t)
+
+	actions := m.handleSyncKey()
+	assert.Contains(t, actions, ActionSetSyncing{Enabled: true})
+	assert.Contains(t, actions, ActionSyncNotifications{Force: true, IsManual: true})
 }
 
 func TestModel_HandleNotificationsLoaded_ManualNoChangeShowsToast(t *testing.T) {
@@ -341,6 +371,7 @@ func TestModel_Transition_Navigation(t *testing.T) {
 	actions := m.Transition(msg, 0)
 	assert.Equal(t, StateDetail, m.state)
 	// Should return ActionEnrichItems because notif.IsEnriched is false
+	assert.Contains(t, actions, ActionSetFetching{Enabled: true})
 	assert.Contains(t, actions, ActionEnrichItems{Notifications: []triage.NotificationWithState{notif}})
 
 	// 2. Return to List View
@@ -370,6 +401,34 @@ func TestModel_Transition_Priority(t *testing.T) {
 	msg = keyPress("0") // Matches PriorityNone
 	actions = m.Transition(msg, 0)
 	assert.Contains(t, actions, ActionSetPriority{ID: "1", Priority: 0})
+}
+
+func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {
+	m := newTestModel(t)
+	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+
+	notif := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "1",
+			SubjectURL:  "https://api.github.com/repos/o/r/issues/1",
+			SubjectType: triage.SubjectIssue,
+			IsEnriched:  true,
+			UpdatedAt:   time.Now(),
+		},
+	}
+	m.allNotifications = []triage.NotificationWithState{notif}
+	m.applyFilters()
+	m.listView.list.Select(0)
+	m.state = StateDetail
+
+	actions := m.Transition(keyPress("r"), 0)
+	assert.Contains(t, actions, ActionSetFetching{Enabled: true})
+	assert.Contains(t, actions, ActionFetchDetail{
+		ID:          notif.GitHubID,
+		URL:         notif.SubjectURL,
+		SubjectType: notif.SubjectType,
+		Force:       true,
+	})
 }
 
 func TestModel_Transition_Tabs(t *testing.T) {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -115,8 +115,7 @@ func (m *Model) transitionDetail(msg tea.Msg) []Action {
 			m.state = StateList
 		case key.Matches(msg, m.keys.Sync):
 			if n, ok := m.selectedNotification(); ok {
-				m.ui.SetFetching(true)
-				actions = append(actions, ActionFetchDetail{
+				actions = append(actions, ActionSetFetching{Enabled: true}, ActionFetchDetail{
 					ID:          n.GitHubID,
 					URL:         n.SubjectURL,
 					SubjectType: n.SubjectType,
@@ -548,8 +547,10 @@ func (m *Model) handlePollTick(msg pollTickMsg) []Action {
 		return actions
 	}
 
-	m.ui.SetSyncing(true)
-	return append(actions, ActionSyncNotifications{Force: false, IsManual: false})
+	return append(actions,
+		ActionSetSyncing{Enabled: true},
+		ActionSyncNotifications{Force: false, IsManual: false},
+	)
 }
 
 func (m *Model) handleClockTick(msg clockTickMsg) []Action {
@@ -675,8 +676,10 @@ func (m *Model) handleSyncKey() []Action {
 	}
 	m.manualSyncPending = true
 	m.manualSyncSnapshot = notificationStateSignature(m.allNotifications)
-	m.ui.SetSyncing(true)
-	return []Action{ActionSyncNotifications{Force: true, IsManual: true}}
+	return []Action{
+		ActionSetSyncing{Enabled: true},
+		ActionSyncNotifications{Force: true, IsManual: true},
+	}
 }
 
 func (m *Model) handleToggleDetailKey() []Action {
@@ -688,8 +691,10 @@ func (m *Model) handleToggleDetailKey() []Action {
 	m.state = StateDetail
 	actions := []Action{}
 	if !n.IsEnriched {
-		m.ui.SetFetching(true)
-		actions = append(actions, ActionEnrichItems{Notifications: []triage.NotificationWithState{n}})
+		actions = append(actions,
+			ActionSetFetching{Enabled: true},
+			ActionEnrichItems{Notifications: []triage.NotificationWithState{n}},
+		)
 	}
 	m.refreshDetailView()
 	return actions


### PR DESCRIPTION
## Summary
- route spinner-start UI state changes through interpreter-executed actions
- ensure sync and fetch start paths schedule the initial Bubble Tea spinner tick
- add regression coverage for manual sync, heartbeat sync, and detail fetch/enrichment entry

## Testing
- env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/tui/...
- env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home golangci-lint run ./internal/tui/...

Closes #325
