### PR TITLE
Simplify traffic controller rate-limit reporting

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -56,37 +56,30 @@ type APITrafficController struct {
 	done               chan struct{}
 	workerWG           sync.WaitGroup
 
-	rateLimitUpdates chan models.RateLimitInfo
-
 	submitBeforeLockHook func()
 }
 
 func NewAPITrafficController(ctx context.Context, logger *slog.Logger) *APITrafficController {
 	controllerCtx, cancel := context.WithCancel(ctx)
 	c := &APITrafficController{
-		ctx:              controllerCtx,
-		cancel:           cancel,
-		logger:           logger,
-		high:             make(chan *apiTask, 10),
-		med:              make(chan *apiTask, 50),
-		low:              make(chan *apiTask, 100),
-		workerLimit:      3, // Default concurrency
-		done:             make(chan struct{}),
-		rateLimitUpdates: make(chan models.RateLimitInfo, 100),
+		ctx:         controllerCtx,
+		cancel:      cancel,
+		logger:      logger,
+		high:        make(chan *apiTask, 10),
+		med:         make(chan *apiTask, 50),
+		low:         make(chan *apiTask, 100),
+		workerLimit: 3, // Default concurrency
+		done:        make(chan struct{}),
 	}
 
 	// Initialize rate limit info with safe defaults
 	c.rlInfo.Store(&models.RateLimitInfo{Remaining: 5000})
 
-	// Start background routines
-	c.workerWG.Add(2)
+	// Start background supervisor
+	c.workerWG.Add(1)
 	go func() {
 		defer c.workerWG.Done()
 		c.supervisor()
-	}()
-	go func() {
-		defer c.workerWG.Done()
-		c.rateLimitListener()
 	}()
 
 	return c
@@ -97,13 +90,15 @@ func (c *APITrafficController) Remaining() int {
 }
 
 func (c *APITrafficController) ReportRateLimit(info models.RateLimitInfo) {
-	select {
-	case <-c.done:
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
+
+	if c.ctx.Err() != nil {
 		// Drop late updates after shutdown starts.
-	case c.rateLimitUpdates <- info:
-	default:
-		// Drop update if channel is full.
+		return
 	}
+
+	c.UpdateRateLimit(c.ctx, info)
 }
 
 func (c *APITrafficController) Submit(ctx context.Context, priority int, fn types.TaskFunc) (<-chan any, error) {
@@ -313,22 +308,6 @@ func (c *APITrafficController) runTask(t *apiTask) {
 	}
 
 	t.resp <- t.fn(t.ctx)
-}
-
-func (c *APITrafficController) rateLimitListener() {
-	for {
-		select {
-		case <-c.done:
-			// Drain remaining updates if any during shutdown
-			c.logger.DebugContext(context.Background(), "traffic controller: rate limit listener stopping")
-			return
-		case info, ok := <-c.rateLimitUpdates:
-			if !ok {
-				return
-			}
-			c.UpdateRateLimit(c.ctx, info)
-		}
-	}
 }
 
 func (c *APITrafficController) Shutdown(ctx context.Context) {

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -21,7 +21,7 @@ func TestAPITrafficController_Background(t *testing.T) {
 		tc := NewAPITrafficController(ctx, slog.Default())
 		defer tc.Shutdown(ctx)
 
-		// 1. RateLimitListener scaling
+		// 1. ReportRateLimit scaling
 		tc.ReportRateLimit(models.RateLimitInfo{Remaining: 100})
 		synctest.Wait()
 		assert.Equal(t, int32(1), atomic.LoadInt32(&tc.workerLimit))
@@ -55,6 +55,26 @@ func TestAPITrafficController_Background(t *testing.T) {
 		})
 		synctest.Wait()
 		assert.Nil(t, <-res, "Enrich task should be skipped during low quota")
+	})
+}
+
+func TestAPITrafficController_ReportRateLimit_UpdatesStateSynchronously(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		tc.ReportRateLimit(models.RateLimitInfo{Limit: 5000, Remaining: 100})
+		synctest.Wait()
+
+		assert.Equal(t, 100, tc.Remaining())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&tc.workerLimit))
+
+		tc.ReportRateLimit(models.RateLimitInfo{Limit: 5000, Remaining: 1000})
+		synctest.Wait()
+
+		assert.Equal(t, 1000, tc.Remaining())
+		assert.Equal(t, int32(3), atomic.LoadInt32(&tc.workerLimit))
 	})
 }
 
@@ -92,7 +112,6 @@ func TestAPITrafficController_Shutdown_Channels(t *testing.T) {
 		ctx := context.Background()
 		tc := NewAPITrafficController(ctx, slog.Default())
 
-		// Verify listener stops on channel closure (simulated by Shutdown)
 		tc.Shutdown(ctx)
 		synctest.Wait()
 
@@ -114,6 +133,7 @@ func TestAPITrafficController_ReportRateLimit_AfterShutdownDoesNotPanic(t *testi
 		assert.NotPanics(t, func() {
 			tc.ReportRateLimit(models.RateLimitInfo{Remaining: 42})
 		})
+		assert.Equal(t, 5000, tc.Remaining())
 	})
 }
 


### PR DESCRIPTION
## Summary
- remove the leftover internal rate-limit queue/listener from `APITrafficController`
- make `ReportRateLimit(...)` a synchronous method-level wrapper with a shutdown guard
- keep regression coverage focused on observable reporting behavior

## Testing
- env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/api/...
- env GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home golangci-lint run ./internal/api/...

Closes #288
