### PR TITLE
Fix enrichment cache pruning TTL handling (#294)

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -73,12 +73,17 @@ func (e *EnrichmentEngine) Shutdown(ctx context.Context) {
 	e.logger.DebugContext(ctx, "enrichment engine shutdown complete")
 }
 
+func (e *EnrichmentEngine) contentTTL() time.Duration {
+	if e.config == nil {
+		return ContentTTL
+	}
+
+	return time.Duration(e.config.Enrichment.ContentTTLSeconds) * time.Second
+}
+
 // FetchDetail retrieves detailed information for a notification from GitHub.
 func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
-	contentTTL := 10 * time.Minute
-	if e.config != nil {
-		contentTTL = time.Duration(e.config.Enrichment.ContentTTLSeconds) * time.Second
-	}
+	contentTTL := e.contentTTL()
 
 	// 1. Check local cache (unless forced)
 	if !force {
@@ -522,9 +527,10 @@ func (e *EnrichmentEngine) pruneExpired(ctx context.Context) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	contentTTL := e.contentTTL()
 	count := 0
 	for u, res := range e.cache {
-		if time.Since(res.FetchedAt) > ContentTTL {
+		if time.Since(res.FetchedAt) > contentTTL {
 			delete(e.cache, u)
 			count++
 		}

--- a/internal/api/enrichment_test.go
+++ b/internal/api/enrichment_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
@@ -247,10 +248,16 @@ func TestEnrichmentEngine_Pruning(t *testing.T) {
 		DB:     mocks.NewMockEnrichmentRepository(t),
 		Logger: slog.Default(),
 	})
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+	engine.config = &config.Config{
+		Enrichment: config.EnrichmentConfig{
+			ContentTTLSeconds: 60,
+		},
+	}
 
 	engine.mu.Lock()
-	engine.cache["old"] = models.EnrichmentResult{FetchedAt: time.Now().Add(-20 * time.Minute)}
-	engine.cache["new"] = models.EnrichmentResult{FetchedAt: time.Now()}
+	engine.cache["old"] = models.EnrichmentResult{FetchedAt: time.Now().Add(-2 * time.Minute)}
+	engine.cache["new"] = models.EnrichmentResult{FetchedAt: time.Now().Add(-30 * time.Second)}
 	engine.mu.Unlock()
 
 	engine.pruneExpired(ctx)
@@ -259,6 +266,35 @@ func TestEnrichmentEngine_Pruning(t *testing.T) {
 	defer engine.mu.RUnlock()
 	assert.NotContains(t, engine.cache, "old")
 	assert.Contains(t, engine.cache, "new")
+}
+
+func TestEnrichmentEngine_ContentTTL(t *testing.T) {
+	t.Run("NilConfigFallsBackToDefault", func(t *testing.T) {
+		engine := &EnrichmentEngine{}
+		assert.Equal(t, ContentTTL, engine.contentTTL())
+	})
+
+	t.Run("ConfiguredZeroTTLIsPreserved", func(t *testing.T) {
+		engine := &EnrichmentEngine{
+			config: &config.Config{
+				Enrichment: config.EnrichmentConfig{
+					ContentTTLSeconds: 0,
+				},
+			},
+		}
+		assert.Zero(t, engine.contentTTL())
+	})
+
+	t.Run("ConfiguredTTLIsUsed", func(t *testing.T) {
+		engine := &EnrichmentEngine{
+			config: &config.Config{
+				Enrichment: config.EnrichmentConfig{
+					ContentTTLSeconds: 45,
+				},
+			},
+		}
+		assert.Equal(t, 45*time.Second, engine.contentTTL())
+	})
 }
 
 func TestNewEnrichmentEngine_Guards(t *testing.T) {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -547,7 +547,8 @@ func (m *Model) handlePollTick(msg pollTickMsg) []Action {
 		return actions
 	}
 
-	return append(actions,
+	return append(
+		actions,
 		ActionSetSyncing{Enabled: true},
 		ActionSyncNotifications{Force: false, IsManual: false},
 	)
@@ -691,7 +692,8 @@ func (m *Model) handleToggleDetailKey() []Action {
 	m.state = StateDetail
 	actions := []Action{}
 	if !n.IsEnriched {
-		actions = append(actions,
+		actions = append(
+			actions,
 			ActionSetFetching{Enabled: true},
 			ActionEnrichItems{Notifications: []triage.NotificationWithState{n}},
 		)


### PR DESCRIPTION
## Summary
- align enrichment cache pruning with the same content TTL policy used by `FetchDetail`
- preserve existing nil-config fallback and explicit zero-TTL semantics
- add regression coverage for configured TTL pruning and TTL helper behavior

## Verification
- `make go/build`
- `make go/test`
- `make go/check`

Closes #294
