### PR TITLE
Fix AppLifecycle signal cleanup on shutdown (#295)

### DIFF
--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -9,8 +9,9 @@ import (
 
 // AppLifecycle manages the global application context and signal handling.
 type AppLifecycle struct {
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx     context.Context
+	cancel  context.CancelFunc
+	sigChan chan os.Signal
 }
 
 // NewAppLifecycle creates a new lifecycle manager linked to system signals.
@@ -18,17 +19,17 @@ func NewAppLifecycle(parent context.Context) *AppLifecycle {
 	ctx, cancel := context.WithCancel(parent)
 
 	l := &AppLifecycle{
-		ctx:    ctx,
-		cancel: cancel,
+		ctx:     ctx,
+		cancel:  cancel,
+		sigChan: make(chan os.Signal, 1),
 	}
 
 	// Handle termination signals
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(l.sigChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
 		select {
-		case <-sigChan:
+		case <-l.sigChan:
 			cancel()
 		case <-ctx.Done():
 			// Already canceled
@@ -45,5 +46,8 @@ func (l *AppLifecycle) Context() context.Context {
 
 // Shutdown manually triggers the lifecycle cancellation.
 func (l *AppLifecycle) Shutdown() {
+	if l.sigChan != nil {
+		signal.Stop(l.sigChan)
+	}
 	l.cancel()
 }

--- a/internal/api/lifecycle_test.go
+++ b/internal/api/lifecycle_test.go
@@ -47,3 +47,34 @@ func TestAppLifecycle_Shutdown(t *testing.T) {
 		t.Fatal("lifecycle context was not canceled after Shutdown()")
 	}
 }
+
+func TestAppLifecycle_ShutdownIsIdempotent(t *testing.T) {
+	l := NewAppLifecycle(context.Background())
+
+	assert.NotNil(t, l.sigChan)
+
+	l.Shutdown()
+	l.Shutdown()
+
+	select {
+	case <-l.Context().Done():
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("lifecycle context was not canceled after repeated Shutdown()")
+	}
+}
+
+func TestAppLifecycle_RepeatedCreateShutdown(t *testing.T) {
+	for i := 0; i < 25; i++ {
+		l := NewAppLifecycle(context.Background())
+		assert.NotNil(t, l.sigChan)
+		l.Shutdown()
+
+		select {
+		case <-l.Context().Done():
+			// Success
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("lifecycle context was not canceled during repeated create/shutdown sequence")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- retain the AppLifecycle-owned signal channel so shutdown can unregister it explicitly
- call `signal.Stop(...)` during shutdown before canceling the lifecycle context
- add regression coverage for repeated shutdown and repeated create/shutdown sequences

## Verification
- `make go/build`
- `make go/test`
- `make go/check`

Closes #295