### PR TITLE
Add owner-aware enrichment cache invalidation (#296)

### DIFF
--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -32,6 +32,7 @@ type EnrichmentEngine struct {
 	db         types.EnrichmentRepository
 	logger     *slog.Logger
 	cache      map[string]models.EnrichmentResult
+	nodeToURLs map[string]map[string]struct{}
 	mu         sync.RWMutex
 	sf         singleflight.Group
 	done       chan struct{}
@@ -56,6 +57,7 @@ func NewEnrichmentEngine(ctx context.Context, p EnrichParams) (*EnrichmentEngine
 		db:         p.DB,
 		logger:     p.Logger,
 		cache:      make(map[string]models.EnrichmentResult),
+		nodeToURLs: make(map[string]map[string]struct{}),
 		done:       make(chan struct{}),
 		config:     cfg,
 		OnMutation: func() {}, // Default no-op
@@ -79,6 +81,48 @@ func (e *EnrichmentEngine) contentTTL() time.Duration {
 	}
 
 	return time.Duration(e.config.Enrichment.ContentTTLSeconds) * time.Second
+}
+
+func (e *EnrichmentEngine) rememberCacheEntryLocked(cacheKey string, res models.EnrichmentResult) {
+	e.cache[cacheKey] = res
+
+	if res.SubjectNodeID == "" {
+		return
+	}
+
+	aliases := e.nodeToURLs[res.SubjectNodeID]
+	if aliases == nil {
+		aliases = make(map[string]struct{})
+		e.nodeToURLs[res.SubjectNodeID] = aliases
+	}
+
+	aliases[cacheKey] = struct{}{}
+	if res.HTMLURL != "" {
+		aliases[res.HTMLURL] = struct{}{}
+	}
+}
+
+func (e *EnrichmentEngine) invalidateByURLLocked(url string) {
+	for nodeID, aliases := range e.nodeToURLs {
+		if _, ok := aliases[url]; !ok {
+			continue
+		}
+
+		for alias := range aliases {
+			delete(e.cache, alias)
+		}
+		delete(e.nodeToURLs, nodeID)
+		return
+	}
+
+	delete(e.cache, url)
+}
+
+func (e *EnrichmentEngine) invalidateByNodeIDLocked(nodeID string) {
+	for url := range e.nodeToURLs[nodeID] {
+		delete(e.cache, url)
+	}
+	delete(e.nodeToURLs, nodeID)
 }
 
 // FetchDetail retrieves detailed information for a notification from GitHub.
@@ -152,7 +196,7 @@ func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectTyp
 
 		// 3. Update cache
 		e.mu.Lock()
-		e.cache[u] = res
+		e.rememberCacheEntryLocked(u, res)
 		e.mu.Unlock()
 
 		return res, nil
@@ -163,6 +207,38 @@ func (e *EnrichmentEngine) FetchDetail(ctx context.Context, u string, subjectTyp
 	}
 
 	return val.(models.EnrichmentResult), nil
+}
+
+func (e *EnrichmentEngine) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
+	if err := e.db.EnrichNotification(ctx, id, res.SubjectNodeID, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	e.rememberCacheEntryLocked(sourceURL, res)
+	e.mu.Unlock()
+
+	e.OnMutation()
+
+	return nil
+}
+
+func (e *EnrichmentEngine) PersistIndependentDetail(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
+	if err := e.db.EnrichNotification(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	if nodeID != "" {
+		e.invalidateByNodeIDLocked(nodeID)
+	} else if htmlURL != "" {
+		e.invalidateByURLLocked(htmlURL)
+	}
+	e.mu.Unlock()
+
+	e.OnMutation()
+
+	return nil
 }
 
 func (e *EnrichmentEngine) fetchPullRequestGQL(ctx context.Context, u string) (models.EnrichmentResult, error) {
@@ -497,6 +573,10 @@ func (e *EnrichmentEngine) updateNodeState(ctx context.Context, nodeID, state, s
 	if err := e.db.UpdateResourceStateByNodeID(ctx, nodeID, state, subState); err != nil {
 		e.logger.ErrorContext(ctx, "enrichment: failed to update resource state", "node_id", nodeID, "error", err)
 	}
+
+	e.mu.Lock()
+	e.invalidateByNodeIDLocked(nodeID)
+	e.mu.Unlock()
 
 	results[nodeID] = models.EnrichmentResult{
 		ResourceState:    state,

--- a/internal/api/enrichment_test.go
+++ b/internal/api/enrichment_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -295,6 +296,191 @@ func TestEnrichmentEngine_ContentTTL(t *testing.T) {
 		}
 		assert.Equal(t, 45*time.Second, engine.contentTTL())
 	})
+}
+
+func TestEnrichmentEngine_PersistFetchedDetailPreservesCache(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(t)
+	mockRepo := mocks.NewMockEnrichmentRepository(t)
+
+	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
+		Client: mockClient,
+		DB:     mockRepo,
+		Logger: slog.Default(),
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+
+	res := models.EnrichmentResult{
+		SubjectNodeID: "node-1",
+		Body:          "fresh body",
+		Author:        "octocat",
+		HTMLURL:       "https://github.com/o/r/pull/1",
+		FetchedAt:     time.Now(),
+	}
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-1", "node-1", "fresh body", "octocat", "https://github.com/o/r/pull/1", "", "").
+		Return(nil).
+		Once()
+
+	err = engine.PersistFetchedDetail(ctx, "notif-1", "https://api.github.com/repos/o/r/pulls/1", res)
+	assert.NoError(t, err)
+
+	got, err := engine.FetchDetail(ctx, "https://api.github.com/repos/o/r/pulls/1", "PullRequest", false)
+	assert.NoError(t, err)
+	assert.Equal(t, "fresh body", got.Body)
+	assert.Equal(t, "node-1", got.SubjectNodeID)
+}
+
+func TestEnrichmentEngine_PersistIndependentDetailInvalidatesCacheByNodeID(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(t)
+	mockRepo := mocks.NewMockEnrichmentRepository(t)
+	mockREST := mocks.NewMockRESTClient(t)
+
+	mockClient.EXPECT().REST().Return(mockREST).Maybe()
+
+	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
+		Client: mockClient,
+		DB:     mockRepo,
+		Logger: slog.Default(),
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+
+	cached := models.EnrichmentResult{
+		SubjectNodeID: "node-2",
+		Body:          "cached body",
+		Author:        "octocat",
+		HTMLURL:       "https://github.com/o/r/issues/2",
+		FetchedAt:     time.Now(),
+	}
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-2", "node-2", "cached body", "octocat", "https://github.com/o/r/issues/2", "", "").
+		Return(nil).
+		Once()
+	assert.NoError(t, engine.PersistFetchedDetail(ctx, "notif-2", "https://api.github.com/repos/o/r/issues/2", cached))
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-2", "node-2", "persisted body", "hirakiuc", "https://github.com/o/r/issues/2", "Closed", "COMPLETED").
+		Return(nil).
+		Once()
+	assert.NoError(t, engine.PersistIndependentDetail(ctx, "notif-2", "node-2", "persisted body", "hirakiuc", "https://github.com/o/r/issues/2", "Closed", "COMPLETED"))
+
+	mockREST.EXPECT().DoWithContext(mock.Anything, "GET", "https://api.github.com/repos/o/r/issues/2", nil, mock.Anything).Run(func(ctx context.Context, method string, path string, body io.Reader, response any) {
+		res := response.(*struct {
+			ID      string `json:"node_id"`
+			Body    string `json:"body"`
+			HTMLURL string `json:"html_url"`
+			User    struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			State       string  `json:"state"`
+			StateReason *string `json:"state_reason"`
+		})
+		res.ID = "node-2"
+		res.Body = "refetched body"
+		res.HTMLURL = "https://github.com/o/r/issues/2"
+		res.User.Login = "hirakiuc"
+	}).Return(nil).Once()
+
+	got, err := engine.FetchDetail(ctx, "https://api.github.com/repos/o/r/issues/2", "Issue", false)
+	assert.NoError(t, err)
+	assert.Equal(t, "refetched body", got.Body)
+}
+
+func TestEnrichmentEngine_PersistIndependentDetailInvalidatesCacheByHTMLURL(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(t)
+	mockRepo := mocks.NewMockEnrichmentRepository(t)
+	mockREST := mocks.NewMockRESTClient(t)
+
+	mockClient.EXPECT().REST().Return(mockREST).Maybe()
+
+	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
+		Client: mockClient,
+		DB:     mockRepo,
+		Logger: slog.Default(),
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+
+	cached := models.EnrichmentResult{
+		SubjectNodeID: "node-4",
+		Body:          "cached body",
+		Author:        "octocat",
+		HTMLURL:       "https://github.com/o/r/issues/4",
+		FetchedAt:     time.Now(),
+	}
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-4", "node-4", "cached body", "octocat", "https://github.com/o/r/issues/4", "", "").
+		Return(nil).
+		Once()
+	assert.NoError(t, engine.PersistFetchedDetail(ctx, "notif-4", "https://api.github.com/repos/o/r/issues/4", cached))
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-4", "", "persisted body", "hirakiuc", "https://github.com/o/r/issues/4", "Closed", "COMPLETED").
+		Return(nil).
+		Once()
+	assert.NoError(t, engine.PersistIndependentDetail(ctx, "notif-4", "", "persisted body", "hirakiuc", "https://github.com/o/r/issues/4", "Closed", "COMPLETED"))
+
+	mockREST.EXPECT().DoWithContext(mock.Anything, "GET", "https://api.github.com/repos/o/r/issues/4", nil, mock.Anything).Run(func(ctx context.Context, method string, path string, body io.Reader, response any) {
+		res := response.(*struct {
+			ID      string `json:"node_id"`
+			Body    string `json:"body"`
+			HTMLURL string `json:"html_url"`
+			User    struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			State       string  `json:"state"`
+			StateReason *string `json:"state_reason"`
+		})
+		res.ID = "node-4"
+		res.Body = "refetched from html-url invalidation"
+		res.HTMLURL = "https://github.com/o/r/issues/4"
+		res.User.Login = "hirakiuc"
+	}).Return(nil).Once()
+
+	got, err := engine.FetchDetail(ctx, "https://api.github.com/repos/o/r/issues/4", "Issue", false)
+	assert.NoError(t, err)
+	assert.Equal(t, "refetched from html-url invalidation", got.Body)
+}
+
+func TestEnrichmentEngine_UpdateNodeStateInvalidatesCacheByNodeID(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(t)
+	mockRepo := mocks.NewMockEnrichmentRepository(t)
+
+	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
+		Client: mockClient,
+		DB:     mockRepo,
+		Logger: slog.Default(),
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-3", "node-3", "cached body", "octocat", "https://github.com/o/r/pull/3", "", "").
+		Return(nil).
+		Once()
+	assert.NoError(t, engine.PersistFetchedDetail(ctx, "notif-3", "https://api.github.com/repos/o/r/pulls/3", models.EnrichmentResult{
+		SubjectNodeID: "node-3",
+		Body:          "cached body",
+		Author:        "octocat",
+		HTMLURL:       "https://github.com/o/r/pull/3",
+		FetchedAt:     time.Now(),
+	}))
+
+	mockRepo.EXPECT().UpdateResourceStateByNodeID(mock.Anything, "node-3", "Merged", "APPROVED").Return(nil).Once()
+	engine.updateNodeState(ctx, "node-3", "Merged", "APPROVED", map[string]models.EnrichmentResult{})
+
+	engine.mu.RLock()
+	_, ok := engine.cache["https://api.github.com/repos/o/r/pulls/3"]
+	engine.mu.RUnlock()
+	assert.False(t, ok)
 }
 
 func TestNewEnrichmentEngine_Guards(t *testing.T) {

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -146,8 +146,26 @@ func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) e
 	return err
 }
 
-// No-ops for client mode (Engine is authority)
-func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
+func (a *MCPAdapter) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
+	_, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "persist_fetched_detail",
+			Arguments: map[string]any{
+				"id":                 id,
+				"source_url":         sourceURL,
+				"node_id":            res.SubjectNodeID,
+				"body":               res.Body,
+				"author":             res.Author,
+				"html_url":           res.HTMLURL,
+				"resource_state":     res.ResourceState,
+				"resource_sub_state": res.ResourceSubState,
+			},
+		},
+	})
+	return err
+}
+
+func (a *MCPAdapter) PersistIndependentDetail(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
 	_, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "enrich_notification",
@@ -163,6 +181,11 @@ func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, a
 		},
 	})
 	return err
+}
+
+// No-ops for client mode (Engine is authority)
+func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
+	return a.PersistIndependentDetail(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 }
 
 func (a *MCPAdapter) UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, resourceSubState string) error {

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/engine/transport"
+	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -495,6 +496,53 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 6. Enrichment Persistence Tool
+	persistFetchedDetailTool := mcp.NewTool(
+		"persist_fetched_detail",
+		mcp.WithDescription("Persist freshly fetched detail through the enrichment owner without self-evicting the cache"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The GitHub notification ID")),
+		mcp.WithString("source_url", mcp.Required(), mcp.Description("The source URL used for the fetch cache key")),
+		mcp.WithString("node_id", mcp.Description("The GitHub subject node ID")),
+		mcp.WithString("body", mcp.Description("The enriched body text")),
+		mcp.WithString("author", mcp.Description("The enriched author login")),
+		mcp.WithString("html_url", mcp.Description("The canonical GitHub HTML URL")),
+		mcp.WithString("resource_state", mcp.Description("The enriched resource state")),
+		mcp.WithString("resource_sub_state", mcp.Description("The enriched resource sub state")),
+	)
+
+	s.server.AddTool(persistFetchedDetailTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("invalid arguments format"), nil
+		}
+
+		id, _ := args["id"].(string)
+		sourceURL, _ := args["source_url"].(string)
+		if id == "" || sourceURL == "" {
+			return mcp.NewToolResultError("id and source_url are required"), nil
+		}
+
+		nodeID, _ := args["node_id"].(string)
+		body, _ := args["body"].(string)
+		author, _ := args["author"].(string)
+		htmlURL, _ := args["html_url"].(string)
+		resourceState, _ := args["resource_state"].(string)
+		resourceSubState, _ := args["resource_sub_state"].(string)
+
+		if err := s.engine.Enrich.PersistFetchedDetail(ctx, id, sourceURL, models.EnrichmentResult{
+			SubjectNodeID:    nodeID,
+			Body:             body,
+			Author:           author,
+			HTMLURL:          htmlURL,
+			ResourceState:    resourceState,
+			ResourceSubState: resourceSubState,
+			FetchedAt:        time.Now(),
+		}); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to persist fetched detail: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText("Fetched detail persisted"), nil
+	})
+
 	enrichNotificationTool := mcp.NewTool(
 		"enrich_notification",
 		mcp.WithDescription("Persist enriched notification fields through the engine-backed repository"),
@@ -525,7 +573,7 @@ func (s *MCPServer) registerTools() {
 		resourceState, _ := args["resource_state"].(string)
 		resourceSubState, _ := args["resource_sub_state"].(string)
 
-		if err := s.engine.DB.EnrichNotification(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState); err != nil {
+		if err := s.engine.Enrich.PersistIndependentDetail(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to persist enrichment: %v", err)), nil
 		}
 

--- a/internal/engine/mcp_enrichment_test.go
+++ b/internal/engine/mcp_enrichment_test.go
@@ -93,7 +93,7 @@ func decodeTextResult[T any](t *testing.T, resp *mcp.CallToolResult) T {
 }
 
 func TestMCPServer_EnrichmentTools(t *testing.T) {
-	srv, mockRepo, mockEnrich := newTestMCPServerForEnrichment(t)
+	srv, _, mockEnrich := newTestMCPServerForEnrichment(t)
 	client := newInMemoryMCPClient(t, srv)
 
 	t.Run("fetch_detail returns a real enrichment payload", func(t *testing.T) {
@@ -163,8 +163,8 @@ func TestMCPServer_EnrichmentTools(t *testing.T) {
 	})
 
 	t.Run("enrich_notification persists enriched fields", func(t *testing.T) {
-		mockRepo.EXPECT().
-			EnrichNotification(mock.Anything, "1", "node-1", "detail body", "hirakiuc", "https://github.com/o/r/pull/1", "OPEN", "APPROVED").
+		mockEnrich.EXPECT().
+			PersistIndependentDetail(mock.Anything, "1", "node-1", "detail body", "hirakiuc", "https://github.com/o/r/pull/1", "OPEN", "APPROVED").
 			Return(nil).
 			Once()
 
@@ -239,7 +239,7 @@ func TestMCPAdapter_FetchHybridBatch_ThroughMCP(t *testing.T) {
 }
 
 func TestMCPAdapter_SingleItemEnrichmentFlow_ThroughMCP(t *testing.T) {
-	srv, mockRepo, mockEnrich := newTestMCPServerForEnrichment(t)
+	srv, _, mockEnrich := newTestMCPServerForEnrichment(t)
 	client := newInMemoryMCPClient(t, srv)
 	adapter := NewMCPAdapter(client)
 
@@ -255,8 +255,8 @@ func TestMCPAdapter_SingleItemEnrichmentFlow_ThroughMCP(t *testing.T) {
 		FetchDetail(mock.Anything, "https://api.github.com/repos/o/r/pulls/3", "PullRequest", true).
 		Return(expected, nil).
 		Once()
-	mockRepo.EXPECT().
-		EnrichNotification(mock.Anything, "notif-3", "node-3", "persisted detail body", "octocat", "https://github.com/o/r/pull/3", "OPEN", "REVIEW_REQUIRED").
+	mockEnrich.EXPECT().
+		PersistIndependentDetail(mock.Anything, "notif-3", "node-3", "persisted detail body", "octocat", "https://github.com/o/r/pull/3", "OPEN", "REVIEW_REQUIRED").
 		Return(nil).
 		Once()
 

--- a/internal/engine/mcp_registration_test.go
+++ b/internal/engine/mcp_registration_test.go
@@ -38,6 +38,7 @@ func TestMCPServer_Registration_Coverage(t *testing.T) {
 		assert.Greater(t, len(tools), 0)
 		assert.Contains(t, tools, "fetch_detail")
 		assert.Contains(t, tools, "fetch_hybrid_batch")
+		assert.Contains(t, tools, "persist_fetched_detail")
 		assert.Contains(t, tools, "enrich_notification")
 	})
 }

--- a/internal/mocks/mock_enricher.go
+++ b/internal/mocks/mock_enricher.go
@@ -182,6 +182,138 @@ func (_c *MockEnricher_FetchHybridBatch_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// PersistFetchedDetail provides a mock function for the type MockEnricher
+func (_mock *MockEnricher) PersistFetchedDetail(ctx context.Context, id string, sourceURL string, res models.EnrichmentResult) error {
+	ret := _mock.Called(ctx, id, sourceURL, res)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PersistFetchedDetail")
+	}
+
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, models.EnrichmentResult) error); ok {
+		return returnFunc(ctx, id, sourceURL, res)
+	}
+
+	return ret.Error(0)
+}
+
+// MockEnricher_PersistFetchedDetail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistFetchedDetail'
+type MockEnricher_PersistFetchedDetail_Call struct {
+	*mock.Call
+}
+
+// PersistFetchedDetail is a helper method to define mock.On call
+func (_e *MockEnricher_Expecter) PersistFetchedDetail(ctx interface{}, id interface{}, sourceURL interface{}, res interface{}) *MockEnricher_PersistFetchedDetail_Call {
+	return &MockEnricher_PersistFetchedDetail_Call{Call: _e.mock.On("PersistFetchedDetail", ctx, id, sourceURL, res)}
+}
+
+func (_c *MockEnricher_PersistFetchedDetail_Call) Run(run func(ctx context.Context, id string, sourceURL string, res models.EnrichmentResult)) *MockEnricher_PersistFetchedDetail_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 models.EnrichmentResult
+		if args[3] != nil {
+			arg3 = args[3].(models.EnrichmentResult)
+		}
+		run(arg0, arg1, arg2, arg3)
+	})
+	return _c
+}
+
+func (_c *MockEnricher_PersistFetchedDetail_Call) Return(err error) *MockEnricher_PersistFetchedDetail_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockEnricher_PersistFetchedDetail_Call) RunAndReturn(run func(ctx context.Context, id string, sourceURL string, res models.EnrichmentResult) error) *MockEnricher_PersistFetchedDetail_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PersistIndependentDetail provides a mock function for the type MockEnricher
+func (_mock *MockEnricher) PersistIndependentDetail(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error {
+	ret := _mock.Called(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PersistIndependentDetail")
+	}
+
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) error); ok {
+		return returnFunc(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
+	}
+
+	return ret.Error(0)
+}
+
+// MockEnricher_PersistIndependentDetail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistIndependentDetail'
+type MockEnricher_PersistIndependentDetail_Call struct {
+	*mock.Call
+}
+
+// PersistIndependentDetail is a helper method to define mock.On call
+func (_e *MockEnricher_Expecter) PersistIndependentDetail(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockEnricher_PersistIndependentDetail_Call {
+	return &MockEnricher_PersistIndependentDetail_Call{Call: _e.mock.On("PersistIndependentDetail", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
+}
+
+func (_c *MockEnricher_PersistIndependentDetail_Call) Run(run func(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string)) *MockEnricher_PersistIndependentDetail_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
+		var arg6 string
+		if args[6] != nil {
+			arg6 = args[6].(string)
+		}
+		var arg7 string
+		if args[7] != nil {
+			arg7 = args[7].(string)
+		}
+		run(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	})
+	return _c
+}
+
+func (_c *MockEnricher_PersistIndependentDetail_Call) Return(err error) *MockEnricher_PersistIndependentDetail_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockEnricher_PersistIndependentDetail_Call) RunAndReturn(run func(ctx context.Context, id string, nodeID string, body string, author string, htmlURL string, resourceState string, resourceSubState string) error) *MockEnricher_PersistIndependentDetail_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Shutdown provides a mock function for the type MockEnricher
 func (_mock *MockEnricher) Shutdown(ctx context.Context) {
 	_mock.Called(ctx)

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -118,8 +118,7 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState, force bool)
 			if err != nil {
 				return types.ErrMsg{Err: err}
 			}
-			// Atomic DB update including nodeID
-			if err := m.db.EnrichNotification(ctx, id, res.SubjectNodeID, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState); err != nil {
+			if err := m.enrich.PersistFetchedDetail(ctx, id, url, res); err != nil {
 				return types.ErrMsg{Err: err}
 			}
 			return detailLoadedMsg{
@@ -166,9 +165,7 @@ func (m *Model) FetchDetailCmd(id, u string, subjectType triage.SubjectType, for
 			return types.ErrMsg{Err: err}
 		}
 
-		// Update database with granular enrich method
-		err = m.db.EnrichNotification(ctx, id, res.SubjectNodeID, res.Body, res.Author, res.HTMLURL, res.ResourceState, res.ResourceSubState)
-		if err != nil {
+		if err := m.enrich.PersistFetchedDetail(ctx, id, u, res); err != nil {
 			return types.ErrMsg{Err: err}
 		}
 

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -98,6 +98,8 @@ type Syncer interface {
 type Enricher interface {
 	FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error)
 	FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult
+	PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error
+	PersistIndependentDetail(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error
 	Shutdown(ctx context.Context)
 }
 


### PR DESCRIPTION
## Summary
- add owner-aware enrichment cache invalidation while keeping URL as the canonical cache key
- preserve fresh cache entries for normal fetch-and-persist flows
- invalidate affected entries for node-ID and HTML-URL-driven independent mutations

## Verification
- `make go/build`
- `make go/test`
- `make go/check`

Closes #296
