### PR TITLE
fix(tui): unify lifecycle ownership and shutdown

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -397,6 +397,13 @@ func runTUI() error {
 
 func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdapter, userID string) error {
 	lifecycle := api.NewAppLifecycle(ctx)
+	lifecycleOwned := true
+	defer func() {
+		if lifecycleOwned {
+			lifecycle.Shutdown()
+		}
+	}()
+
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   config.DefaultConfig(), // Placeholder or from engine
@@ -410,6 +417,7 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 		Alerter:  adapter, // Alerter (Mock/Engine bridge)
 		Options: []tui.Option{
 			tui.WithConnectionMode("Connected"),
+			tui.WithOwnedSubsystemShutdown(),
 			tui.WithVersion(buildinfo.Version),
 		},
 	})
@@ -417,6 +425,7 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 		return err
 	}
 
+	lifecycleOwned = false
 	return runProgram(lifecycle, m)
 }
 
@@ -425,6 +434,13 @@ func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.Core
 	eng.Client.SetRateLimitReporter(eng.Traffic.ReportRateLimit)
 
 	lifecycle := api.NewAppLifecycle(ctx)
+	lifecycleOwned := true
+	defer func() {
+		if lifecycleOwned {
+			lifecycle.Shutdown()
+		}
+	}()
+
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   eng.Config,
@@ -447,6 +463,7 @@ func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.Core
 		return err
 	}
 
+	lifecycleOwned = false
 	return runProgram(lifecycle, m)
 }
 

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -396,10 +396,12 @@ func runTUI() error {
 }
 
 func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdapter, userID string) error {
+	lifecycle := api.NewAppLifecycle(ctx)
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   config.DefaultConfig(), // Placeholder or from engine
 		Logger:   env.logger,
+		TaskRoot: lifecycle.Context(),
 		DB:       adapter, // Repository
 		Client:   nil,     // Client (unused in MCP mode)
 		Syncer:   adapter, // Syncer
@@ -415,17 +417,19 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 		return err
 	}
 
-	return runProgram(ctx, m)
+	return runProgram(lifecycle, m)
 }
 
 func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.CoreEngine, userID string) error {
 	// Step 6.15: Connect Client to TrafficController for intelligent rate limit propagation
 	eng.Client.SetRateLimitReporter(eng.Traffic.ReportRateLimit)
 
+	lifecycle := api.NewAppLifecycle(ctx)
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   eng.Config,
 		Logger:   env.logger,
+		TaskRoot: lifecycle.Context(),
 		DB:       eng.DB,
 		Client:   eng.Client,
 		Syncer:   eng.Sync,
@@ -443,14 +447,24 @@ func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.Core
 		return err
 	}
 
-	return runProgram(ctx, m)
+	return runProgram(lifecycle, m)
 }
 
-func runProgram(ctx context.Context, m *tui.Model) error {
-	lifecycle := api.NewAppLifecycle(ctx)
-	defer lifecycle.Shutdown()
+type teaProgram interface {
+	Run() (tea.Model, error)
+}
 
-	p := tea.NewProgram(m, tea.WithContext(lifecycle.Context()))
+var newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
+	return tea.NewProgram(m, opts...)
+}
+
+func runProgram(lifecycle *api.AppLifecycle, m *tui.Model) error {
+	defer func() {
+		lifecycle.Shutdown()
+		m.Shutdown()
+	}()
+
+	p := newTeaProgram(m, tea.WithContext(lifecycle.Context()))
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/hirakiuc/gh-orbit/internal/api"
@@ -24,7 +25,14 @@ func (f fakeTeaProgram) Run() (tea.Model, error) {
 	return f.run()
 }
 
-func newRunProgramTestModel(t *testing.T, taskRoot context.Context) *tui.Model {
+type runProgramTestDeps struct {
+	model    *tui.Model
+	syncer   *mocks.MockSyncer
+	enricher *mocks.MockEnricher
+	alerter  *mocks.MockAlerter
+}
+
+func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.Option) runProgramTestDeps {
 	t.Helper()
 
 	cfg := config.DefaultConfig()
@@ -37,15 +45,6 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context) *tui.Model {
 	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
-		err := ctx.Err()
-		_, hasDeadline := ctx.Deadline()
-		return err == nil && hasDeadline
-	})
-	syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   "user",
 		Config:   cfg,
@@ -55,10 +54,16 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context) *tui.Model {
 		Syncer:   syncer,
 		Enricher: enricher,
 		Alerter:  alerter,
+		Options:  opts,
 	})
 	assert.NoError(t, err)
 
-	return m
+	return runProgramTestDeps{
+		model:    m,
+		syncer:   syncer,
+		enricher: enricher,
+		alerter:  alerter,
+	}
 }
 
 func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
@@ -66,7 +71,15 @@ func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
 	t.Cleanup(func() { newTeaProgram = orig })
 
 	lifecycle := api.NewAppLifecycle(context.Background())
-	m := newRunProgramTestModel(t, lifecycle.Context())
+	deps := newRunProgramTestModel(t, lifecycle.Context(), tui.WithOwnedSubsystemShutdown())
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
 		return fakeTeaProgram{
@@ -76,7 +89,7 @@ func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
 		}
 	}
 
-	err := runProgram(lifecycle, m)
+	err := runProgram(lifecycle, deps.model)
 	assert.NoError(t, err)
 }
 
@@ -88,7 +101,15 @@ func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
 	t.Cleanup(cancel)
 
 	lifecycle := api.NewAppLifecycle(parent)
-	m := newRunProgramTestModel(t, lifecycle.Context())
+	deps := newRunProgramTestModel(t, lifecycle.Context(), tui.WithOwnedSubsystemShutdown())
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
 		return fakeTeaProgram{
@@ -99,7 +120,7 @@ func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
 		}
 	}
 
-	err := runProgram(lifecycle, m)
+	err := runProgram(lifecycle, deps.model)
 	assert.NoError(t, err)
 }
 
@@ -108,7 +129,15 @@ func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
 	t.Cleanup(func() { newTeaProgram = orig })
 
 	lifecycle := api.NewAppLifecycle(context.Background())
-	m := newRunProgramTestModel(t, lifecycle.Context())
+	deps := newRunProgramTestModel(t, lifecycle.Context(), tui.WithOwnedSubsystemShutdown())
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
 		return fakeTeaProgram{
@@ -118,7 +147,41 @@ func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
 		}
 	}
 
-	err := runProgram(lifecycle, m)
+	err := runProgram(lifecycle, deps.model)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "TUI error: boom")
+}
+
+func TestRunProgram_StandaloneOwnershipLeavesSubsystemShutdownToOuterLayer(t *testing.T) {
+	orig := newTeaProgram
+	t.Cleanup(func() { newTeaProgram = orig })
+
+	lifecycle := api.NewAppLifecycle(context.Background())
+	deps := newRunProgramTestModel(t, lifecycle.Context())
+
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+
+	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
+		return fakeTeaProgram{
+			run: func() (tea.Model, error) {
+				return m, nil
+			},
+		}
+	}
+
+	err := runProgram(lifecycle, deps.model)
+	assert.NoError(t, err)
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	deps.syncer.Shutdown(cleanupCtx)
+	deps.enricher.Shutdown(cleanupCtx)
+	deps.alerter.Shutdown(cleanupCtx)
 }

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/hirakiuc/gh-orbit/internal/api"
+	"github.com/hirakiuc/gh-orbit/internal/config"
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
+	"github.com/hirakiuc/gh-orbit/internal/tui"
+	"github.com/hirakiuc/gh-orbit/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type fakeTeaProgram struct {
+	run func() (tea.Model, error)
+}
+
+func (f fakeTeaProgram) Run() (tea.Model, error) {
+	return f.run()
+}
+
+func newRunProgramTestModel(t *testing.T, taskRoot context.Context) *tui.Model {
+	t.Helper()
+
+	cfg := config.DefaultConfig()
+	logger := slog.Default()
+	repo := mocks.NewMockRepository(t)
+	syncer := mocks.NewMockSyncer(t)
+	enricher := mocks.NewMockEnricher(t)
+	alerter := mocks.NewMockAlerter(t)
+
+	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
+	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
+
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+
+	m, err := tui.NewModel(tui.ModelParams{
+		UserID:   "user",
+		Config:   cfg,
+		Logger:   logger,
+		TaskRoot: taskRoot,
+		DB:       repo,
+		Syncer:   syncer,
+		Enricher: enricher,
+		Alerter:  alerter,
+	})
+	assert.NoError(t, err)
+
+	return m
+}
+
+func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
+	orig := newTeaProgram
+	t.Cleanup(func() { newTeaProgram = orig })
+
+	lifecycle := api.NewAppLifecycle(context.Background())
+	m := newRunProgramTestModel(t, lifecycle.Context())
+
+	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
+		return fakeTeaProgram{
+			run: func() (tea.Model, error) {
+				return m, nil
+			},
+		}
+	}
+
+	err := runProgram(lifecycle, m)
+	assert.NoError(t, err)
+}
+
+func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
+	orig := newTeaProgram
+	t.Cleanup(func() { newTeaProgram = orig })
+
+	parent, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	lifecycle := api.NewAppLifecycle(parent)
+	m := newRunProgramTestModel(t, lifecycle.Context())
+
+	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
+		return fakeTeaProgram{
+			run: func() (tea.Model, error) {
+				cancel()
+				return m, nil
+			},
+		}
+	}
+
+	err := runProgram(lifecycle, m)
+	assert.NoError(t, err)
+}
+
+func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
+	orig := newTeaProgram
+	t.Cleanup(func() { newTeaProgram = orig })
+
+	lifecycle := api.NewAppLifecycle(context.Background())
+	m := newRunProgramTestModel(t, lifecycle.Context())
+
+	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
+		return fakeTeaProgram{
+			run: func() (tea.Model, error) {
+				return m, errors.New("boom")
+			},
+		}
+	}
+
+	err := runProgram(lifecycle, m)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "TUI error: boom")
+}

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -93,6 +93,7 @@ func TestModel_NewTaskContext_UsesTaskRootCancellation(t *testing.T) {
 func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
 	m := newTestModel(t)
 	m.traffic = nil
+	m.ownsSubsystems = true
 	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
 		err := ctx.Err()
 		_, hasDeadline := ctx.Deadline()
@@ -105,20 +106,10 @@ func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
 	m.Shutdown()
 }
 
-func TestModel_Shutdown_StandaloneModeShutsDownAllSubsystemsWithUsableCleanupContext(t *testing.T) {
+func TestModel_Shutdown_StandaloneModeDoesNotShutdownEngineOwnedSubsystems(t *testing.T) {
 	taskRoot, cancel := context.WithCancel(context.Background())
 	m := newTestModelWithTaskRoot(t, taskRoot)
 	cancel()
-
-	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
-		err := ctx.Err()
-		_, hasDeadline := ctx.Deadline()
-		return err == nil && hasDeadline
-	})
-	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	m.traffic.(*mocks.MockTrafficController).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	m.Shutdown()
 }

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
@@ -23,64 +25,100 @@ func TestNewModel_Guards(t *testing.T) {
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
 	t.Run("Missing UserID", func(t *testing.T) {
-		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "user ID is required")
 	})
 
 	t.Run("Missing Config", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "config is required")
 	})
 
 	t.Run("Missing Logger", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "logger is required")
 	})
 
+	t.Run("Missing TaskRoot", func(t *testing.T) {
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "task root context is required")
+	})
+
 	t.Run("Missing DB", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database is required")
 	})
 
 	t.Run("Missing Syncer", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, DB: mockRepo, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Enricher: mockEnricher, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "syncer is required")
 	})
 
 	t.Run("Missing Enricher", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, DB: mockRepo, Syncer: mockSyncer, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "enricher is required")
 	})
 
 	t.Run("Missing Alerter", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "alerter is required")
 	})
 }
 
+func TestModel_NewTaskContext_UsesTaskRootCancellation(t *testing.T) {
+	taskRoot, cancel := context.WithCancel(context.Background())
+	m := newTestModelWithTaskRoot(t, taskRoot)
+
+	ctx, release := m.newTaskContext("notifications:sync", 0)
+	t.Cleanup(release)
+
+	assert.NoError(t, ctx.Err())
+	cancel()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected scoped task context to be canceled when task root is canceled")
+	}
+}
+
 func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
 	m := newTestModel(t)
 	m.traffic = nil
-	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(mock.Anything).Return().Once()
-	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(mock.Anything).Return().Once()
-	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(mock.Anything).Return().Once()
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	m.Shutdown()
 }
 
-func TestModel_Shutdown_StandaloneModeShutsDownAllSubsystems(t *testing.T) {
-	m := newTestModel(t)
-	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(mock.Anything).Return().Once()
-	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(mock.Anything).Return().Once()
-	m.traffic.(*mocks.MockTrafficController).EXPECT().Shutdown(mock.Anything).Return().Once()
-	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(mock.Anything).Return().Once()
+func TestModel_Shutdown_StandaloneModeShutsDownAllSubsystemsWithUsableCleanupContext(t *testing.T) {
+	taskRoot, cancel := context.WithCancel(context.Background())
+	m := newTestModelWithTaskRoot(t, taskRoot)
+	cancel()
+
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		err := ctx.Err()
+		_, hasDeadline := ctx.Deadline()
+		return err == nil && hasDeadline
+	})
+	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	m.traffic.(*mocks.MockTrafficController).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	m.Shutdown()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -114,6 +114,7 @@ type Model struct {
 	taskCancelSeq       uint64
 	taskCancels         map[string]scopedTaskCancel
 	taskRoot            context.Context
+	ownsSubsystems      bool
 	manualSyncPending   bool
 	manualSyncSnapshot  string
 
@@ -156,6 +157,14 @@ func WithVersion(v string) Option {
 func WithConnectionMode(mode string) Option {
 	return func(m *Model) {
 		m.ConnectionMode = mode
+	}
+}
+
+// WithOwnedSubsystemShutdown makes Model.Shutdown responsible for shutting down
+// the injected sync/enrich/traffic/alerter services.
+func WithOwnedSubsystemShutdown() Option {
+	return func(m *Model) {
+		m.ownsSubsystems = true
 	}
 }
 
@@ -297,9 +306,14 @@ func (m *Model) tickEnrich() tea.Cmd {
 }
 
 func (m *Model) Shutdown() {
+	m.cancelScopedTasks()
+
+	if !m.ownsSubsystems {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	m.cancelScopedTasks()
 
 	if m.sync != nil {
 		m.sync.Shutdown(ctx)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -113,6 +113,7 @@ type Model struct {
 	taskCancelMu        sync.Mutex
 	taskCancelSeq       uint64
 	taskCancels         map[string]scopedTaskCancel
+	taskRoot            context.Context
 	manualSyncPending   bool
 	manualSyncSnapshot  string
 
@@ -163,6 +164,7 @@ type ModelParams struct {
 	UserID   string
 	Config   *config.Config
 	Logger   *slog.Logger
+	TaskRoot context.Context
 	DB       notificationStore
 	Client   github.Client
 	Syncer   types.Syncer
@@ -182,6 +184,9 @@ func NewModel(p ModelParams) (*Model, error) {
 	}
 	if p.Logger == nil {
 		return nil, fmt.Errorf("logger is required for TUI")
+	}
+	if p.TaskRoot == nil {
+		return nil, fmt.Errorf("task root context is required for TUI")
 	}
 	if p.DB == nil {
 		return nil, fmt.Errorf("database is required for TUI")
@@ -242,6 +247,7 @@ func NewModel(p ModelParams) (*Model, error) {
 		clockInterval:       1 * time.Minute,
 		inflightEnrichments: make(map[string]time.Time),
 		taskCancels:         make(map[string]scopedTaskCancel),
+		taskRoot:            p.TaskRoot,
 		executor:            api.NewOSCommandExecutor(), // Default executor
 	}
 
@@ -331,7 +337,7 @@ func (m *Model) submitTask(scope string, timeout time.Duration, priority int, fn
 }
 
 func (m *Model) newTaskContext(scope string, timeout time.Duration) (context.Context, func()) {
-	base := context.Background()
+	base := m.taskRoot
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
@@ -22,6 +23,10 @@ type TestingT interface {
 
 // newTestModel creates a model with basic mocks.
 func newTestModel(t TestingT) *Model {
+	return newTestModelWithTaskRoot(t, context.Background())
+}
+
+func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	cfg := config.DefaultConfig()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	userID := "test-user"
@@ -44,6 +49,7 @@ func newTestModel(t TestingT) *Model {
 		UserID:   userID,
 		Config:   cfg,
 		Logger:   logger,
+		TaskRoot: taskRoot,
 		DB:       mockRepo,
 		Client:   mockClient,
 		Syncer:   mockSyncer,

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -133,6 +134,7 @@ func TestRenderHeader_States(t *testing.T) {
 			UserID:   "user",
 			Config:   cfg,
 			Logger:   logger,
+			TaskRoot: context.Background(),
 			DB:       mocks.NewMockRepository(t),
 			Syncer:   mockSyncer,
 			Enricher: mocks.NewMockEnricher(t),


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #333

## Objective

Make TUI-scoped work obey one authoritative lifecycle root and ensure quit/cancel paths run one deterministic cleanup flow.

## Changes

- require explicit TUI task-root injection via `tui.ModelParams`
- root scoped TUI task contexts in the injected lifecycle context instead of `context.Background()`
- keep final subsystem shutdown on a separate bounded cleanup context
- make both TUI launch paths inject the lifecycle root explicitly
- make `runProgram` own one cleanup path across normal exit, lifecycle cancellation, and `p.Run()` error returns
- add lifecycle-focused tests for task-root cancellation and `runProgram` shutdown behavior

## Verification Results

- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/tui ./cmd/gh-orbit -run 'Test(NewModel_Guards|Model_Shutdown|Model_NewTaskContext|RunProgram_)' -v`
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/tui ./cmd/gh-orbit -v`

## Checklist

- [ ] All checks passed (`make check`)
- [ ] Documentation updated (if applicable)
