### PR TITLE
refactor(engine): clarify shared-service shutdown ownership

### DIFF
--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -53,8 +53,9 @@ func (s *SyncEngine) Fetcher() github.Fetcher {
 
 // Shutdown ensures all background services are stopped gracefully.
 func (s *SyncEngine) Shutdown(ctx context.Context) {
+	// Injected alerts are caller-owned; SyncEngine only shuts down itself.
 	if s.alerts != nil {
-		s.alerts.Shutdown(ctx)
+		s.logger.DebugContext(ctx, "sync engine shutdown leaves injected alerts to caller ownership")
 	}
 	s.logger.DebugContext(ctx, "sync engine shutdown complete")
 }

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -231,6 +231,23 @@ func TestNewSyncEngine_Guards(t *testing.T) {
 	})
 }
 
+func TestSyncEngine_Shutdown_DoesNotOwnInjectedAlerts(t *testing.T) {
+	logger := slog.Default()
+	mockFetcher := mocks.NewMockFetcher(t)
+	mockRepo := mocks.NewMockSyncRepository(t)
+	mockAlerter := mocks.NewMockAlerter(t)
+
+	engine, err := NewSyncEngine(SyncParams{
+		Fetcher: mockFetcher,
+		DB:      mockRepo,
+		Alerts:  mockAlerter,
+		Logger:  logger,
+	})
+	require.NoError(t, err)
+
+	engine.Shutdown(context.Background())
+}
+
 func TestConditionalRequest(t *testing.T) {
 	client := github.NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.Header.Get("If-None-Match") == "etag-123" {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoreEngine_Initialization(t *testing.T) {
@@ -57,5 +60,36 @@ func TestNewCoreEngine_Guards(t *testing.T) {
 		_, err := NewCoreEngine(ctx, cfg, logger, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "executor is required")
+	})
+}
+
+func TestCoreEngine_Shutdown_IntegratedModeOwnsSharedServices(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+	mockTraffic := mocks.NewMockTrafficController(t)
+	mockAlerter := mocks.NewMockAlerter(t)
+
+	usableCleanupCtx := mock.MatchedBy(func(ctx context.Context) bool {
+		return ctx != nil
+	})
+
+	mockSyncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	mockEnricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	mockTraffic.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	mockAlerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+
+	engine := &CoreEngine{
+		Logger:  logger,
+		Sync:    mockSyncer,
+		Enrich:  mockEnricher,
+		Traffic: mockTraffic,
+		Alert:   mockAlerter,
+	}
+
+	require.NotPanics(t, func() {
+		engine.Shutdown(ctx)
 	})
 }


### PR DESCRIPTION
## Summary
- remove duplicate alert teardown authority from `SyncEngine` so injected alerts remain caller-owned
- keep `CoreEngine` as the integrated shutdown owner for shared services it constructs
- add lifecycle tests that make the ownership contract explicit

Closes #335.
