### PR TITLE
refactor(engine): narrow connected-mode adapter boundary

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -409,7 +409,7 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 		Config:   config.DefaultConfig(), // Placeholder or from engine
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
-		DB:       adapter, // Repository
+		DB:       adapter, // NotificationStore
 		Client:   nil,     // Client (unused in MCP mode)
 		Syncer:   adapter, // Syncer
 		Enricher: adapter, // Enricher

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -91,7 +91,7 @@ func (a *MCPAdapter) handleResourceUpdate(n mcp.JSONRPCNotification) {
 	})
 }
 
-// --- types.Repository Implementation ---
+// --- types.NotificationStore Implementation ---
 
 func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
 	resp, err := a.client.ReadResource(ctx, mcp.ReadResourceRequest{
@@ -183,40 +183,9 @@ func (a *MCPAdapter) PersistIndependentDetail(ctx context.Context, id, nodeID, b
 	return err
 }
 
-// No-ops for client mode (Engine is authority)
 func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error {
 	return a.PersistIndependentDetail(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 }
-
-func (a *MCPAdapter) UpdateResourceStateByNodeID(ctx context.Context, nodeID, state, resourceSubState string) error {
-	return nil
-}
-func (a *MCPAdapter) UpdateSyncMeta(ctx context.Context, s models.SyncMeta) error { return nil }
-func (a *MCPAdapter) MarkNotifiedBatch(ctx context.Context, ids []string) error   { return nil }
-func (a *MCPAdapter) UpdateBridgeHealth(ctx context.Context, h models.BridgeHealth) error {
-	return nil
-}
-
-// Stubs for remaining Repository methods
-func (a *MCPAdapter) GetNotification(ctx context.Context, id string) (*triage.NotificationWithState, error) {
-	return nil, nil
-}
-
-func (a *MCPAdapter) GetSyncMeta(ctx context.Context, userID, key string) (*models.SyncMeta, error) {
-	return nil, nil
-}
-
-func (a *MCPAdapter) GetBridgeHealth(ctx context.Context) (*models.BridgeHealth, error) {
-	return nil, nil
-}
-
-func (a *MCPAdapter) UpsertNotifications(ctx context.Context, notifications []triage.Notification) error {
-	return nil
-}
-func (a *MCPAdapter) ArchiveThread(ctx context.Context, id string) error   { return nil }
-func (a *MCPAdapter) UnarchiveThread(ctx context.Context, id string) error { return nil }
-func (a *MCPAdapter) MuteThread(ctx context.Context, id string) error      { return nil }
-func (a *MCPAdapter) UnmuteThread(ctx context.Context, id string) error    { return nil }
 
 // --- types.Syncer Implementation ---
 
@@ -373,8 +342,8 @@ func (a *MCPAdapter) TestNotify(ctx context.Context, title, subtitle, body strin
 
 // Ensure MCPAdapter implements required interfaces
 var (
-	_ types.Repository = (*MCPAdapter)(nil)
-	_ types.Syncer     = (*MCPAdapter)(nil)
-	_ types.Enricher   = (*MCPAdapter)(nil)
-	_ api.Alerter      = (*MCPAdapter)(nil)
+	_ types.NotificationStore = (*MCPAdapter)(nil)
+	_ types.Syncer            = (*MCPAdapter)(nil)
+	_ types.Enricher          = (*MCPAdapter)(nil)
+	_ api.Alerter             = (*MCPAdapter)(nil)
 )

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -234,3 +234,8 @@ func TestMCPAdapter_SyncRejectsInvalidStructuredContract(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid sync tool status "unknown"`)
 }
+
+func TestMCPAdapter_ImplementsConnectedNotificationStoreBoundary(t *testing.T) {
+	var store types.NotificationStore = NewMCPAdapter(nil)
+	require.NotNil(t, store)
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -51,14 +51,6 @@ type DetailModel struct {
 	lastRenderedWidth int
 }
 
-// notificationStore defines the notification persistence behavior the TUI needs.
-type notificationStore interface {
-	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
-	MarkReadLocally(ctx context.Context, id string, isRead bool) error
-	SetPriority(ctx context.Context, id string, priority int) error
-	EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error
-}
-
 // Model represents the application state.
 type Model struct {
 	// Sub-Models
@@ -66,7 +58,7 @@ type Model struct {
 	detailView DetailModel
 
 	// Shared State & Services (Interfaces)
-	db               notificationStore
+	db               types.NotificationStore
 	client           github.Client
 	sync             types.Syncer
 	enrich           types.Enricher
@@ -174,7 +166,7 @@ type ModelParams struct {
 	Config   *config.Config
 	Logger   *slog.Logger
 	TaskRoot context.Context
-	DB       notificationStore
+	DB       types.NotificationStore
 	Client   github.Client
 	Syncer   types.Syncer
 	Enricher types.Enricher

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -126,6 +126,15 @@ type CommandExecutor interface {
 // ErrMsg is a common error message wrapper for Bubble Tea updates.
 type ErrMsg struct{ Err error }
 
+// NotificationStore defines the persistence surface the TUI needs in both
+// standalone and connected mode.
+type NotificationStore interface {
+	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
+	MarkReadLocally(ctx context.Context, id string, isRead bool) error
+	SetPriority(ctx context.Context, id string, priority int) error
+	EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error
+}
+
 // SyncRepository defines the database interactions required by the SyncEngine.
 type SyncRepository interface {
 	GetSyncMeta(ctx context.Context, userID, key string) (*models.SyncMeta, error)
@@ -148,14 +157,13 @@ type AlertRepository interface {
 	UpdateBridgeHealth(ctx context.Context, h models.BridgeHealth) error
 }
 
-// Repository defines the full database capabilities required by the TUI and Services.
+// Repository defines the full database capabilities required by the engine and services.
 type Repository interface {
 	SyncRepository
 	EnrichmentRepository
 	AlertRepository
 
-	// Triage specific
-	MarkReadLocally(ctx context.Context, id string, isRead bool) error
+	NotificationStore
 	ArchiveThread(ctx context.Context, id string) error
 	UnarchiveThread(ctx context.Context, id string) error
 	MuteThread(ctx context.Context, id string) error


### PR DESCRIPTION
## Summary
- narrow connected-mode TUI persistence to a named `types.NotificationStore` port
- remove the broad `types.Repository` conformance claim from `MCPAdapter`
- delete repository-shaped no-op adapter methods that overstated connected-mode authority

## What Changed
- added `types.NotificationStore` in `internal/types/api.go` as the shared persistence surface used by the TUI
- updated `internal/tui/model.go` to depend on that named port instead of a private local interface
- updated `cmd/gh-orbit/main.go` so `launchTUIMCP` wires the adapter as a `NotificationStore`, not an implicit repository facade
- removed broad repository-shaped stub methods from `internal/engine/adapter.go` and kept only the interfaces the adapter actually satisfies
- added a focused adapter boundary test in `internal/engine/adapter_sync_test.go`

## Why
Issue #337 identified that connected mode overclaimed parity by presenting `MCPAdapter` as a full `types.Repository` even though several methods were unsupported and silently returned `nil`. This change makes the connected-mode boundary advertise only the authority it actually provides.

## Validation
- `go test ./internal/engine ./internal/tui ./cmd/gh-orbit`
- `make go/check`

Closes #337