### PR TITLE
refactor(config): unify runtime config authority

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -360,7 +360,7 @@ func runTUI() error {
 				adapter := engine.NewMCPAdapter(mcpClient)
 
 				user := "mcp-user" // Placeholder until tool added
-				return launchTUIMCP(ctx, env, adapter, user)
+				return launchTUIMCP(ctx, env, cfg, adapter, user)
 			}
 			if requireEngine {
 				return fmt.Errorf("cockpit-managed launch requires MCP engine initialization: %w", err)
@@ -395,7 +395,7 @@ func runTUI() error {
 	return launchTUIStandalone(ctx, env, eng, user.Login)
 }
 
-func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdapter, userID string) error {
+func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, adapter *engine.MCPAdapter, userID string) error {
 	lifecycle := api.NewAppLifecycle(ctx)
 	lifecycleOwned := true
 	defer func() {
@@ -406,7 +406,7 @@ func launchTUIMCP(ctx context.Context, env *environment, adapter *engine.MCPAdap
 
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
-		Config:   config.DefaultConfig(), // Placeholder or from engine
+		Config:   cfg,
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
 		DB:       adapter, // NotificationStore

--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -47,11 +47,13 @@ func NewEnrichmentEngine(ctx context.Context, p EnrichParams) (*EnrichmentEngine
 	if p.DB == nil {
 		return nil, fmt.Errorf("database is required for EnrichmentEngine")
 	}
+	if p.Config == nil {
+		return nil, fmt.Errorf("config is required for EnrichmentEngine")
+	}
 	if p.Logger == nil {
 		return nil, fmt.Errorf("logger is required for EnrichmentEngine")
 	}
 
-	cfg, _ := config.Load()
 	e := &EnrichmentEngine{
 		client:     p.Client,
 		db:         p.DB,
@@ -59,7 +61,7 @@ func NewEnrichmentEngine(ctx context.Context, p EnrichParams) (*EnrichmentEngine
 		cache:      make(map[string]models.EnrichmentResult),
 		nodeToURLs: make(map[string]map[string]struct{}),
 		done:       make(chan struct{}),
-		config:     cfg,
+		config:     p.Config,
 		OnMutation: func() {}, // Default no-op
 	}
 

--- a/internal/api/enrichment_test.go
+++ b/internal/api/enrichment_test.go
@@ -54,6 +54,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 
 		engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 			Client: mockClient,
+			Config: config.DefaultConfig(),
 			DB:     mockRepo,
 			Logger: slog.Default(),
 		})
@@ -88,6 +89,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 
 		engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 			Client: mockClient,
+			Config: config.DefaultConfig(),
 			DB:     mockRepo,
 			Logger: slog.Default(),
 		})
@@ -104,6 +106,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 	t.Run("Cache Hit", func(t *testing.T) {
 		engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 			Client: mockClient,
+			Config: config.DefaultConfig(),
 			DB:     mockRepo,
 			Logger: slog.Default(),
 		})
@@ -136,6 +139,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 
 		engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 			Client: mockClient,
+			Config: config.DefaultConfig(),
 			DB:     mockRepo,
 			Logger: slog.Default(),
 		})
@@ -163,7 +167,7 @@ func TestEnrichmentEngine_FetchDetail(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				mockREST.EXPECT().DoWithContext(mock.Anything, "GET", "url", nil, mock.Anything).Return(tt.apiErr).Once()
-				engine, _ := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, DB: mockRepo, Logger: slog.Default()})
+				engine, _ := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, Config: config.DefaultConfig(), DB: mockRepo, Logger: slog.Default()})
 				_, err := engine.FetchDetail(ctx, "url", "Issue", false)
 				assert.ErrorIs(t, err, tt.expected)
 			})
@@ -221,6 +225,7 @@ func TestEnrichmentEngine_FetchHybridBatch(t *testing.T) {
 
 		engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 			Client: mockClient,
+			Config: config.DefaultConfig(),
 			DB:     mockRepo,
 			Logger: slog.Default(),
 		})
@@ -246,6 +251,7 @@ func TestEnrichmentEngine_Pruning(t *testing.T) {
 	ctx := context.Background()
 	engine, _ := NewEnrichmentEngine(ctx, EnrichParams{
 		Client: mocks.NewMockClient(t),
+		Config: config.DefaultConfig(),
 		DB:     mocks.NewMockEnrichmentRepository(t),
 		Logger: slog.Default(),
 	})
@@ -305,6 +311,7 @@ func TestEnrichmentEngine_PersistFetchedDetailPreservesCache(t *testing.T) {
 
 	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 		Client: mockClient,
+		Config: config.DefaultConfig(),
 		DB:     mockRepo,
 		Logger: slog.Default(),
 	})
@@ -343,6 +350,7 @@ func TestEnrichmentEngine_PersistIndependentDetailInvalidatesCacheByNodeID(t *te
 
 	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 		Client: mockClient,
+		Config: config.DefaultConfig(),
 		DB:     mockRepo,
 		Logger: slog.Default(),
 	})
@@ -401,6 +409,7 @@ func TestEnrichmentEngine_PersistIndependentDetailInvalidatesCacheByHTMLURL(t *t
 
 	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 		Client: mockClient,
+		Config: config.DefaultConfig(),
 		DB:     mockRepo,
 		Logger: slog.Default(),
 	})
@@ -456,6 +465,7 @@ func TestEnrichmentEngine_UpdateNodeStateInvalidatesCacheByNodeID(t *testing.T) 
 
 	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
 		Client: mockClient,
+		Config: config.DefaultConfig(),
 		DB:     mockRepo,
 		Logger: slog.Default(),
 	})
@@ -490,19 +500,25 @@ func TestNewEnrichmentEngine_Guards(t *testing.T) {
 	logger := slog.Default()
 
 	t.Run("Missing Client", func(t *testing.T) {
-		_, err := NewEnrichmentEngine(ctx, EnrichParams{DB: mockRepo, Logger: logger})
+		_, err := NewEnrichmentEngine(ctx, EnrichParams{DB: mockRepo, Config: config.DefaultConfig(), Logger: logger})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "github client is required")
 	})
 
 	t.Run("Missing DB", func(t *testing.T) {
-		_, err := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, Logger: logger})
+		_, err := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, Config: config.DefaultConfig(), Logger: logger})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database is required")
 	})
 
+	t.Run("Missing Config", func(t *testing.T) {
+		_, err := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, DB: mockRepo, Logger: logger})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "config is required")
+	})
+
 	t.Run("Missing Logger", func(t *testing.T) {
-		_, err := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, DB: mockRepo})
+		_, err := NewEnrichmentEngine(ctx, EnrichParams{Client: mockClient, DB: mockRepo, Config: config.DefaultConfig()})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "logger is required")
 	})

--- a/internal/api/interfaces.go
+++ b/internal/api/interfaces.go
@@ -31,6 +31,7 @@ type SyncParams struct {
 type EnrichParams struct {
 	Client github.Client
 	DB     types.EnrichmentRepository
+	Config *config.Config
 	Logger *slog.Logger
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -82,6 +82,7 @@ func NewCoreEngine(
 	enricher, err := api.NewEnrichmentEngine(ctx, api.EnrichParams{
 		Client: client,
 		DB:     database,
+		Config: cfg,
 		Logger: logger,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- unify runtime config propagation across standalone mode, connected mode, and enrichment construction
- stop connected mode from substituting `config.DefaultConfig()` while standalone mode uses loaded runtime config
- remove internal `config.Load()` from `NewEnrichmentEngine()` and require caller-owned config instead

## What Changed
- `launchTUIMCP()` now receives and passes the same loaded runtime config used by the standalone path
- `api.EnrichParams` now includes `Config *config.Config`
- `NewEnrichmentEngine()` now requires injected config and no longer reloads config internally
- `engine.NewCoreEngine()` now passes its authoritative config into enrichment construction
- enrichment tests and constructor guards were updated to use explicit fixture config

## Why
Issue #338 identified two accidental divergence points:
- connected mode used `config.DefaultConfig()` while standalone mode used `eng.Config`
- enrichment construction reloaded config internally instead of consuming the caller-owned runtime config

This change makes runtime config come from one authoritative path so TTLs, polling intervals, and UX behavior do not diverge by constructor accident.

## Validation
- `go test ./cmd/gh-orbit ./internal/api ./internal/engine ./internal/tui`
- `make go/build`
- `make go/check`

Closes #338