### PR TITLE
docs(api): record traffic controller polling decision

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -210,8 +210,11 @@ func (c *APITrafficController) UpdateRateLimit(ctx context.Context, info models.
 }
 
 func (c *APITrafficController) supervisor() {
-	// We use a ticker to periodically check for workers becoming available
-	// while avoiding tight loop spinning.
+	// Keep the coordinator polling-based for now. The fixed 2ms ticker lets
+	// worker completion and rate-limit changes become visible without adding a
+	// second wakeup protocol between Submit, workers, and shutdown. Revisit this
+	// only if profiling shows measurable idle scheduler cost or if coordination
+	// bugs appear that need causal wakeups instead of periodic polling.
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -78,6 +78,28 @@ func TestAPITrafficController_ReportRateLimit_UpdatesStateSynchronously(t *testi
 	})
 }
 
+func TestAPITrafficController_PollingSupervisorDispatchesQueuedWorkAfterCapacityRestores(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		atomic.StoreInt32(&tc.workerLimit, 0)
+		synctest.Wait()
+
+		resChan, err := tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
+			return "drained"
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(tc.med), "task should remain queued while capacity is zero")
+
+		atomic.StoreInt32(&tc.workerLimit, 1)
+		synctest.Wait()
+
+		assert.Equal(t, "drained", <-resChan, "supervisor should drain queued work after capacity returns without explicit wakeup")
+	})
+}
+
 func TestAPITrafficController_LockoutClearsAfterHealthyRecovery(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- document why the traffic controller keeps the current 2ms polling supervisor for now
- add an invariant test that queued work drains once capacity is restored without an explicit wakeup path
- make the redesign trigger explicit: revisit only if profiling shows measurable idle scheduler cost or coordination bugs require causal wakeups

## Validation
- go test ./internal/api
- make go/check

Closes #339