### PR TITLE
refactor(tui): introduce backend client seam

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -409,10 +409,7 @@ func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, ada
 		Config:   cfg,
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
-		DB:       adapter, // NotificationStore
-		Client:   nil,     // Client (unused in MCP mode)
-		Syncer:   adapter, // Syncer
-		Enricher: adapter, // Enricher
+		Backend:  adapter,
 		Traffic:  nil,     // Traffic (Engine handles it)
 		Alerter:  adapter, // Alerter (Mock/Engine bridge)
 		Options: []tui.Option{
@@ -441,15 +438,17 @@ func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.Core
 		}
 	}()
 
+	backend, err := api.NewTUIBackendClient(userID, eng.DB, eng.Sync, eng.Enrich, eng.Client)
+	if err != nil {
+		return err
+	}
+
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   eng.Config,
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
-		DB:       eng.DB,
-		Client:   eng.Client,
-		Syncer:   eng.Sync,
-		Enricher: eng.Enrich,
+		Backend:  backend,
 		Traffic:  eng.Traffic,
 		Alerter:  eng.Alert,
 		Options: []tui.Option{

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -44,15 +44,15 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.
 
 	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
+	backend, err := api.NewTUIBackendClient("user", repo, syncer, enricher, nil)
+	assert.NoError(t, err)
 
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   "user",
 		Config:   cfg,
 		Logger:   logger,
 		TaskRoot: taskRoot,
-		DB:       repo,
-		Syncer:   syncer,
-		Enricher: enricher,
+		Backend:  backend,
 		Alerter:  alerter,
 		Options:  opts,
 	})

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hirakiuc/gh-orbit/internal/github"
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/triage"
+	"github.com/hirakiuc/gh-orbit/internal/types"
+)
+
+// TUIBackendClient adapts the existing in-process services to the TUI-facing
+// backend contract used by the architecture-v2 migration.
+type TUIBackendClient struct {
+	UserID   string
+	Store    types.NotificationStore
+	Client   github.Client
+	Syncer   types.Syncer
+	Enricher types.Enricher
+}
+
+func NewTUIBackendClient(userID string, store types.NotificationStore, syncer types.Syncer, enricher types.Enricher, client github.Client) (*TUIBackendClient, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("user ID is required for TUIBackendClient")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("notification store is required for TUIBackendClient")
+	}
+	if syncer == nil {
+		return nil, fmt.Errorf("syncer is required for TUIBackendClient")
+	}
+	if enricher == nil {
+		return nil, fmt.Errorf("enricher is required for TUIBackendClient")
+	}
+
+	return &TUIBackendClient{
+		UserID:   userID,
+		Store:    store,
+		Client:   client,
+		Syncer:   syncer,
+		Enricher: enricher,
+	}, nil
+}
+
+func (b *TUIBackendClient) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
+	return b.Store.ListNotifications(ctx)
+}
+
+func (b *TUIBackendClient) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
+	return b.Syncer.Sync(ctx, b.UserID, force)
+}
+
+func (b *TUIBackendClient) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
+	if err := b.Store.MarkReadLocally(ctx, id, read); err != nil {
+		return types.MarkReadResult{}, err
+	}
+	if read && b.Client != nil {
+		if err := b.Client.MarkThreadAsRead(ctx, id); err != nil {
+			return types.MarkReadResult{Status: types.MarkReadRemoteFailure, Err: err}, nil
+		}
+	}
+	return types.MarkReadResult{Status: types.MarkReadSuccess}, nil
+}
+
+func (b *TUIBackendClient) SetPriority(ctx context.Context, id string, priority int) error {
+	return b.Store.SetPriority(ctx, id, priority)
+}
+
+func (b *TUIBackendClient) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
+	return b.Enricher.FetchDetail(ctx, u, subjectType, force)
+}
+
+func (b *TUIBackendClient) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
+	return b.Enricher.PersistFetchedDetail(ctx, id, sourceURL, res)
+}
+
+func (b *TUIBackendClient) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
+	return b.Enricher.FetchHybridBatch(ctx, notifications, force)
+}
+
+func (b *TUIBackendClient) BridgeStatus() types.BridgeStatus {
+	return b.Syncer.BridgeStatus()
+}
+
+func (b *TUIBackendClient) Shutdown(ctx context.Context) {
+	if b.Syncer != nil {
+		b.Syncer.Shutdown(ctx)
+	}
+	if b.Enricher != nil {
+		b.Enricher.Shutdown(ctx)
+	}
+}
+
+func IsRemoteMarkReadFailure(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to mark read on GitHub")
+}

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -91,7 +92,7 @@ func (a *MCPAdapter) handleResourceUpdate(n mcp.JSONRPCNotification) {
 	})
 }
 
-// --- types.NotificationStore Implementation ---
+// --- types.TUIBackend / types.NotificationStore Implementation ---
 
 func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
 	resp, err := a.client.ReadResource(ctx, mcp.ReadResourceRequest{
@@ -120,8 +121,8 @@ func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.Notificati
 	return notifs, err
 }
 
-func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
-	_, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (types.MarkReadResult, error) {
+	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "mark_read",
 			Arguments: map[string]any{
@@ -130,6 +131,24 @@ func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool
 			},
 		},
 	})
+	if err != nil {
+		return types.MarkReadResult{}, err
+	}
+	if resp == nil {
+		return types.MarkReadResult{}, errors.New("mark_read returned nil result")
+	}
+	if resp.IsError {
+		toolErr := decodeToolResultError("mark_read", resp)
+		if api.IsRemoteMarkReadFailure(toolErr) {
+			return types.MarkReadResult{Status: types.MarkReadRemoteFailure, Err: toolErr}, nil
+		}
+		return types.MarkReadResult{}, toolErr
+	}
+	return types.MarkReadResult{Status: types.MarkReadSuccess}, nil
+}
+
+func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
+	_, err := a.MarkRead(ctx, id, isRead)
 	return err
 }
 
@@ -187,9 +206,9 @@ func (a *MCPAdapter) EnrichNotification(ctx context.Context, id, nodeID, body, a
 	return a.PersistIndependentDetail(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
 }
 
-// --- types.Syncer Implementation ---
+// --- types.TUIBackend Implementation ---
 
-func (a *MCPAdapter) Sync(ctx context.Context, userID string, force bool) (models.RateLimitInfo, error) {
+func (a *MCPAdapter) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, types.ConnectedSyncTimeout)
@@ -253,6 +272,19 @@ func decodeSyncToolResult(resp *mcp.CallToolResult) (syncToolResult, bool) {
 	}
 
 	return payload, true
+}
+
+func decodeToolResultError(toolName string, resp *mcp.CallToolResult) error {
+	if resp == nil {
+		return fmt.Errorf("%s error: empty response", toolName)
+	}
+	if len(resp.Content) == 0 {
+		return fmt.Errorf("%s error: unknown tool failure", toolName)
+	}
+	if text, ok := resp.Content[0].(mcp.TextContent); ok && text.Text != "" {
+		return errors.New(text.Text)
+	}
+	return fmt.Errorf("%s error: unexpected tool failure payload", toolName)
 }
 
 func (a *MCPAdapter) Shutdown(ctx context.Context) {
@@ -342,8 +374,7 @@ func (a *MCPAdapter) TestNotify(ctx context.Context, title, subtitle, body strin
 
 // Ensure MCPAdapter implements required interfaces
 var (
-	_ types.NotificationStore = (*MCPAdapter)(nil)
-	_ types.Syncer            = (*MCPAdapter)(nil)
-	_ types.Enricher          = (*MCPAdapter)(nil)
-	_ api.Alerter             = (*MCPAdapter)(nil)
+	_ types.TUIBackend = (*MCPAdapter)(nil)
+	_ types.Enricher   = (*MCPAdapter)(nil)
+	_ api.Alerter      = (*MCPAdapter)(nil)
 )

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -108,7 +108,7 @@ func TestMCPAdapter_SyncAddsFallbackTimeoutWhenCallerHasNoDeadline(t *testing.T)
 		},
 	})
 
-	_, err := adapter.Sync(context.Background(), "user-1", true)
+	_, err := adapter.Sync(context.Background(), true)
 	require.Error(t, err)
 	assert.True(t, sawDeadline)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -137,7 +137,7 @@ func TestMCPAdapter_SyncRespectsCallerDeadline(t *testing.T) {
 		},
 	})
 
-	_, err := adapter.Sync(parentCtx, "user-1", true)
+	_, err := adapter.Sync(parentCtx, true)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Equal(t, parentDeadline, seenDeadline)
@@ -158,7 +158,7 @@ func TestMCPAdapter_SyncPassesThroughSuccessfulResponse(t *testing.T) {
 		},
 	})
 
-	rl, err := adapter.Sync(context.Background(), "user-1", true)
+	rl, err := adapter.Sync(context.Background(), true)
 	require.NoError(t, err)
 	assert.Equal(t, models.RateLimitInfo{Remaining: 123}, rl)
 }
@@ -178,7 +178,7 @@ func TestMCPAdapter_SyncReconstructsIntervalNotReachedFromStructuredResult(t *te
 		},
 	})
 
-	rl, err := adapter.Sync(context.Background(), "user-1", false)
+	rl, err := adapter.Sync(context.Background(), false)
 	assert.Equal(t, models.RateLimitInfo{Remaining: 456}, rl)
 	assert.ErrorIs(t, err, types.ErrSyncIntervalNotReached)
 }
@@ -194,7 +194,7 @@ func TestMCPAdapter_SyncFallsBackToLegacySuccessParsingWithoutStructuredContent(
 		},
 	})
 
-	rl, err := adapter.Sync(context.Background(), "user-1", true)
+	rl, err := adapter.Sync(context.Background(), true)
 	require.NoError(t, err)
 	assert.Equal(t, models.RateLimitInfo{Remaining: 789}, rl)
 }
@@ -211,7 +211,7 @@ func TestMCPAdapter_SyncFallsBackToLegacyErrorWithoutStructuredContent(t *testin
 		},
 	})
 
-	_, err := adapter.Sync(context.Background(), "user-1", true)
+	_, err := adapter.Sync(context.Background(), true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sync error: sync failed: boom")
 }
@@ -230,12 +230,51 @@ func TestMCPAdapter_SyncRejectsInvalidStructuredContract(t *testing.T) {
 		},
 	})
 
-	_, err := adapter.Sync(context.Background(), "user-1", true)
+	_, err := adapter.Sync(context.Background(), true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid sync tool status "unknown"`)
 }
 
-func TestMCPAdapter_ImplementsConnectedNotificationStoreBoundary(t *testing.T) {
-	var store types.NotificationStore = NewMCPAdapter(nil)
-	require.NotNil(t, store)
+func TestMCPAdapter_MarkRead_ClassifiesRemoteFailureFromToolResult(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			require.Equal(t, "mark_read", request.Params.Name)
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					mcp.NewTextContent("failed to mark read on GitHub: boom"),
+				},
+			}, nil
+		},
+	})
+
+	result, err := adapter.MarkRead(context.Background(), "123", true)
+	require.NoError(t, err)
+	assert.Equal(t, types.MarkReadRemoteFailure, result.Status)
+	require.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "failed to mark read on GitHub: boom")
+}
+
+func TestMCPAdapter_MarkRead_TreatsLocalToolFailureAsError(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			require.Equal(t, "mark_read", request.Params.Name)
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					mcp.NewTextContent("failed to mark read locally: sqlite busy"),
+				},
+			}, nil
+		},
+	})
+
+	result, err := adapter.MarkRead(context.Background(), "123", true)
+	require.Error(t, err)
+	assert.Equal(t, types.MarkReadResult{}, result)
+	assert.Contains(t, err.Error(), "failed to mark read locally: sqlite busy")
+}
+
+func TestMCPAdapter_ImplementsTUIBackendBoundary(t *testing.T) {
+	var backend types.TUIBackend = NewMCPAdapter(nil)
+	require.NotNil(t, backend)
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -41,10 +41,10 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 
 	// 2. Persistent Local & Remote Update via Traffic Controller
 	return m.submitTask("read:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
-		err := m.db.MarkReadLocally(ctx, id, read)
+		result, err := m.backend.MarkRead(ctx, id, read)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "failed to update local read state", "error", err)
-			notifs, reloadErr := m.db.ListNotifications(ctx)
+			notifs, reloadErr := m.backend.ListNotifications(ctx)
 			if reloadErr != nil {
 				if found {
 					for idx, n := range m.allNotifications {
@@ -70,17 +70,14 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 		status := markReadReconcileSuccess
 		var resultErr error
 		toast := ""
-		if read && m.client != nil {
-			err = m.client.MarkThreadAsRead(ctx, id)
-			if err != nil {
-				m.logger.ErrorContext(ctx, "failed to mark thread as read on GitHub", "error", err)
-				status = markReadReconcileRemoteFailure
-				resultErr = err
-				toast = "Marked read locally; GitHub sync failed"
-			}
+		if result.Status == types.MarkReadRemoteFailure {
+			m.logger.ErrorContext(ctx, "failed to mark thread as read on GitHub", "error", result.Err)
+			status = markReadReconcileRemoteFailure
+			resultErr = result.Err
+			toast = "Marked read locally; GitHub sync failed"
 		}
 
-		notifs, err := m.db.ListNotifications(ctx)
+		notifs, err := m.backend.ListNotifications(ctx)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
@@ -97,13 +94,13 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 // setPriorityByID updates the priority of a notification using only its ID.
 func (m *Model) setPriorityByID(id string, priority int) tea.Cmd {
 	return m.submitTask("priority:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
-		err := m.db.SetPriority(ctx, id, priority)
+		err := m.backend.SetPriority(ctx, id, priority)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 
 		// Reload to reflect state
-		notifs, err := m.db.ListNotifications(ctx)
+		notifs, err := m.backend.ListNotifications(ctx)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
@@ -155,11 +152,11 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState, force bool)
 	for _, n := range discovery {
 		id, url, st := n.GitHubID, n.SubjectURL, n.SubjectType
 		cmds = append(cmds, m.submitTask("enrich:detail:"+id, 0, api.PriorityEnrich, func(ctx context.Context) any {
-			res, err := m.enrich.FetchDetail(ctx, url, string(st), force)
+			res, err := m.backend.FetchDetail(ctx, url, string(st), force)
 			if err != nil {
 				return types.ErrMsg{Err: err}
 			}
-			if err := m.enrich.PersistFetchedDetail(ctx, id, url, res); err != nil {
+			if err := m.backend.PersistFetchedDetail(ctx, id, url, res); err != nil {
 				return types.ErrMsg{Err: err}
 			}
 			return detailLoadedMsg{
@@ -183,7 +180,7 @@ func (m *Model) enrichItems(toEnrich []triage.NotificationWithState, force bool)
 		chunk := batch[i:end]
 
 		cmds = append(cmds, m.submitTask(enrichmentBatchScope(chunk), 0, api.PriorityEnrich, func(ctx context.Context) any {
-			results := m.enrich.FetchHybridBatch(ctx, chunk, force)
+			results := m.backend.FetchHybridBatch(ctx, chunk, force)
 			return enrichmentBatchCompleteMsg{Results: results}
 		}))
 	}
@@ -201,12 +198,12 @@ func (m *Model) ToggleRead(i item) tea.Cmd {
 
 func (m *Model) FetchDetailCmd(id, u string, subjectType triage.SubjectType, force bool) tea.Cmd {
 	return m.submitTask("detail:view", 0, api.PriorityUser, func(ctx context.Context) any {
-		res, err := m.enrich.FetchDetail(ctx, u, string(subjectType), force)
+		res, err := m.backend.FetchDetail(ctx, u, string(subjectType), force)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 
-		if err := m.enrich.PersistFetchedDetail(ctx, id, u, res); err != nil {
+		if err := m.backend.PersistFetchedDetail(ctx, id, u, res); err != nil {
 			return types.ErrMsg{Err: err}
 		}
 

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/types"
@@ -24,50 +25,41 @@ func TestNewModel_Guards(t *testing.T) {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
+	backend, err := api.NewTUIBackendClient("u", mockRepo, mockSyncer, mockEnricher, nil)
+	assert.NoError(t, err)
+
 	t.Run("Missing UserID", func(t *testing.T) {
-		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "user ID is required")
 	})
 
 	t.Run("Missing Config", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "config is required")
 	})
 
 	t.Run("Missing Logger", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "logger is required")
 	})
 
 	t.Run("Missing TaskRoot", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, Backend: backend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "task root context is required")
 	})
 
-	t.Run("Missing DB", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Syncer: mockSyncer, Enricher: mockEnricher, Alerter: mockAlerter})
+	t.Run("Missing Backend", func(t *testing.T) {
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Alerter: mockAlerter})
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "database is required")
-	})
-
-	t.Run("Missing Syncer", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Enricher: mockEnricher, Alerter: mockAlerter})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "syncer is required")
-	})
-
-	t.Run("Missing Enricher", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Alerter: mockAlerter})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "enricher is required")
+		assert.Contains(t, err.Error(), "backend is required")
 	})
 
 	t.Run("Missing Alerter", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), DB: mockRepo, Syncer: mockSyncer, Enricher: mockEnricher})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: backend})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "alerter is required")
 	})
@@ -99,8 +91,8 @@ func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
 		_, hasDeadline := ctx.Deadline()
 		return err == nil && hasDeadline
 	})
-	m.sync.(*mocks.MockSyncer).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	m.enrich.(*mocks.MockEnricher).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	testSyncer(m).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
+	testEnricher(m).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	m.Shutdown()

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -144,7 +144,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTimeoutClearsSyncing(t *t
 		types.ConnectedSyncTimeout = originalTimeout
 	})
 
-	m.sync.(*mocks.MockSyncer).EXPECT().
+	testSyncer(m).EXPECT().
 		Sync(mock.Anything, "test-user", true).
 		RunAndReturn(func(ctx context.Context, userID string, force bool) (models.RateLimitInfo, error) {
 			<-ctx.Done()
@@ -195,7 +195,7 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedA
 	m.traffic = nil
 	m.ui.SetSyncing(true)
 
-	m.sync.(*mocks.MockSyncer).EXPECT().
+	testSyncer(m).EXPECT().
 		Sync(mock.Anything, "test-user", false).
 		Return(models.RateLimitInfo{Remaining: 999}, types.ErrSyncIntervalNotReached).
 		Once()
@@ -216,13 +216,13 @@ func TestModel_SyncNotificationsWithForce_ConnectedModeTreatsIntervalNotReachedA
 
 func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	m := newTestModel(t)
-	m.client = nil
+	testBackend(m).Client = nil
 	m.traffic = nil
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
-	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
@@ -247,9 +247,9 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
-	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
-	m.client.(*mocks.MockClient).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
@@ -270,14 +270,14 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 
 func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T) {
 	m := newTestModel(t)
-	m.client = nil
+	testBackend(m).Client = nil
 	m.traffic = nil
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
 	localErr := assert.AnError
-	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
 
@@ -298,15 +298,15 @@ func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T)
 
 func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t *testing.T) {
 	m := newTestModel(t)
-	m.client = nil
+	testBackend(m).Client = nil
 	m.traffic = nil
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
 	localErr := assert.AnError
 	reloadErr := sql.ErrConnDone
-	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, reloadErr).Once()
+	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, reloadErr).Once()
 
 	cmd := m.MarkReadByID("1", true)
 	require.NotNil(t, cmd)
@@ -326,9 +326,9 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
 	remoteErr := assert.AnError
-	m.db.(*mocks.MockRepository).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
-	m.client.(*mocks.MockClient).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(remoteErr).Once()
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(remoteErr).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
@@ -349,7 +349,7 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 
 func TestModel_Transition_EdgeCases(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 	m.allNotifications = []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}
 	m.applyFilters()
 
@@ -441,7 +441,7 @@ func TestModel_HandleTransitionError_ManualSyncShowsFailureToast(t *testing.T) {
 
 func TestModel_Transition_Navigation(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{
@@ -474,7 +474,7 @@ func TestModel_Transition_Navigation(t *testing.T) {
 
 func TestModel_Transition_Priority(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{GitHubID: "1"},
@@ -497,7 +497,7 @@ func TestModel_Transition_Priority(t *testing.T) {
 
 func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{
@@ -525,7 +525,7 @@ func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {
 
 func TestModel_Transition_Tabs(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	// 1. Next Tab
 	msg := keyPress("tab")
@@ -541,7 +541,7 @@ func TestModel_Transition_Tabs(t *testing.T) {
 
 func TestModel_Transition_Enrichment(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notifs := []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()}},
@@ -568,7 +568,7 @@ func TestModel_Transition_Enrichment(t *testing.T) {
 
 func TestModel_Enrichment_Deduplication(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{GitHubID: "1", IsEnriched: false, UpdatedAt: time.Now()},
@@ -592,7 +592,7 @@ func TestModel_Enrichment_Deduplication(t *testing.T) {
 
 func TestModel_Enrichment_SurgicalUpdate(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	notif := triage.NotificationWithState{
 		Notification: triage.Notification{
@@ -619,7 +619,7 @@ func TestModel_Enrichment_SurgicalUpdate(t *testing.T) {
 
 func TestModel_Transition_Filtering(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	// 1. Filter PRs
 	msg := keyPress("p") // matches FilterPR
@@ -731,7 +731,7 @@ func TestHelpers(t *testing.T) {
 
 func TestModel_Transition_Global(t *testing.T) {
 	m := newTestModel(t)
-	m.db.(*mocks.MockRepository).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Maybe()
 
 	// Window Size
 	actions := m.Transition(tea.WindowSizeMsg{Width: 100, Height: 50}, 0)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,7 +15,6 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
-	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
@@ -58,10 +57,7 @@ type Model struct {
 	detailView DetailModel
 
 	// Shared State & Services (Interfaces)
-	db               types.NotificationStore
-	client           github.Client
-	sync             types.Syncer
-	enrich           types.Enricher
+	backend          types.TUIBackend
 	traffic          types.TrafficController
 	alerter          api.Alerter
 	ui               UIController
@@ -166,10 +162,7 @@ type ModelParams struct {
 	Config   *config.Config
 	Logger   *slog.Logger
 	TaskRoot context.Context
-	DB       types.NotificationStore
-	Client   github.Client
-	Syncer   types.Syncer
-	Enricher types.Enricher
+	Backend  types.TUIBackend
 	Traffic  types.TrafficController
 	Alerter  api.Alerter
 	Options  []Option
@@ -189,14 +182,8 @@ func NewModel(p ModelParams) (*Model, error) {
 	if p.TaskRoot == nil {
 		return nil, fmt.Errorf("task root context is required for TUI")
 	}
-	if p.DB == nil {
-		return nil, fmt.Errorf("database is required for TUI")
-	}
-	if p.Syncer == nil {
-		return nil, fmt.Errorf("syncer is required for TUI")
-	}
-	if p.Enricher == nil {
-		return nil, fmt.Errorf("enricher is required for TUI")
+	if p.Backend == nil {
+		return nil, fmt.Errorf("backend is required for TUI")
 	}
 	if p.Alerter == nil {
 		return nil, fmt.Errorf("alerter is required for TUI")
@@ -229,10 +216,7 @@ func NewModel(p ModelParams) (*Model, error) {
 		detailView: DetailModel{
 			viewport: vp,
 		},
-		db:           p.DB,
-		client:       p.Client,
-		sync:         p.Syncer,
-		enrich:       p.Enricher,
+		backend:      p.Backend,
 		traffic:      p.Traffic,
 		alerter:      p.Alerter,
 		config:       p.Config,
@@ -307,11 +291,8 @@ func (m *Model) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if m.sync != nil {
-		m.sync.Shutdown(ctx)
-	}
-	if m.enrich != nil {
-		m.enrich.Shutdown(ctx)
+	if m.backend != nil {
+		m.backend.Shutdown(ctx)
 	}
 	if m.traffic != nil {
 		m.traffic.Shutdown(ctx)
@@ -394,7 +375,7 @@ func (m *Model) cancelScopedTasks() {
 // loadNotifications loads the full list of notifications from local database.
 func (m *Model) loadNotifications(isInitial bool, isForced bool, isManual bool) tea.Cmd {
 	return m.submitTask("notifications:load", 0, api.PrioritySync, func(ctx context.Context) any {
-		notifs, err := m.db.ListNotifications(ctx)
+		notifs, err := m.backend.ListNotifications(ctx)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
@@ -405,7 +386,7 @@ func (m *Model) loadNotifications(isInitial bool, isForced bool, isManual bool) 
 
 func (m *Model) syncNotificationsWithForce(force bool, isManual bool) tea.Cmd {
 	return m.submitTask("notifications:sync", types.ConnectedSyncTimeout, api.PrioritySync, func(ctx context.Context) any {
-		rl, err := m.sync.Sync(ctx, m.userID, force)
+		rl, err := m.backend.Sync(ctx, force)
 		if err != nil && !errors.Is(err, types.ErrSyncIntervalNotReached) {
 			return types.ErrMsg{Err: err}
 		}

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
@@ -45,15 +46,17 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
+	backend, err := api.NewTUIBackendClient(userID, mockRepo, mockSyncer, mockEnricher, mockClient)
+	if err != nil {
+		panic(err)
+	}
+
 	m, _ := NewModel(ModelParams{
 		UserID:   userID,
 		Config:   cfg,
 		Logger:   logger,
 		TaskRoot: taskRoot,
-		DB:       mockRepo,
-		Client:   mockClient,
-		Syncer:   mockSyncer,
-		Enricher: mockEnricher,
+		Backend:  backend,
 		Traffic:  mockTraffic,
 		Alerter:  mockAlerter,
 		Options: []Option{
@@ -87,6 +90,26 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 
 	m.ui.SetSize(80, 24)
 	return m
+}
+
+func testBackend(m *Model) *api.TUIBackendClient {
+	return m.backend.(*api.TUIBackendClient)
+}
+
+func testRepo(m *Model) *mocks.MockRepository {
+	return testBackend(m).Store.(*mocks.MockRepository)
+}
+
+func testClient(m *Model) *mocks.MockClient {
+	return testBackend(m).Client.(*mocks.MockClient)
+}
+
+func testSyncer(m *Model) *mocks.MockSyncer {
+	return testBackend(m).Syncer.(*mocks.MockSyncer)
+}
+
+func testEnricher(m *Model) *mocks.MockEnricher {
+	return testBackend(m).Enricher.(*mocks.MockEnricher)
 }
 
 func daysAgo(days int) time.Time {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -14,7 +14,7 @@ import (
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Global bridge status refresh (Imperative Shell side-effect)
-	m.bridgeStatus = m.sync.BridgeStatus()
+	m.bridgeStatus = m.backend.BridgeStatus()
 
 	// 1. Transition State (Functional Core)
 	oldIndex := m.listView.list.Index()

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
@@ -129,15 +130,15 @@ func TestRenderHeader_States(t *testing.T) {
 		mockAlerter := mocks.NewMockAlerter(t)
 		mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 		mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
+		backend, err := api.NewTUIBackendClient("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil)
+		assert.NoError(t, err)
 
 		m, err := NewModel(ModelParams{
 			UserID:   "user",
 			Config:   cfg,
 			Logger:   logger,
 			TaskRoot: context.Background(),
-			DB:       mocks.NewMockRepository(t),
-			Syncer:   mockSyncer,
-			Enricher: mocks.NewMockEnricher(t),
+			Backend:  backend,
 			Alerter:  mockAlerter,
 			Traffic:  nil, // Intentional nil
 		})

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -126,6 +126,35 @@ type CommandExecutor interface {
 // ErrMsg is a common error message wrapper for Bubble Tea updates.
 type ErrMsg struct{ Err error }
 
+// MarkReadStatus describes the outcome of a backend-owned mark-read mutation.
+type MarkReadStatus uint8
+
+const (
+	MarkReadSuccess MarkReadStatus = iota
+	MarkReadRemoteFailure
+)
+
+// MarkReadResult captures the backend-visible outcome of a mark-read mutation.
+type MarkReadResult struct {
+	Status MarkReadStatus
+	Err    error
+}
+
+// TUIBackend defines the application-facing backend seam used by the TUI.
+// It is intentionally shaped around TUI use cases rather than persistence or
+// transport categories.
+type TUIBackend interface {
+	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
+	Sync(ctx context.Context, force bool) (models.RateLimitInfo, error)
+	MarkRead(ctx context.Context, id string, read bool) (MarkReadResult, error)
+	SetPriority(ctx context.Context, id string, priority int) error
+	FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error)
+	PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error
+	FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult
+	BridgeStatus() BridgeStatus
+	Shutdown(ctx context.Context)
+}
+
 // NotificationStore defines the persistence surface the TUI needs in both
 // standalone and connected mode.
 type NotificationStore interface {


### PR DESCRIPTION
## Summary
- introduce a new transport-agnostic `types.TUIBackend` seam for TUI-facing operations
- add an in-process `api.TUIBackendClient` that binds runtime `userID` and adapts the existing standalone services
- move `internal/tui.Model` off split `NotificationStore` / `Syncer` / `Enricher` dependencies onto the single backend seam
- route `MarkRead` through the new backend seam in both standalone and connected modes

## Details
- add `types.MarkReadResult` / `types.MarkReadStatus` and the new `types.TUIBackend` contract in `internal/types/api.go`
- add `internal/api/tui_backend.go` as the first in-process compatibility adapter for the new seam
- update `internal/engine/MCPAdapter` to satisfy `types.TUIBackend`, including correct MCP tool-result error handling for connected-mode `mark_read`
- update TUI wiring and tests so constructor paths target the new backend seam rather than direct persistence-shaped dependencies
- keep this slice limited to seam introduction and first wiring; broader TUI action migration remains deferred to later roadmap steps

## Preserved Invariants
- embedded and standalone TUI behavior remain semantically aligned
- `Sync` is exposed as `Sync(ctx, force)` with runtime identity bound in the concrete implementation
- direct TUI-owned `github.Client` mutation authority is removed from the `MarkRead` path

## Validation
- `go test ./internal/engine ./internal/tui ./cmd/gh-orbit`
- `make go/check`

Closes #357
