### PR TITLE
refactor(api): add backend orchestration owner

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -438,17 +438,12 @@ func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.Core
 		}
 	}()
 
-	backend, err := api.NewTUIBackendClient(userID, eng.DB, eng.Sync, eng.Enrich, eng.Client)
-	if err != nil {
-		return err
-	}
-
 	m, err := tui.NewModel(tui.ModelParams{
 		UserID:   userID,
 		Config:   eng.Config,
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
-		Backend:  backend,
+		Backend:  eng.Backend,
 		Traffic:  eng.Traffic,
 		Alerter:  eng.Alert,
 		Options: []tui.Option{

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -44,7 +44,7 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.
 
 	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-	backend, err := api.NewTUIBackendClient("user", repo, syncer, enricher, nil)
+	backend, err := api.NewBackend("user", repo, syncer, enricher, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	m, err := tui.NewModel(tui.ModelParams{

--- a/internal/api/enrichment.go
+++ b/internal/api/enrichment.go
@@ -220,8 +220,6 @@ func (e *EnrichmentEngine) PersistFetchedDetail(ctx context.Context, id, sourceU
 	e.rememberCacheEntryLocked(sourceURL, res)
 	e.mu.Unlock()
 
-	e.OnMutation()
-
 	return nil
 }
 
@@ -237,8 +235,6 @@ func (e *EnrichmentEngine) PersistIndependentDetail(ctx context.Context, id, nod
 		e.invalidateByURLLocked(htmlURL)
 	}
 	e.mu.Unlock()
-
-	e.OnMutation()
 
 	return nil
 }

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -84,9 +84,12 @@ func TestSyncEngine_Sync(t *testing.T) {
 			Logger:  logger,
 		})
 		assert.NoError(t, err)
+		published := 0
+		engine.OnMutation = func() { published++ }
 		_, err = engine.Sync(ctx, userID, false)
 
 		require.NoError(t, err)
+		assert.Equal(t, 1, published)
 	})
 
 	t.Run("Skips Sync When Interval Not Reached", func(t *testing.T) {

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -11,86 +12,170 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/types"
 )
 
-// TUIBackendClient adapts the existing in-process services to the TUI-facing
-// backend contract used by the architecture-v2 migration.
-type TUIBackendClient struct {
+// Backend is the in-process application-facing backend owner for TUI operations.
+// It composes narrower services but owns direct mutation semantics and their
+// corresponding event publication.
+type Backend struct {
 	UserID   string
 	Store    types.NotificationStore
 	Client   github.Client
 	Syncer   types.Syncer
 	Enricher types.Enricher
+
+	resolveUserID func(context.Context) (string, error)
+	userMu        sync.RWMutex
+
+	publishNotificationsChanged func()
+	publishEnrichmentUpdated    func()
 }
 
-func NewTUIBackendClient(userID string, store types.NotificationStore, syncer types.Syncer, enricher types.Enricher, client github.Client) (*TUIBackendClient, error) {
-	if userID == "" {
-		return nil, fmt.Errorf("user ID is required for TUIBackendClient")
-	}
+func NewBackend(
+	userID string,
+	store types.NotificationStore,
+	syncer types.Syncer,
+	enricher types.Enricher,
+	client github.Client,
+	resolveUserID func(context.Context) (string, error),
+	publishNotificationsChanged func(),
+	publishEnrichmentUpdated func(),
+) (*Backend, error) {
 	if store == nil {
-		return nil, fmt.Errorf("notification store is required for TUIBackendClient")
+		return nil, fmt.Errorf("notification store is required for Backend")
 	}
 	if syncer == nil {
-		return nil, fmt.Errorf("syncer is required for TUIBackendClient")
+		return nil, fmt.Errorf("syncer is required for Backend")
 	}
 	if enricher == nil {
-		return nil, fmt.Errorf("enricher is required for TUIBackendClient")
+		return nil, fmt.Errorf("enricher is required for Backend")
+	}
+	if userID == "" && resolveUserID == nil {
+		return nil, fmt.Errorf("user ID or resolver is required for Backend")
+	}
+	if publishNotificationsChanged == nil {
+		publishNotificationsChanged = func() {}
+	}
+	if publishEnrichmentUpdated == nil {
+		publishEnrichmentUpdated = func() {}
 	}
 
-	return &TUIBackendClient{
-		UserID:   userID,
-		Store:    store,
-		Client:   client,
-		Syncer:   syncer,
-		Enricher: enricher,
+	return &Backend{
+		UserID:                      userID,
+		Store:                       store,
+		Client:                      client,
+		Syncer:                      syncer,
+		Enricher:                    enricher,
+		resolveUserID:               resolveUserID,
+		publishNotificationsChanged: publishNotificationsChanged,
+		publishEnrichmentUpdated:    publishEnrichmentUpdated,
 	}, nil
 }
 
-func (b *TUIBackendClient) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
+// NewTUIBackendClient is a temporary constructor alias kept only for
+// compatibility while the architecture-v2 migration lands. It must not own any
+// behavior beyond constructing the real Backend type.
+func NewTUIBackendClient(
+	userID string,
+	store types.NotificationStore,
+	syncer types.Syncer,
+	enricher types.Enricher,
+	client github.Client,
+) (*Backend, error) {
+	return NewBackend(userID, store, syncer, enricher, client, nil, nil, nil)
+}
+
+func (b *Backend) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
 	return b.Store.ListNotifications(ctx)
 }
 
-func (b *TUIBackendClient) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
-	return b.Syncer.Sync(ctx, b.UserID, force)
+func (b *Backend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
+	userID, err := b.boundUserID(ctx)
+	if err != nil {
+		return models.RateLimitInfo{}, err
+	}
+	return b.Syncer.Sync(ctx, userID, force)
 }
 
-func (b *TUIBackendClient) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
+func (b *Backend) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
 	if err := b.Store.MarkReadLocally(ctx, id, read); err != nil {
 		return types.MarkReadResult{}, err
 	}
+
+	b.publishNotificationsChanged()
+
 	if read && b.Client != nil {
 		if err := b.Client.MarkThreadAsRead(ctx, id); err != nil {
 			return types.MarkReadResult{Status: types.MarkReadRemoteFailure, Err: err}, nil
 		}
 	}
+
 	return types.MarkReadResult{Status: types.MarkReadSuccess}, nil
 }
 
-func (b *TUIBackendClient) SetPriority(ctx context.Context, id string, priority int) error {
-	return b.Store.SetPriority(ctx, id, priority)
+func (b *Backend) SetPriority(ctx context.Context, id string, priority int) error {
+	if err := b.Store.SetPriority(ctx, id, priority); err != nil {
+		return err
+	}
+
+	b.publishNotificationsChanged()
+	return nil
 }
 
-func (b *TUIBackendClient) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
+func (b *Backend) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
 	return b.Enricher.FetchDetail(ctx, u, subjectType, force)
 }
 
-func (b *TUIBackendClient) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
-	return b.Enricher.PersistFetchedDetail(ctx, id, sourceURL, res)
+func (b *Backend) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
+	if err := b.Enricher.PersistFetchedDetail(ctx, id, sourceURL, res); err != nil {
+		return err
+	}
+
+	b.publishEnrichmentUpdated()
+	return nil
 }
 
-func (b *TUIBackendClient) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
+func (b *Backend) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
 	return b.Enricher.FetchHybridBatch(ctx, notifications, force)
 }
 
-func (b *TUIBackendClient) BridgeStatus() types.BridgeStatus {
+func (b *Backend) BridgeStatus() types.BridgeStatus {
 	return b.Syncer.BridgeStatus()
 }
 
-func (b *TUIBackendClient) Shutdown(ctx context.Context) {
+func (b *Backend) Shutdown(ctx context.Context) {
 	if b.Syncer != nil {
 		b.Syncer.Shutdown(ctx)
 	}
 	if b.Enricher != nil {
 		b.Enricher.Shutdown(ctx)
 	}
+}
+
+func (b *Backend) boundUserID(ctx context.Context) (string, error) {
+	b.userMu.RLock()
+	if b.UserID != "" {
+		defer b.userMu.RUnlock()
+		return b.UserID, nil
+	}
+	b.userMu.RUnlock()
+
+	if b.resolveUserID == nil {
+		return "", fmt.Errorf("backend user ID is unavailable")
+	}
+
+	userID, err := b.resolveUserID(ctx)
+	if err != nil {
+		return "", err
+	}
+	if userID == "" {
+		return "", fmt.Errorf("backend user ID is empty")
+	}
+
+	b.userMu.Lock()
+	defer b.userMu.Unlock()
+	if b.UserID == "" {
+		b.UserID = userID
+	}
+	return b.UserID, nil
 }
 
 func IsRemoteMarkReadFailure(err error) bool {

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/hirakiuc/gh-orbit/internal/config"
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+	mockClient := mocks.NewMockClient(t)
+
+	mockRepo.EXPECT().MarkReadLocally(mock.Anything, "notif-1", true).Return(nil).Once()
+	mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-1").Return(nil).Once()
+
+	published := 0
+	backend, err := NewBackend(
+		"user-1",
+		mockRepo,
+		mockSyncer,
+		mockEnricher,
+		mockClient,
+		nil,
+		func() { published++ },
+		nil,
+	)
+	require.NoError(t, err)
+
+	result, err := backend.MarkRead(context.Background(), "notif-1", true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, published)
+	assert.Equal(t, types.MarkReadSuccess, result.Status)
+}
+
+func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+
+	mockRepo.EXPECT().SetPriority(mock.Anything, "notif-2", 3).Return(nil).Once()
+
+	published := 0
+	backend, err := NewBackend(
+		"user-1",
+		mockRepo,
+		mockSyncer,
+		mockEnricher,
+		nil,
+		nil,
+		func() { published++ },
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, backend.SetPriority(context.Background(), "notif-2", 3))
+	assert.Equal(t, 1, published)
+}
+
+func TestBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+
+	res := models.EnrichmentResult{
+		SubjectNodeID: "node-1",
+		Body:          "body",
+		Author:        "octocat",
+		HTMLURL:       "https://github.com/o/r/pull/1",
+	}
+	mockEnricher.EXPECT().
+		PersistFetchedDetail(mock.Anything, "notif-3", "https://api.github.com/repos/o/r/pulls/1", res).
+		Return(nil).
+		Once()
+
+	published := 0
+	backend, err := NewBackend(
+		"user-1",
+		mockRepo,
+		mockSyncer,
+		mockEnricher,
+		nil,
+		nil,
+		nil,
+		func() { published++ },
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, backend.PersistFetchedDetail(context.Background(), "notif-3", "https://api.github.com/repos/o/r/pulls/1", res))
+	assert.Equal(t, 1, published)
+}
+
+func TestBackend_PersistFetchedDetailDoesNotDoublePublishViaEnricherHook(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockClient := mocks.NewMockClient(t)
+	mockRepo := mocks.NewMockEnrichmentRepository(t)
+
+	engine, err := NewEnrichmentEngine(ctx, EnrichParams{
+		Client: mockClient,
+		DB:     mockRepo,
+		Config: config.DefaultConfig(),
+		Logger: logger,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { engine.Shutdown(ctx) })
+
+	res := models.EnrichmentResult{SubjectNodeID: "node-1", Body: "body"}
+	mockRepo.EXPECT().
+		EnrichNotification(mock.Anything, "notif-4", "node-1", "body", "", "", "", "").
+		Return(nil).
+		Once()
+
+	published := 0
+	engine.OnMutation = func() { published++ }
+
+	require.NoError(t, engine.PersistFetchedDetail(ctx, "notif-4", "https://api.github.com/repos/o/r/pulls/4", res))
+	assert.Equal(t, 0, published)
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -19,6 +19,7 @@ type CoreEngine struct {
 	Bus     *EventBus
 	DB      types.Repository
 	Client  github.Client
+	Backend types.TUIBackend
 	Sync    types.Syncer
 	Enrich  types.Enricher
 	Traffic types.TrafficController
@@ -121,12 +122,34 @@ func NewCoreEngine(
 	}
 	syncer.OnMutation = func() { bus.Publish(EventNotificationsChanged) }
 
+	backend, err := api.NewBackend(
+		"",
+		database,
+		syncer,
+		enricher,
+		client,
+		func(ctx context.Context) (string, error) {
+			user, err := client.CurrentUser(ctx)
+			if err != nil {
+				return "", err
+			}
+			return user.Login, nil
+		},
+		func() { bus.Publish(EventNotificationsChanged) },
+		func() { bus.Publish(EventEnrichmentUpdated) },
+	)
+	if err != nil {
+		_ = database.Close()
+		return nil, err
+	}
+
 	return &CoreEngine{
 		Config:  cfg,
 		Logger:  logger,
 		Bus:     bus,
 		DB:      database,
 		Client:  client,
+		Backend: backend,
 		Sync:    syncer,
 		Enrich:  enricher,
 		Traffic: traffic,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -33,6 +33,7 @@ func TestCoreEngine_Initialization(t *testing.T) {
 
 	assert.NotNil(t, eng.Sync)
 	assert.NotNil(t, eng.Enrich)
+	assert.NotNil(t, eng.Backend)
 	assert.NotNil(t, eng.Traffic)
 	assert.NotNil(t, eng.Alert)
 	assert.NotNil(t, eng.DB)

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -25,7 +25,7 @@ func TestNewModel_Guards(t *testing.T) {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	backend, err := api.NewTUIBackendClient("u", mockRepo, mockSyncer, mockEnricher, nil)
+	backend, err := api.NewBackend("u", mockRepo, mockSyncer, mockEnricher, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	t.Run("Missing UserID", func(t *testing.T) {

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -46,7 +46,7 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	backend, err := api.NewTUIBackendClient(userID, mockRepo, mockSyncer, mockEnricher, mockClient)
+	backend, err := api.NewBackend(userID, mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -92,8 +92,8 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	return m
 }
 
-func testBackend(m *Model) *api.TUIBackendClient {
-	return m.backend.(*api.TUIBackendClient)
+func testBackend(m *Model) *api.Backend {
+	return m.backend.(*api.Backend)
 }
 
 func testRepo(m *Model) *mocks.MockRepository {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -130,7 +130,7 @@ func TestRenderHeader_States(t *testing.T) {
 		mockAlerter := mocks.NewMockAlerter(t)
 		mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 		mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-		backend, err := api.NewTUIBackendClient("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil)
+		backend, err := api.NewBackend("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil, nil, nil, nil)
 		assert.NoError(t, err)
 
 		m, err := NewModel(ModelParams{


### PR DESCRIPTION
## Summary
- add a real in-process `api.Backend` as the backend orchestration owner behind `types.TUIBackend`
- move direct mutation and enrichment-persistence publication ownership into that backend layer
- make `NewCoreEngine` construct and expose the backend owner explicitly in runtime wiring

## Details
- replace the behavior-bearing `TUIBackendClient` implementation in `internal/api/tui_backend.go` with `api.Backend`
- keep `NewTUIBackendClient(...)` only as a trivial constructor alias to avoid preserving a second behavior owner
- keep `SyncEngine` focused on sync-cycle mechanics and sync-driven notification publication
- remove enrichment-persistence publication from `EnrichmentEngine` so the backend owner publishes `EventEnrichmentUpdated` for direct persistence use cases
- update standalone runtime wiring to consume `eng.Backend` instead of constructing and patching backend ownership later in `main.go`
- add focused tests for the event-owner split and for `CoreEngine.Backend` initialization

## Preserved Invariants
- SQLite remains the local source of truth
- current sync and enrichment behavior stays functionally intact
- event ownership for this slice is explicit:
  - `api.Backend` for direct mutations
  - `api.Backend` for enrichment persistence
  - `SyncEngine` for sync-driven refresh

## Validation
- `go test ./internal/api ./internal/engine ./internal/tui ./cmd/gh-orbit`
- `make go/check`

Closes #358
