### PR TITLE
refactor(tui): move mutation reconciliation behind backend

### DIFF
--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -96,28 +96,99 @@ func (b *Backend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, e
 }
 
 func (b *Backend) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
+	before, _ := b.Store.ListNotifications(ctx)
+
 	if err := b.Store.MarkReadLocally(ctx, id, read); err != nil {
-		return types.MarkReadResult{}, err
+		notifications, reloadErr := b.Store.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before != nil {
+				return types.MarkReadResult{
+					Status:        types.MarkReadLocalFailure,
+					Notifications: before,
+					Toast:         "Failed to update read state",
+					Err:           err,
+				}, nil
+			}
+			return types.MarkReadResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, err)
+		}
+		return types.MarkReadResult{
+			Status:        types.MarkReadLocalFailure,
+			Notifications: notifications,
+			Toast:         "Failed to update read state",
+			Err:           err,
+		}, nil
 	}
 
 	b.publishNotificationsChanged()
 
 	if read && b.Client != nil {
 		if err := b.Client.MarkThreadAsRead(ctx, id); err != nil {
-			return types.MarkReadResult{Status: types.MarkReadRemoteFailure, Err: err}, nil
+			notifications, reloadErr := b.Store.ListNotifications(ctx)
+			if reloadErr != nil {
+				notifications = withReadState(before, id, read)
+			}
+			return types.MarkReadResult{
+				Status:        types.MarkReadRemoteFailure,
+				Notifications: notifications,
+				Toast:         "Marked read locally; GitHub sync failed",
+				Err:           err,
+			}, nil
 		}
 	}
 
-	return types.MarkReadResult{Status: types.MarkReadSuccess}, nil
+	notifications, err := b.Store.ListNotifications(ctx)
+	if err != nil {
+		if before != nil {
+			notifications = withReadState(before, id, read)
+		} else {
+			return types.MarkReadResult{}, err
+		}
+	}
+
+	return types.MarkReadResult{
+		Status:        types.MarkReadSuccess,
+		Notifications: notifications,
+	}, nil
 }
 
-func (b *Backend) SetPriority(ctx context.Context, id string, priority int) error {
+func (b *Backend) SetPriority(ctx context.Context, id string, priority int) (types.PriorityUpdateResult, error) {
+	before, _ := b.Store.ListNotifications(ctx)
+
 	if err := b.Store.SetPriority(ctx, id, priority); err != nil {
-		return err
+		notifications, reloadErr := b.Store.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before != nil {
+				return types.PriorityUpdateResult{
+					Status:        types.PriorityUpdateFailure,
+					Notifications: before,
+					Err:           err,
+				}, nil
+			}
+			return types.PriorityUpdateResult{}, fmt.Errorf("reload notifications after priority update failure: %w (original error: %v)", reloadErr, err)
+		}
+		return types.PriorityUpdateResult{
+			Status:        types.PriorityUpdateFailure,
+			Notifications: notifications,
+			Err:           err,
+		}, nil
 	}
 
 	b.publishNotificationsChanged()
-	return nil
+
+	notifications, err := b.Store.ListNotifications(ctx)
+	if err != nil {
+		if before != nil {
+			notifications = withPriority(before, id, priority)
+		} else {
+			return types.PriorityUpdateResult{}, err
+		}
+	}
+
+	return types.PriorityUpdateResult{
+		Status:        types.PriorityUpdateSuccess,
+		Notifications: notifications,
+		Toast:         priorityToast(priority),
+	}, nil
 }
 
 func (b *Backend) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
@@ -180,4 +251,39 @@ func (b *Backend) boundUserID(ctx context.Context) (string, error) {
 
 func IsRemoteMarkReadFailure(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "failed to mark read on GitHub")
+}
+
+func withReadState(notifications []triage.NotificationWithState, id string, read bool) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].IsReadLocally = read
+			break
+		}
+	}
+	return cloned
+}
+
+func withPriority(notifications []triage.NotificationWithState, id string, priority int) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].Priority = priority
+			break
+		}
+	}
+	return cloned
+}
+
+func priorityToast(priority int) string {
+	switch priority {
+	case 1:
+		return "Priority set to Low"
+	case 2:
+		return "Priority set to Medium"
+	case 3:
+		return "Priority set to High"
+	default:
+		return "Priority cleared"
+	}
 }

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -20,9 +21,12 @@ func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
 	mockClient := mocks.NewMockClient(t)
+	snapshot := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true}}}
 
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-1"}}}, nil).Once()
 	mockRepo.EXPECT().MarkReadLocally(mock.Anything, "notif-1", true).Return(nil).Once()
 	mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-1").Return(nil).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
 	backend, err := NewBackend(
@@ -41,14 +45,18 @@ func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, published)
 	assert.Equal(t, types.MarkReadSuccess, result.Status)
+	assert.Equal(t, snapshot, result.Notifications)
 }
 
 func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
+	snapshot := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-2"}, State: triage.State{Priority: 3}}}
 
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-2"}}}, nil).Once()
 	mockRepo.EXPECT().SetPriority(mock.Anything, "notif-2", 3).Return(nil).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
 	backend, err := NewBackend(
@@ -63,8 +71,12 @@ func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, backend.SetPriority(context.Background(), "notif-2", 3))
+	result, err := backend.SetPriority(context.Background(), "notif-2", 3)
+	require.NoError(t, err)
 	assert.Equal(t, 1, published)
+	assert.Equal(t, types.PriorityUpdateSuccess, result.Status)
+	assert.Equal(t, snapshot, result.Notifications)
+	assert.Equal(t, "Priority set to High", result.Toast)
 }
 
 func TestBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -103,8 +103,7 @@ func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.Notificati
 	if err != nil {
 		return nil, err
 	}
-
-	if len(resp.Contents) == 0 {
+	if resp == nil || len(resp.Contents) == 0 {
 		return nil, nil
 	}
 
@@ -122,6 +121,8 @@ func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.Notificati
 }
 
 func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (types.MarkReadResult, error) {
+	before, _ := a.ListNotifications(ctx)
+
 	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "mark_read",
@@ -140,11 +141,48 @@ func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (type
 	if resp.IsError {
 		toolErr := decodeToolResultError("mark_read", resp)
 		if api.IsRemoteMarkReadFailure(toolErr) {
-			return types.MarkReadResult{Status: types.MarkReadRemoteFailure, Err: toolErr}, nil
+			notifications, reloadErr := a.ListNotifications(ctx)
+			if reloadErr != nil {
+				notifications = applyReadState(before, id, isRead)
+			}
+			return types.MarkReadResult{
+				Status:        types.MarkReadRemoteFailure,
+				Notifications: notifications,
+				Toast:         "Marked read locally; GitHub sync failed",
+				Err:           toolErr,
+			}, nil
 		}
-		return types.MarkReadResult{}, toolErr
+		notifications, reloadErr := a.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before != nil {
+				return types.MarkReadResult{
+					Status:        types.MarkReadLocalFailure,
+					Notifications: before,
+					Toast:         "Failed to update read state",
+					Err:           toolErr,
+				}, nil
+			}
+			return types.MarkReadResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, toolErr)
+		}
+		return types.MarkReadResult{
+			Status:        types.MarkReadLocalFailure,
+			Notifications: notifications,
+			Toast:         "Failed to update read state",
+			Err:           toolErr,
+		}, nil
 	}
-	return types.MarkReadResult{Status: types.MarkReadSuccess}, nil
+	notifications, err := a.ListNotifications(ctx)
+	if err != nil {
+		if before != nil {
+			notifications = applyReadState(before, id, isRead)
+		} else {
+			return types.MarkReadResult{}, err
+		}
+	}
+	return types.MarkReadResult{
+		Status:        types.MarkReadSuccess,
+		Notifications: notifications,
+	}, nil
 }
 
 func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
@@ -152,8 +190,10 @@ func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool
 	return err
 }
 
-func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) error {
-	_, err := a.client.CallTool(ctx, mcp.CallToolRequest{
+func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) (types.PriorityUpdateResult, error) {
+	before, _ := a.ListNotifications(ctx)
+
+	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "set_priority",
 			Arguments: map[string]any{
@@ -162,7 +202,41 @@ func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) e
 			},
 		},
 	})
-	return err
+	if err != nil {
+		return types.PriorityUpdateResult{}, err
+	}
+	if resp != nil && resp.IsError {
+		toolErr := decodeToolResultError("set_priority", resp)
+		notifications, reloadErr := a.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before != nil {
+				return types.PriorityUpdateResult{
+					Status:        types.PriorityUpdateFailure,
+					Notifications: before,
+					Err:           toolErr,
+				}, nil
+			}
+			return types.PriorityUpdateResult{}, fmt.Errorf("reload notifications after priority update failure: %w (original error: %v)", reloadErr, toolErr)
+		}
+		return types.PriorityUpdateResult{
+			Status:        types.PriorityUpdateFailure,
+			Notifications: notifications,
+			Err:           toolErr,
+		}, nil
+	}
+	notifications, err := a.ListNotifications(ctx)
+	if err != nil {
+		if before != nil {
+			notifications = applyPriority(before, id, priority)
+		} else {
+			return types.PriorityUpdateResult{}, err
+		}
+	}
+	return types.PriorityUpdateResult{
+		Status:        types.PriorityUpdateSuccess,
+		Notifications: notifications,
+		Toast:         priorityToast(priority),
+	}, nil
 }
 
 func (a *MCPAdapter) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
@@ -285,6 +359,41 @@ func decodeToolResultError(toolName string, resp *mcp.CallToolResult) error {
 		return errors.New(text.Text)
 	}
 	return fmt.Errorf("%s error: unexpected tool failure payload", toolName)
+}
+
+func applyReadState(notifications []triage.NotificationWithState, id string, read bool) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].IsReadLocally = read
+			break
+		}
+	}
+	return cloned
+}
+
+func applyPriority(notifications []triage.NotificationWithState, id string, priority int) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].Priority = priority
+			break
+		}
+	}
+	return cloned
+}
+
+func priorityToast(priority int) string {
+	switch priority {
+	case 1:
+		return "Priority set to Low"
+	case 2:
+		return "Priority set to Medium"
+	case 3:
+		return "Priority set to High"
+	default:
+		return "Priority cleared"
+	}
 }
 
 func (a *MCPAdapter) Shutdown(ctx context.Context) {

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -269,9 +269,10 @@ func TestMCPAdapter_MarkRead_TreatsLocalToolFailureAsError(t *testing.T) {
 	})
 
 	result, err := adapter.MarkRead(context.Background(), "123", true)
-	require.Error(t, err)
-	assert.Equal(t, types.MarkReadResult{}, result)
-	assert.Contains(t, err.Error(), "failed to mark read locally: sqlite busy")
+	require.NoError(t, err)
+	assert.Equal(t, types.MarkReadLocalFailure, result.Status)
+	require.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "failed to mark read locally: sqlite busy")
 }
 
 func TestMCPAdapter_ImplementsTUIBackendBoundary(t *testing.T) {

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -26,13 +25,9 @@ func enrichmentBatchScope(chunk []triage.NotificationWithState) string {
 // MarkReadByID marks a notification as read using only its ID.
 func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 	// 1. Update master copy
-	originalRead := read
-	found := false
 	for idx, n := range m.allNotifications {
 		if n.GitHubID == id {
-			originalRead = m.allNotifications[idx].IsReadLocally
 			m.allNotifications[idx].IsReadLocally = read
-			found = true
 			break
 		}
 	}
@@ -43,50 +38,14 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 	return m.submitTask("read:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
 		result, err := m.backend.MarkRead(ctx, id, read)
 		if err != nil {
-			m.logger.ErrorContext(ctx, "failed to update local read state", "error", err)
-			notifs, reloadErr := m.backend.ListNotifications(ctx)
-			if reloadErr != nil {
-				if found {
-					for idx, n := range m.allNotifications {
-						if n.GitHubID == id {
-							m.allNotifications[idx].IsReadLocally = originalRead
-							break
-						}
-					}
-					m.applyFilters()
-				}
-				return types.ErrMsg{Err: fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, err)}
-			}
-			return markReadReconciledMsg{
-				notifications: notifs,
-				status:        markReadReconcileLocalFailure,
-				err:           err,
-				toast:         "Failed to update read state",
-			}
-		}
-
-		// Connected mode delegates the remote read mutation to the engine-backed
-		// repository path, so the direct GitHub client is optional here.
-		status := markReadReconcileSuccess
-		var resultErr error
-		toast := ""
-		if result.Status == types.MarkReadRemoteFailure {
-			m.logger.ErrorContext(ctx, "failed to mark thread as read on GitHub", "error", result.Err)
-			status = markReadReconcileRemoteFailure
-			resultErr = result.Err
-			toast = "Marked read locally; GitHub sync failed"
-		}
-
-		notifs, err := m.backend.ListNotifications(ctx)
-		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
 
 		return markReadReconciledMsg{
-			notifications: notifs,
-			status:        status,
-			err:           resultErr,
-			toast:         toast,
+			notifications: result.Notifications,
+			status:        markReadReconcileStatus(result.Status),
+			err:           result.Err,
+			toast:         result.Toast,
 		}
 	})
 }
@@ -94,28 +53,11 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 // setPriorityByID updates the priority of a notification using only its ID.
 func (m *Model) setPriorityByID(id string, priority int) tea.Cmd {
 	return m.submitTask("priority:"+id, 0, api.PriorityUser, func(ctx context.Context) any {
-		err := m.backend.SetPriority(ctx, id, priority)
+		result, err := m.backend.SetPriority(ctx, id, priority)
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
-
-		// Reload to reflect state
-		notifs, err := m.backend.ListNotifications(ctx)
-		if err != nil {
-			return types.ErrMsg{Err: err}
-		}
-
-		toast := "Priority cleared"
-		switch priority {
-		case 1:
-			toast = "Priority set to Low"
-		case 2:
-			toast = "Priority set to Medium"
-		case 3:
-			toast = "Priority set to High"
-		}
-
-		return priorityUpdatedMsg{notifications: notifs, toast: toast}
+		return priorityUpdatedMsg{notifications: result.Notifications, toast: result.Toast, err: result.Err}
 	})
 }
 

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -221,6 +221,9 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
+	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
@@ -247,6 +250,9 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	m.allNotifications = []triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
+	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
@@ -276,6 +282,9 @@ func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T)
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
 	localErr := assert.AnError
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
+	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
@@ -305,6 +314,9 @@ func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t 
 	}
 	localErr := assert.AnError
 	reloadErr := sql.ErrConnDone
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
+	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, reloadErr).Once()
 
@@ -312,11 +324,14 @@ func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t 
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	errMsg, ok := msg.(types.ErrMsg)
+	reconciled, ok := msg.(markReadReconciledMsg)
 	require.True(t, ok)
-	assert.ErrorIs(t, errMsg.Err, reloadErr)
-	assert.Contains(t, errMsg.Err.Error(), "original error")
+	assert.Equal(t, markReadReconcileLocalFailure, reconciled.status)
+	assert.ErrorIs(t, reconciled.err, localErr)
+	actions := m.Transition(reconciled, 0)
 	assert.False(t, m.allNotifications[0].IsReadLocally)
+	assert.ErrorIs(t, m.err, localErr)
+	assert.Contains(t, actions, ActionShowToast{Message: "Failed to update read state"})
 }
 
 func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) {
@@ -326,6 +341,9 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 		{Notification: triage.Notification{GitHubID: "1"}},
 	}
 	remoteErr := assert.AnError
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
+	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(remoteErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -422,6 +422,7 @@ type notificationsLoadedMsg struct {
 type priorityUpdatedMsg struct {
 	notifications []triage.NotificationWithState
 	toast         string
+	err           error
 }
 
 type markReadReconcileStatus uint8

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -450,6 +450,10 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 func (m *Model) handlePriorityUpdated(msg priorityUpdatedMsg) []Action {
 	m.allNotifications = msg.notifications
 	m.applyFilters()
+	m.err = msg.err
+	if msg.toast == "" {
+		return nil
+	}
 	return []Action{ActionShowToast{Message: msg.toast}}
 }
 

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -131,13 +131,30 @@ type MarkReadStatus uint8
 
 const (
 	MarkReadSuccess MarkReadStatus = iota
+	MarkReadLocalFailure
 	MarkReadRemoteFailure
 )
 
 // MarkReadResult captures the backend-visible outcome of a mark-read mutation.
 type MarkReadResult struct {
-	Status MarkReadStatus
-	Err    error
+	Status        MarkReadStatus
+	Notifications []triage.NotificationWithState
+	Toast         string
+	Err           error
+}
+
+type PriorityUpdateStatus uint8
+
+const (
+	PriorityUpdateSuccess PriorityUpdateStatus = iota
+	PriorityUpdateFailure
+)
+
+type PriorityUpdateResult struct {
+	Status        PriorityUpdateStatus
+	Notifications []triage.NotificationWithState
+	Toast         string
+	Err           error
 }
 
 // TUIBackend defines the application-facing backend seam used by the TUI.
@@ -147,7 +164,7 @@ type TUIBackend interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
 	Sync(ctx context.Context, force bool) (models.RateLimitInfo, error)
 	MarkRead(ctx context.Context, id string, read bool) (MarkReadResult, error)
-	SetPriority(ctx context.Context, id string, priority int) error
+	SetPriority(ctx context.Context, id string, priority int) (PriorityUpdateResult, error)
 	FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error)
 	PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error
 	FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult


### PR DESCRIPTION
## Summary
- move read-state and priority reconciliation policy behind backend-owned mutation operations
- make both in-process and MCP-backed backends return canonical reconciled outcomes for these two flows
- thin `internal/tui/actions.go` down to optimistic UI updates plus application of backend results

## Details
- extend `types.TUIBackend` in `internal/types/api.go` with narrow semantic result contracts for `MarkRead` and `SetPriority`
- update `internal/api/tui_backend.go` so `api.Backend` performs authoritative reload/reconciliation internally and returns:
  - status
  - canonical notification snapshot
  - resolved toast text
  - error information where needed
- update `internal/engine/adapter.go` so MCP-backed connected mode follows the same reconciled-outcome contract
- remove TUI-owned reload/rollback/toast classification logic from `internal/tui/actions.go`
- keep the existing user-visible behavior intact, including:
  - partial remote-failure handling for read-state updates
  - rollback-equivalent behavior on local failure
  - current priority toasts and canonical refresh behavior

## Preserved Invariants
- TUI read-state and priority flows keep the same user-visible outcomes and refresh behavior
- the backend, not the TUI, decides reconciliation and canonical state for these two mutation classes
- the semantic-result pattern remains narrow and scoped to these flows only

## Validation
- `go test ./internal/api ./internal/engine ./internal/tui`
- `make go/check`

Closes #359
