### PR TITLE
refactor(tui): unify connected and standalone runtime model

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -359,7 +359,14 @@ func runTUI() error {
 				env.logger.Info("connected to headless engine", "server", initResp.ServerInfo.Name)
 				adapter := engine.NewMCPAdapter(mcpClient)
 
-				user := "mcp-user" // Placeholder until tool added
+				user, err := adapter.ResolveUserID(connectCtx)
+				if err != nil {
+					if requireEngine {
+						return fmt.Errorf("cockpit-managed launch requires connected engine user identity: %w", err)
+					}
+					env.logger.Warn("failed to resolve connected engine user identity, falling back to standalone", "error", err)
+					goto standalone
+				}
 				return launchTUIMCP(ctx, env, cfg, adapter, user)
 			}
 			if requireEngine {
@@ -376,6 +383,7 @@ func runTUI() error {
 		return fmt.Errorf("cockpit-managed launch requires a running MCP engine at %s", socketPath)
 	}
 
+standalone:
 	// 2. Standalone Mode (Library access)
 	eng, err := engine.NewCoreEngine(ctx, cfg, env.logger, executor)
 	if err != nil {
@@ -410,8 +418,10 @@ func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, ada
 		Logger:   env.logger,
 		TaskRoot: lifecycle.Context(),
 		Backend:  adapter,
-		Traffic:  nil,     // Traffic (Engine handles it)
-		Alerter:  adapter, // Alerter (Mock/Engine bridge)
+		// Connected mode intentionally treats traffic control as backend-hosted;
+		// the TUI only renders connection state and no longer owns quota control.
+		Traffic: nil,
+		Alerter: adapter,
 		Options: []tui.Option{
 			tui.WithConnectionMode("Connected"),
 			tui.WithOwnedSubsystemShutdown(),

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -120,6 +120,36 @@ func (a *MCPAdapter) ListNotifications(ctx context.Context) ([]triage.Notificati
 	return notifs, err
 }
 
+func (a *MCPAdapter) ResolveUserID(ctx context.Context) (string, error) {
+	resp, err := a.client.ReadResource(ctx, mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{
+			URI: "gh-orbit://session/user",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if resp == nil || len(resp.Contents) == 0 {
+		return "", errors.New("current user resource returned no content")
+	}
+
+	content, ok := resp.Contents[0].(mcp.TextResourceContents)
+	if !ok {
+		return "", fmt.Errorf("unexpected current user resource content type")
+	}
+
+	var payload struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal([]byte(content.Text), &payload); err != nil {
+		return "", err
+	}
+	if payload.Login == "" {
+		return "", errors.New("current user login is empty")
+	}
+	return payload.Login, nil
+}
+
 func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (types.MarkReadResult, error) {
 	before, _ := a.ListNotifications(ctx)
 

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 type blockingMCPClient struct {
-	callTool func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	callTool     func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	readResource func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error)
 }
 
 var _ client.MCPClient = (*blockingMCPClient)(nil)
@@ -42,6 +43,9 @@ func (c *blockingMCPClient) ListResourceTemplates(ctx context.Context, request m
 }
 
 func (c *blockingMCPClient) ReadResource(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	if c.readResource != nil {
+		return c.readResource(ctx, request)
+	}
 	return nil, nil
 }
 
@@ -273,6 +277,47 @@ func TestMCPAdapter_MarkRead_TreatsLocalToolFailureAsError(t *testing.T) {
 	assert.Equal(t, types.MarkReadLocalFailure, result.Status)
 	require.Error(t, result.Err)
 	assert.Contains(t, result.Err.Error(), "failed to mark read locally: sqlite busy")
+}
+
+func TestMCPAdapter_ResolveUserID_ReadsEffectiveSessionIdentity(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		readResource: func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			require.Equal(t, "gh-orbit://session/user", request.Params.URI)
+			return &mcp.ReadResourceResult{
+				Contents: []mcp.ResourceContents{
+					mcp.TextResourceContents{
+						URI:      "gh-orbit://session/user",
+						MIMEType: "application/json",
+						Text:     `{"login":"hirakiuc"}`,
+					},
+				},
+			}, nil
+		},
+	})
+
+	userID, err := adapter.ResolveUserID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "hirakiuc", userID)
+}
+
+func TestMCPAdapter_ResolveUserID_RejectsEmptyIdentity(t *testing.T) {
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		readResource: func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{
+				Contents: []mcp.ResourceContents{
+					mcp.TextResourceContents{
+						URI:      "gh-orbit://session/user",
+						MIMEType: "application/json",
+						Text:     `{"login":""}`,
+					},
+				},
+			}, nil
+		},
+	})
+
+	_, err := adapter.ResolveUserID(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current user login is empty")
 }
 
 func TestMCPAdapter_ImplementsTUIBackendBoundary(t *testing.T) {

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -591,6 +591,34 @@ func (s *MCPServer) registerTools() {
 }
 
 func (s *MCPServer) registerResources() {
+	s.server.AddResource(
+		mcp.NewResource(
+			"gh-orbit://session/user",
+			"Current User",
+			mcp.WithResourceDescription("Effective GitHub login for the connected engine session"),
+			mcp.WithMIMEType("application/json"),
+		),
+		func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			user, err := s.engine.Client.CurrentUser(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			data, err := json.Marshal(map[string]string{"login": user.Login})
+			if err != nil {
+				return nil, err
+			}
+
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      "gh-orbit://session/user",
+					MIMEType: "application/json",
+					Text:     string(data),
+				},
+			}, nil
+		},
+	)
+
 	// Notifications Resource Template
 	tpl := mcp.NewResourceTemplate(
 		"gh-orbit://notifications/{category}", "Notifications List",


### PR DESCRIPTION
## Summary
- resolve the effective connected-session user through MCP before constructing the TUI
- expose the connected engine user as an MCP resource and consume it through the adapter
- keep Traffic:nil as an explicit backend-hosted capability in connected mode

## Preserved Invariants
- connected and standalone TUI construction still require a concrete effective user identity
- Alerter remains present in both modes
- shutdown ownership remains hosting-specific rather than behavior-specific

## Validation
- `make go/test`
- `make go/check`

Closes #360