### PR TITLE
refactor(engine): narrow MCP adapter boundary

### DIFF
--- a/cmd/gh-orbit/connected_alert_bridge.go
+++ b/cmd/gh-orbit/connected_alert_bridge.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hirakiuc/gh-orbit/internal/api"
+	"github.com/hirakiuc/gh-orbit/internal/github"
+	"github.com/hirakiuc/gh-orbit/internal/types"
+)
+
+// connectedModeAlerter keeps the connected-mode alert requirement explicit at
+// the TUI wiring layer without re-expanding MCPAdapter into a pseudo-runtime
+// facade.
+type connectedModeAlerter struct{}
+
+var _ api.Alerter = connectedModeAlerter{}
+
+func (connectedModeAlerter) Notify(context.Context, github.Notification) error { return nil }
+func (connectedModeAlerter) SyncStart(context.Context)                         {}
+func (connectedModeAlerter) Shutdown(context.Context)                          {}
+func (connectedModeAlerter) ActiveTierInfo() (string, types.BridgeStatus) {
+	return "Connected", types.StatusHealthy
+}
+func (connectedModeAlerter) TestNotify(context.Context, string, string, string) error { return nil }
+func (connectedModeAlerter) BridgeStatus() types.BridgeStatus                         { return types.StatusHealthy }

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -421,7 +421,7 @@ func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, ada
 		// Connected mode intentionally treats traffic control as backend-hosted;
 		// the TUI only renders connection state and no longer owns quota control.
 		Traffic: nil,
-		Alerter: adapter,
+		Alerter: connectedModeAlerter{},
 		Options: []tui.Option{
 			tui.WithConnectionMode("Connected"),
 			tui.WithOwnedSubsystemShutdown(),

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
+	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/tui"
 	"github.com/hirakiuc/gh-orbit/internal/types"
@@ -184,4 +185,18 @@ func TestRunProgram_StandaloneOwnershipLeavesSubsystemShutdownToOuterLayer(t *te
 	deps.syncer.Shutdown(cleanupCtx)
 	deps.enricher.Shutdown(cleanupCtx)
 	deps.alerter.Shutdown(cleanupCtx)
+}
+
+func TestConnectedModeAlerter_SatisfiesConnectedTUIAlertBridge(t *testing.T) {
+	var alerter api.Alerter = connectedModeAlerter{}
+
+	tier, status := alerter.ActiveTierInfo()
+	assert.Equal(t, "Connected", tier)
+	assert.Equal(t, types.StatusHealthy, status)
+	assert.Equal(t, types.StatusHealthy, alerter.BridgeStatus())
+	assert.NoError(t, alerter.Notify(context.Background(), github.Notification{}))
+	assert.NoError(t, alerter.TestNotify(context.Background(), "title", "subtitle", "body"))
+
+	alerter.SyncStart(context.Background())
+	alerter.Shutdown(context.Background())
 }

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/api"
-	"github.com/hirakiuc/gh-orbit/internal/github"
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
@@ -499,21 +498,8 @@ func (a *MCPAdapter) FetchHybridBatch(ctx context.Context, notifications []triag
 	return results
 }
 
-// --- api.Alerter Implementation ---
-
-func (a *MCPAdapter) Notify(ctx context.Context, n github.Notification) error { return nil }
-func (a *MCPAdapter) SyncStart(ctx context.Context)                           {}
-func (a *MCPAdapter) ActiveTierInfo() (string, types.BridgeStatus) {
-	return "Connected", types.StatusHealthy
-}
-
-func (a *MCPAdapter) TestNotify(ctx context.Context, title, subtitle, body string) error {
-	return nil
-}
-
 // Ensure MCPAdapter implements required interfaces
 var (
 	_ types.TUIBackend = (*MCPAdapter)(nil)
 	_ types.Enricher   = (*MCPAdapter)(nil)
-	_ api.Alerter      = (*MCPAdapter)(nil)
 )

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/mark3labs/mcp-go/client"
@@ -323,4 +324,9 @@ func TestMCPAdapter_ResolveUserID_RejectsEmptyIdentity(t *testing.T) {
 func TestMCPAdapter_ImplementsTUIBackendBoundary(t *testing.T) {
 	var backend types.TUIBackend = NewMCPAdapter(nil)
 	require.NotNil(t, backend)
+}
+
+func TestMCPAdapter_NoLongerImplementsAlerterBoundary(t *testing.T) {
+	_, ok := any(NewMCPAdapter(nil)).(api.Alerter)
+	assert.False(t, ok)
 }


### PR DESCRIPTION
## Summary
- remove the misleading api.Alerter façade from MCPAdapter
- inject a narrow connected-mode alert bridge at TUI launch time instead
- keep MCPAdapter aligned to the TUI backend seam while preserving connected refresh behavior

## Preserved Invariants
- MCPAdapter still satisfies `types.TUIBackend`
- connected-mode TUI construction still passes with a non-nil alerter
- MCP-connected refresh and event behavior remain unchanged

## Validation
- `make go/test`
- `make go/check`

Closes #361