### PR TITLE
refactor(engine): delegate MCP handlers through backend

### DIFF
--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -164,13 +164,6 @@ func (s *MCPServer) eventLoop(ctx context.Context) {
 	}
 }
 
-func (s *MCPServer) publishNotificationsChanged() {
-	if s.engine == nil || s.engine.Bus == nil {
-		return
-	}
-	s.engine.Bus.Publish(EventNotificationsChanged)
-}
-
 func (s *MCPServer) handleStaleSocket() error {
 	if _, err := os.Stat(s.socket); os.IsNotExist(err) {
 		return nil
@@ -332,12 +325,7 @@ func (s *MCPServer) registerTools() {
 			force = f
 		}
 
-		user, err := s.engine.Client.CurrentUser(ctx)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get current user: %v", err)), nil
-		}
-
-		rl, err := s.engine.Sync.Sync(ctx, user.Login, force)
+		rl, err := s.engine.Backend.Sync(ctx, force)
 		if err != nil {
 			if errors.Is(err, types.ErrSyncIntervalNotReached) {
 				payload := syncToolResult{
@@ -387,13 +375,18 @@ func (s *MCPServer) registerTools() {
 			read = r
 		}
 
-		if err := s.engine.DB.MarkReadLocally(ctx, id, read); err != nil {
+		result, err := s.engine.Backend.MarkRead(ctx, id, read)
+		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to mark read locally: %v", err)), nil
 		}
-		s.publishNotificationsChanged()
-		if read {
-			if err := s.engine.Client.MarkThreadAsRead(ctx, id); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("failed to mark read on GitHub: %v", err)), nil
+		if result.Err != nil {
+			switch result.Status {
+			case types.MarkReadRemoteFailure:
+				return mcp.NewToolResultError(fmt.Sprintf("failed to mark read on GitHub: %v", result.Err)), nil
+			case types.MarkReadLocalFailure:
+				return mcp.NewToolResultError(fmt.Sprintf("failed to mark read locally: %v", result.Err)), nil
+			default:
+				return mcp.NewToolResultError(fmt.Sprintf("failed to mark read: %v", result.Err)), nil
 			}
 		}
 		return mcp.NewToolResultText("Notification read state updated"), nil
@@ -417,14 +410,19 @@ func (s *MCPServer) registerTools() {
 		levelVal, _ := args["level"].(float64)
 		level := int(levelVal)
 
-		if err := s.engine.DB.SetPriority(ctx, id, level); err != nil {
+		result, err := s.engine.Backend.SetPriority(ctx, id, level)
+		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to set priority: %v", err)), nil
 		}
-		s.publishNotificationsChanged()
+		if result.Err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to set priority: %v", result.Err)), nil
+		}
 		return mcp.NewToolResultText("Priority updated"), nil
 	})
 
 	// 4. Fetch Detail Tool
+	// Temporary explicit exception: already transport-thin and no matching
+	// backend seam expansion is needed for this slice.
 	fetchDetailTool := mcp.NewTool(
 		"fetch_detail",
 		mcp.WithDescription("Fetch enriched detail for a single notification subject"),
@@ -460,6 +458,8 @@ func (s *MCPServer) registerTools() {
 	})
 
 	// 5. Batch Enrichment Tool
+	// Temporary explicit exception: already transport-thin and no matching
+	// backend seam expansion is needed for this slice.
 	batchEnrichTool := mcp.NewTool(
 		"fetch_hybrid_batch",
 		mcp.WithDescription("Fetch enrichment state for a batch of notifications"),
@@ -537,7 +537,7 @@ func (s *MCPServer) registerTools() {
 		resourceState, _ := args["resource_state"].(string)
 		resourceSubState, _ := args["resource_sub_state"].(string)
 
-		if err := s.engine.Enrich.PersistFetchedDetail(ctx, id, sourceURL, models.EnrichmentResult{
+		if err := s.engine.Backend.PersistFetchedDetail(ctx, id, sourceURL, models.EnrichmentResult{
 			SubjectNodeID:    nodeID,
 			Body:             body,
 			Author:           author,
@@ -552,6 +552,8 @@ func (s *MCPServer) registerTools() {
 		return mcp.NewToolResultText("Fetched detail persisted"), nil
 	})
 
+	// Temporary explicit exception: there is not yet a matching backend seam
+	// operation for independent enrichment persistence.
 	enrichNotificationTool := mcp.NewTool(
 		"enrich_notification",
 		mcp.WithDescription("Persist enriched notification fields through the engine-backed repository"),

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
@@ -275,13 +277,29 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		mockRepo := mocks.NewMockRepository(t)
 		mockGH := mocks.NewMockClient(t)
 		mockSync := mocks.NewMockSyncer(t)
+		mockEnrich := mocks.NewMockEnricher(t)
+		bus := NewEventBus()
+
+		backend, err := api.NewBackend(
+			"user-123",
+			mockRepo,
+			mockSync,
+			mockEnrich,
+			mockGH,
+			nil,
+			func() { bus.Publish(EventNotificationsChanged) },
+			func() { bus.Publish(EventEnrichmentUpdated) },
+		)
+		require.NoError(t, err)
 
 		eng := &CoreEngine{
-			Logger: slog.Default(),
-			Bus:    NewEventBus(),
-			DB:     mockRepo,
-			Client: mockGH,
-			Sync:   mockSync,
+			Logger:  slog.Default(),
+			Bus:     bus,
+			DB:      mockRepo,
+			Client:  mockGH,
+			Sync:    mockSync,
+			Enrich:  mockEnrich,
+			Backend: backend,
 		}
 
 		return NewMCPServer(eng, filepath.Join(t.TempDir(), "mcp-mutation.sock"), true, false), mockRepo, mockGH
@@ -362,6 +380,10 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 			SetPriority(mock.Anything, "1", 2).
 			Return(nil).
 			Once()
+		mockRepo.EXPECT().
+			ListNotifications(mock.Anything).
+			Return(nil, nil).
+			Twice()
 
 		response := callTool(t, srv, sessionCtx, 2, "set_priority", map[string]any{
 			"id":    "1",
@@ -386,6 +408,10 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 			MarkThreadAsRead(mock.Anything, "2").
 			Return(errors.New("boom")).
 			Once()
+		mockRepo.EXPECT().
+			ListNotifications(mock.Anything).
+			Return(nil, nil).
+			Twice()
 
 		response := callTool(t, srv, sessionCtx, 2, "mark_read", map[string]any{
 			"id":   "2",
@@ -408,6 +434,10 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 			MarkReadLocally(mock.Anything, "3", true).
 			Return(errors.New("write failed")).
 			Once()
+		mockRepo.EXPECT().
+			ListNotifications(mock.Anything).
+			Return(nil, nil).
+			Twice()
 
 		response := callTool(t, srv, sessionCtx, 2, "mark_read", map[string]any{
 			"id":   "3",
@@ -423,6 +453,55 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		require.ErrorAs(t, err, &netErr)
 		assert.True(t, netErr.Timeout(), "expected no notification after pre-commit failure")
 		require.NoError(t, clientConn.SetReadDeadline(time.Time{}))
+	})
+
+	t.Run("sync interval not reached keeps structured MCP status after backend delegation", func(t *testing.T) {
+		srv, _, _ := newTestServer(t)
+		sessionCtx, _, _, cleanup := newSession(t, srv)
+		defer cleanup()
+
+		mockSync := srv.engine.Sync.(*mocks.MockSyncer)
+		mockSync.EXPECT().
+			Sync(mock.Anything, "user-123", false).
+			Return(models.RateLimitInfo{Remaining: 123, Limit: 5000}, types.ErrSyncIntervalNotReached).
+			Once()
+
+		response := callTool(t, srv, sessionCtx, 2, "sync", map[string]any{})
+
+		result, ok := response["result"].(map[string]any)
+		require.True(t, ok)
+		assert.NotEqual(t, true, result["isError"])
+
+		structured, ok := result["structuredContent"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, string(syncToolStatusIntervalNotReached), structured["status"])
+		assert.Equal(t, "sync interval not reached", result["content"].([]any)[0].(map[string]any)["text"])
+	})
+
+	t.Run("persist_fetched_detail still notifies after backend delegation", func(t *testing.T) {
+		srv, _, _ := newTestServer(t)
+		sessionCtx, clientConn, reader, cleanup := newSession(t, srv)
+		defer cleanup()
+
+		mockEnrich := srv.engine.Enrich.(*mocks.MockEnricher)
+		mockEnrich.EXPECT().
+			PersistFetchedDetail(mock.Anything, "4", "https://api.github.com/repos/o/r/pulls/4", mock.Anything).
+			Return(nil).
+			Once()
+
+		response := callTool(t, srv, sessionCtx, 2, "persist_fetched_detail", map[string]any{
+			"id":             "4",
+			"source_url":     "https://api.github.com/repos/o/r/pulls/4",
+			"node_id":        "node-4",
+			"body":           "detail body",
+			"author":         "hirakiuc",
+			"html_url":       "https://github.com/o/r/pull/4",
+			"resource_state": "OPEN",
+		})
+		notification := readNotification(t, clientConn, reader, time.Second)
+
+		require.Contains(t, response, "result")
+		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
 	})
 }
 


### PR DESCRIPTION
## Summary
- delegate MCP handlers with backend-seam equivalents through `s.engine.Backend`
- keep MCP-specific request parsing and wire-result shaping inside `internal/engine/mcp.go`
- mark the remaining direct enrichment handlers as explicit temporary exceptions

## Preserved Invariants
- current MCP tools and resources remain functional for existing clients
- structured sync statuses and mutation error text remain unchanged for MCP clients
- `resources/list_changed` observability remains intact for delegated mutation and persistence paths

## Validation
- `make go/test`
- `make go/check`

Closes #362