### PR TITLE
refactor(runtime): clarify ownership and config authority

### DIFF
--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -424,6 +424,9 @@ func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, ada
 		Alerter: connectedModeAlerter{},
 		Options: []tui.Option{
 			tui.WithConnectionMode("Connected"),
+			// Connected mode may still own host-local cleanup hooks, but the
+			// injected backend must not act as a second owner for shared engine
+			// services such as sync or enrichment.
 			tui.WithOwnedSubsystemShutdown(),
 			tui.WithVersion(buildinfo.Version),
 		},

--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -78,8 +78,6 @@ func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
 		_, hasDeadline := ctx.Deadline()
 		return err == nil && hasDeadline
 	})
-	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
@@ -92,6 +90,8 @@ func TestRunProgram_ShutsDownModelOnSuccess(t *testing.T) {
 
 	err := runProgram(lifecycle, deps.model)
 	assert.NoError(t, err)
+	deps.syncer.AssertNotCalled(t, "Shutdown", mock.Anything)
+	deps.enricher.AssertNotCalled(t, "Shutdown", mock.Anything)
 }
 
 func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
@@ -108,8 +108,6 @@ func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
 		_, hasDeadline := ctx.Deadline()
 		return err == nil && hasDeadline
 	})
-	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
@@ -123,6 +121,8 @@ func TestRunProgram_ShutsDownModelAfterLifecycleCancellation(t *testing.T) {
 
 	err := runProgram(lifecycle, deps.model)
 	assert.NoError(t, err)
+	deps.syncer.AssertNotCalled(t, "Shutdown", mock.Anything)
+	deps.enricher.AssertNotCalled(t, "Shutdown", mock.Anything)
 }
 
 func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
@@ -136,8 +136,6 @@ func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
 		_, hasDeadline := ctx.Deadline()
 		return err == nil && hasDeadline
 	})
-	deps.syncer.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	deps.enricher.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 	deps.alerter.EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	newTeaProgram = func(m tea.Model, opts ...tea.ProgramOption) teaProgram {
@@ -151,6 +149,8 @@ func TestRunProgram_ShutsDownModelOnProgramError(t *testing.T) {
 	err := runProgram(lifecycle, deps.model)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "TUI error: boom")
+	deps.syncer.AssertNotCalled(t, "Shutdown", mock.Anything)
+	deps.enricher.AssertNotCalled(t, "Shutdown", mock.Anything)
 }
 
 func TestRunProgram_StandaloneOwnershipLeavesSubsystemShutdownToOuterLayer(t *testing.T) {

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -212,13 +212,14 @@ func (b *Backend) BridgeStatus() types.BridgeStatus {
 	return b.Syncer.BridgeStatus()
 }
 
+// Shutdown is intentionally non-owning for the in-process Backend.
+//
+// Shared-service teardown in standalone mode belongs to CoreEngine, which owns
+// the syncer, enricher, traffic controller, and alerter it constructs.
+// Backend keeps this method only to satisfy the transport-agnostic TUIBackend
+// seam while connected-mode adapters may still need local cleanup hooks.
 func (b *Backend) Shutdown(ctx context.Context) {
-	if b.Syncer != nil {
-		b.Syncer.Shutdown(ctx)
-	}
-	if b.Enricher != nil {
-		b.Enricher.Shutdown(ctx)
-	}
+	_ = ctx
 }
 
 func (b *Backend) boundUserID(ctx context.Context) (string, error) {

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -16,6 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBackend_Shutdown_DoesNotOwnSharedServices(t *testing.T) {
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+
+	backend, err := NewBackend(
+		"user-1",
+		mockRepo,
+		mockSyncer,
+		mockEnricher,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	backend.Shutdown(context.Background())
+
+	mockSyncer.AssertNotCalled(t, "Shutdown", mock.Anything)
+	mockEnricher.AssertNotCalled(t, "Shutdown", mock.Anything)
+}
+
 func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -91,11 +91,11 @@ func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {
 		_, hasDeadline := ctx.Deadline()
 		return err == nil && hasDeadline
 	})
-	testSyncer(m).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
-	testEnricher(m).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 	m.alerter.(*mocks.MockAlerter).EXPECT().Shutdown(usableCleanupCtx).Return().Once()
 
 	m.Shutdown()
+	testSyncer(m).AssertNotCalled(t, "Shutdown", mock.Anything)
+	testEnricher(m).AssertNotCalled(t, "Shutdown", mock.Anything)
 }
 
 func TestModel_Shutdown_StandaloneModeDoesNotShutdownEngineOwnedSubsystems(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -148,8 +148,9 @@ func WithConnectionMode(mode string) Option {
 	}
 }
 
-// WithOwnedSubsystemShutdown makes Model.Shutdown responsible for shutting down
-// the injected sync/enrich/traffic/alerter services.
+// WithOwnedSubsystemShutdown makes Model.Shutdown responsible only for
+// host-local injected cleanup surfaces. Shared standalone runtime services must
+// still be owned by the outer runtime, not by the TUI model.
 func WithOwnedSubsystemShutdown() Option {
 	return func(m *Model) {
 		m.ownsSubsystems = true

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -169,6 +169,9 @@ type TUIBackend interface {
 	PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error
 	FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult
 	BridgeStatus() BridgeStatus
+	// Shutdown is reserved for transport- or host-local cleanup. It must not own
+	// teardown of shared runtime services such as sync, enrichment, traffic, or
+	// alerting in standalone engine mode.
 	Shutdown(ctx context.Context)
 }
 


### PR DESCRIPTION
## Summary
- make standalone shared-service teardown ownership explicit at the runtime and backend seams
- keep TUIBackend.Shutdown limited to host-local cleanup rather than backend-owned service teardown
- encode the connected-versus-standalone ownership split directly in comments and tests

## Details
- make internal/api.Backend.Shutdown an intentional no-op so it can no longer compete with CoreEngine for sync/enrichment ownership
- document the types.TUIBackend shutdown contract as transport- or host-local cleanup only
- narrow the WithOwnedSubsystemShutdown semantics to host-local surfaces and clarify the connected-mode exception in startup wiring
- update lifecycle and guard tests so connected mode no longer expects backend-owned sync/enrichment shutdown through the TUI model

## Preserved Invariants
- CoreEngine remains the sole standalone owner for shared-service teardown
- connected-mode shutdown differences remain hosting-only exceptions
- no lower-level subsystem regains config authority or shared-service shutdown ownership
- TUI-visible behavior remains unchanged

## Validation
- make go/test
- make go/check

Closes #363