### PR TITLE
refactor(api): clarify app backend naming

### DIFF
--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -45,7 +45,7 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.
 
 	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-	backend, err := api.NewBackend("user", repo, syncer, enricher, nil, nil, nil, nil)
+	appBackend, err := api.NewAppBackend("user", repo, syncer, enricher, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	m, err := tui.NewModel(tui.ModelParams{
@@ -53,7 +53,7 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.
 		Config:   cfg,
 		Logger:   logger,
 		TaskRoot: taskRoot,
-		Backend:  backend,
+		Backend:  appBackend,
 		Alerter:  alerter,
 		Options:  opts,
 	})

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/types"
 )
 
-// Backend is the in-process application-facing backend owner for TUI operations.
-// It composes narrower services but owns direct mutation semantics and their
-// corresponding event publication.
-type Backend struct {
+// AppBackend is the in-process application-facing backend owner for TUI
+// operations. It composes narrower services but owns direct mutation semantics
+// and their corresponding event publication.
+type AppBackend struct {
 	UserID   string
 	Store    types.NotificationStore
 	Client   github.Client
@@ -29,7 +29,7 @@ type Backend struct {
 	publishEnrichmentUpdated    func()
 }
 
-func NewBackend(
+func NewAppBackend(
 	userID string,
 	store types.NotificationStore,
 	syncer types.Syncer,
@@ -38,18 +38,18 @@ func NewBackend(
 	resolveUserID func(context.Context) (string, error),
 	publishNotificationsChanged func(),
 	publishEnrichmentUpdated func(),
-) (*Backend, error) {
+) (*AppBackend, error) {
 	if store == nil {
-		return nil, fmt.Errorf("notification store is required for Backend")
+		return nil, fmt.Errorf("notification store is required for AppBackend")
 	}
 	if syncer == nil {
-		return nil, fmt.Errorf("syncer is required for Backend")
+		return nil, fmt.Errorf("syncer is required for AppBackend")
 	}
 	if enricher == nil {
-		return nil, fmt.Errorf("enricher is required for Backend")
+		return nil, fmt.Errorf("enricher is required for AppBackend")
 	}
 	if userID == "" && resolveUserID == nil {
-		return nil, fmt.Errorf("user ID or resolver is required for Backend")
+		return nil, fmt.Errorf("user ID or resolver is required for AppBackend")
 	}
 	if publishNotificationsChanged == nil {
 		publishNotificationsChanged = func() {}
@@ -58,7 +58,7 @@ func NewBackend(
 		publishEnrichmentUpdated = func() {}
 	}
 
-	return &Backend{
+	return &AppBackend{
 		UserID:                      userID,
 		Store:                       store,
 		Client:                      client,
@@ -72,22 +72,22 @@ func NewBackend(
 
 // NewTUIBackendClient is a temporary constructor alias kept only for
 // compatibility while the architecture-v2 migration lands. It must not own any
-// behavior beyond constructing the real Backend type.
+// behavior beyond constructing the real AppBackend type.
 func NewTUIBackendClient(
 	userID string,
 	store types.NotificationStore,
 	syncer types.Syncer,
 	enricher types.Enricher,
 	client github.Client,
-) (*Backend, error) {
-	return NewBackend(userID, store, syncer, enricher, client, nil, nil, nil)
+) (*AppBackend, error) {
+	return NewAppBackend(userID, store, syncer, enricher, client, nil, nil, nil)
 }
 
-func (b *Backend) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
+func (b *AppBackend) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
 	return b.Store.ListNotifications(ctx)
 }
 
-func (b *Backend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
+func (b *AppBackend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
 	userID, err := b.boundUserID(ctx)
 	if err != nil {
 		return models.RateLimitInfo{}, err
@@ -95,7 +95,7 @@ func (b *Backend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, e
 	return b.Syncer.Sync(ctx, userID, force)
 }
 
-func (b *Backend) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
+func (b *AppBackend) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
 	before, _ := b.Store.ListNotifications(ctx)
 
 	if err := b.Store.MarkReadLocally(ctx, id, read); err != nil {
@@ -151,7 +151,7 @@ func (b *Backend) MarkRead(ctx context.Context, id string, read bool) (types.Mar
 	}, nil
 }
 
-func (b *Backend) SetPriority(ctx context.Context, id string, priority int) (types.PriorityUpdateResult, error) {
+func (b *AppBackend) SetPriority(ctx context.Context, id string, priority int) (types.PriorityUpdateResult, error) {
 	before, _ := b.Store.ListNotifications(ctx)
 
 	if err := b.Store.SetPriority(ctx, id, priority); err != nil {
@@ -191,11 +191,11 @@ func (b *Backend) SetPriority(ctx context.Context, id string, priority int) (typ
 	}, nil
 }
 
-func (b *Backend) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
+func (b *AppBackend) FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error) {
 	return b.Enricher.FetchDetail(ctx, u, subjectType, force)
 }
 
-func (b *Backend) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
+func (b *AppBackend) PersistFetchedDetail(ctx context.Context, id, sourceURL string, res models.EnrichmentResult) error {
 	if err := b.Enricher.PersistFetchedDetail(ctx, id, sourceURL, res); err != nil {
 		return err
 	}
@@ -204,25 +204,25 @@ func (b *Backend) PersistFetchedDetail(ctx context.Context, id, sourceURL string
 	return nil
 }
 
-func (b *Backend) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
+func (b *AppBackend) FetchHybridBatch(ctx context.Context, notifications []triage.NotificationWithState, force bool) map[string]models.EnrichmentResult {
 	return b.Enricher.FetchHybridBatch(ctx, notifications, force)
 }
 
-func (b *Backend) BridgeStatus() types.BridgeStatus {
+func (b *AppBackend) BridgeStatus() types.BridgeStatus {
 	return b.Syncer.BridgeStatus()
 }
 
-// Shutdown is intentionally non-owning for the in-process Backend.
+// Shutdown is intentionally non-owning for the in-process AppBackend.
 //
 // Shared-service teardown in standalone mode belongs to CoreEngine, which owns
 // the syncer, enricher, traffic controller, and alerter it constructs.
-// Backend keeps this method only to satisfy the transport-agnostic TUIBackend
+// AppBackend keeps this method only to satisfy the transport-agnostic TUIBackend
 // seam while connected-mode adapters may still need local cleanup hooks.
-func (b *Backend) Shutdown(ctx context.Context) {
+func (b *AppBackend) Shutdown(ctx context.Context) {
 	_ = ctx
 }
 
-func (b *Backend) boundUserID(ctx context.Context) (string, error) {
+func (b *AppBackend) boundUserID(ctx context.Context) (string, error) {
 	b.userMu.RLock()
 	if b.UserID != "" {
 		defer b.userMu.RUnlock()

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBackend_Shutdown_DoesNotOwnSharedServices(t *testing.T) {
+func TestAppBackend_Shutdown_DoesNotOwnSharedServices(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
 
-	backend, err := NewBackend(
+	appBackend, err := NewAppBackend(
 		"user-1",
 		mockRepo,
 		mockSyncer,
@@ -33,13 +33,13 @@ func TestBackend_Shutdown_DoesNotOwnSharedServices(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	backend.Shutdown(context.Background())
+	appBackend.Shutdown(context.Background())
 
 	mockSyncer.AssertNotCalled(t, "Shutdown", mock.Anything)
 	mockEnricher.AssertNotCalled(t, "Shutdown", mock.Anything)
 }
 
-func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
+func TestAppBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
@@ -52,7 +52,7 @@ func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
-	backend, err := NewBackend(
+	appBackend, err := NewAppBackend(
 		"user-1",
 		mockRepo,
 		mockSyncer,
@@ -64,14 +64,14 @@ func TestBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := backend.MarkRead(context.Background(), "notif-1", true)
+	result, err := appBackend.MarkRead(context.Background(), "notif-1", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, published)
 	assert.Equal(t, types.MarkReadSuccess, result.Status)
 	assert.Equal(t, snapshot, result.Notifications)
 }
 
-func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
+func TestAppBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
@@ -82,7 +82,7 @@ func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
-	backend, err := NewBackend(
+	appBackend, err := NewAppBackend(
 		"user-1",
 		mockRepo,
 		mockSyncer,
@@ -94,7 +94,7 @@ func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := backend.SetPriority(context.Background(), "notif-2", 3)
+	result, err := appBackend.SetPriority(context.Background(), "notif-2", 3)
 	require.NoError(t, err)
 	assert.Equal(t, 1, published)
 	assert.Equal(t, types.PriorityUpdateSuccess, result.Status)
@@ -102,7 +102,7 @@ func TestBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	assert.Equal(t, "Priority set to High", result.Toast)
 }
 
-func TestBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {
+func TestAppBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
@@ -119,7 +119,7 @@ func TestBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {
 		Once()
 
 	published := 0
-	backend, err := NewBackend(
+	appBackend, err := NewAppBackend(
 		"user-1",
 		mockRepo,
 		mockSyncer,
@@ -131,11 +131,11 @@ func TestBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, backend.PersistFetchedDetail(context.Background(), "notif-3", "https://api.github.com/repos/o/r/pulls/1", res))
+	require.NoError(t, appBackend.PersistFetchedDetail(context.Background(), "notif-3", "https://api.github.com/repos/o/r/pulls/1", res))
 	assert.Equal(t, 1, published)
 }
 
-func TestBackend_PersistFetchedDetailDoesNotDoublePublishViaEnricherHook(t *testing.T) {
+func TestAppBackend_PersistFetchedDetailDoesNotDoublePublishViaEnricherHook(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	mockClient := mocks.NewMockClient(t)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -122,7 +122,7 @@ func NewCoreEngine(
 	}
 	syncer.OnMutation = func() { bus.Publish(EventNotificationsChanged) }
 
-	backend, err := api.NewBackend(
+	appBackend, err := api.NewAppBackend(
 		"",
 		database,
 		syncer,
@@ -149,7 +149,7 @@ func NewCoreEngine(
 		Bus:     bus,
 		DB:      database,
 		Client:  client,
-		Backend: backend,
+		Backend: appBackend,
 		Sync:    syncer,
 		Enrich:  enricher,
 		Traffic: traffic,

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -280,7 +280,7 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		mockEnrich := mocks.NewMockEnricher(t)
 		bus := NewEventBus()
 
-		backend, err := api.NewBackend(
+		appBackend, err := api.NewAppBackend(
 			"user-123",
 			mockRepo,
 			mockSync,
@@ -299,7 +299,7 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 			Client:  mockGH,
 			Sync:    mockSync,
 			Enrich:  mockEnrich,
-			Backend: backend,
+			Backend: appBackend,
 		}
 
 		return NewMCPServer(eng, filepath.Join(t.TempDir(), "mcp-mutation.sock"), true, false), mockRepo, mockGH

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -25,29 +25,29 @@ func TestNewModel_Guards(t *testing.T) {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	backend, err := api.NewBackend("u", mockRepo, mockSyncer, mockEnricher, nil, nil, nil, nil)
+	appBackend, err := api.NewAppBackend("u", mockRepo, mockSyncer, mockEnricher, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	t.Run("Missing UserID", func(t *testing.T) {
-		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: appBackend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "user ID is required")
 	})
 
 	t.Run("Missing Config", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Logger: logger, TaskRoot: context.Background(), Backend: appBackend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "config is required")
 	})
 
 	t.Run("Missing Logger", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, TaskRoot: context.Background(), Backend: backend, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, TaskRoot: context.Background(), Backend: appBackend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "logger is required")
 	})
 
 	t.Run("Missing TaskRoot", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, Backend: backend, Alerter: mockAlerter})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, Backend: appBackend, Alerter: mockAlerter})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "task root context is required")
 	})
@@ -59,7 +59,7 @@ func TestNewModel_Guards(t *testing.T) {
 	})
 
 	t.Run("Missing Alerter", func(t *testing.T) {
-		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: backend})
+		_, err := NewModel(ModelParams{UserID: "u", Config: cfg, Logger: logger, TaskRoot: context.Background(), Backend: appBackend})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "alerter is required")
 	})

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -46,7 +46,7 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	backend, err := api.NewBackend(userID, mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
+	appBackend, err := api.NewAppBackend(userID, mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +56,7 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 		Config:   cfg,
 		Logger:   logger,
 		TaskRoot: taskRoot,
-		Backend:  backend,
+		Backend:  appBackend,
 		Traffic:  mockTraffic,
 		Alerter:  mockAlerter,
 		Options: []Option{
@@ -92,8 +92,8 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	return m
 }
 
-func testBackend(m *Model) *api.Backend {
-	return m.backend.(*api.Backend)
+func testBackend(m *Model) *api.AppBackend {
+	return m.backend.(*api.AppBackend)
 }
 
 func testRepo(m *Model) *mocks.MockRepository {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -130,7 +130,7 @@ func TestRenderHeader_States(t *testing.T) {
 		mockAlerter := mocks.NewMockAlerter(t)
 		mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 		mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-		backend, err := api.NewBackend("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil, nil, nil, nil)
+		appBackend, err := api.NewAppBackend("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil, nil, nil, nil)
 		assert.NoError(t, err)
 
 		m, err := NewModel(ModelParams{
@@ -138,7 +138,7 @@ func TestRenderHeader_States(t *testing.T) {
 			Config:   cfg,
 			Logger:   logger,
 			TaskRoot: context.Background(),
-			Backend:  backend,
+			Backend:  appBackend,
 			Alerter:  mockAlerter,
 			Traffic:  nil, // Intentional nil
 		})


### PR DESCRIPTION
## Summary
- rename the in-process application-facing backend owner from api.Backend to api.AppBackend
- rename the constructor from api.NewBackend(...) to api.NewAppBackend(...)
- update runtime wiring and tests to use the clearer application-shaped name directly

## Details
- apply the narrow owner rename in internal/api/tui_backend.go
- update CoreEngine construction and dependent test wiring to use AppBackend naming
- keep the stable outer seams unchanged for this slice, including CoreEngine.Backend, ModelParams.Backend, and types.TUIBackend

## Preserved Invariants
- no behavior changes
- no reopening of architecture-v2 ownership or config-authority decisions
- no broader package-shape cleanup is bundled into this slice

## Validation
- make go/test
- make go/check

Closes #376