### PR TITLE
refactor(engine): tighten event semantic naming

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -90,7 +90,7 @@ func NewCoreEngine(
 		_ = database.Close()
 		return nil, err
 	}
-	enricher.OnMutation = func() { bus.Publish(EventEnrichmentUpdated) }
+	enricher.OnMutation = func() { bus.Publish(EventNotificationEnrichmentChanged) }
 
 	alerter, err := api.NewAlertService(ctx, api.AlertParams{
 		Config:   cfg,
@@ -120,7 +120,7 @@ func NewCoreEngine(
 		_ = database.Close()
 		return nil, err
 	}
-	syncer.OnMutation = func() { bus.Publish(EventNotificationsChanged) }
+	syncer.OnMutation = func() { bus.Publish(EventNotificationListChanged) }
 
 	appBackend, err := api.NewAppBackend(
 		"",
@@ -135,8 +135,8 @@ func NewCoreEngine(
 			}
 			return user.Login, nil
 		},
-		func() { bus.Publish(EventNotificationsChanged) },
-		func() { bus.Publish(EventEnrichmentUpdated) },
+		func() { bus.Publish(EventNotificationListChanged) },
+		func() { bus.Publish(EventNotificationEnrichmentChanged) },
 	)
 	if err != nil {
 		_ = database.Close()

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -8,8 +8,8 @@ import (
 type EngineEvent string
 
 const (
-	EventNotificationsChanged EngineEvent = "notifications_changed"
-	EventEnrichmentUpdated    EngineEvent = "enrichment_updated"
+	EventNotificationListChanged       EngineEvent = "notifications_changed"
+	EventNotificationEnrichmentChanged EngineEvent = "enrichment_updated"
 )
 
 // EventBus handles internal pub/sub for engine events.

--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -26,7 +26,7 @@ func TestEventBus_Stress(t *testing.T) {
 			wg.Add(1)
 			go func(id int) {
 				defer wg.Done()
-				ch, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+				ch, unsubscribe := bus.Subscribe(EventNotificationListChanged)
 				defer unsubscribe()
 
 				for {
@@ -50,10 +50,10 @@ func TestEventBus_Stress(t *testing.T) {
 			go func(id int) {
 				defer pubWG.Done()
 				for j := 0; j < numEvents; j++ {
-					bus.Publish(EventNotificationsChanged)
+					bus.Publish(EventNotificationListChanged)
 					if j%10 == 0 {
 						// Mix in some random subs during active publishing
-						_, unsubscribe := bus.Subscribe(EventEnrichmentUpdated)
+						_, unsubscribe := bus.Subscribe(EventNotificationEnrichmentChanged)
 						unsubscribe()
 					}
 				}
@@ -86,7 +86,7 @@ func TestEventBus_DeadlockDetection(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				_, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+				_, unsubscribe := bus.Subscribe(EventNotificationListChanged)
 				unsubscribe()
 			}
 		}()
@@ -94,7 +94,7 @@ func TestEventBus_DeadlockDetection(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				bus.Publish(EventNotificationsChanged)
+				bus.Publish(EventNotificationListChanged)
 			}
 		}()
 
@@ -105,12 +105,12 @@ func TestEventBus_DeadlockDetection(t *testing.T) {
 func TestEventBus_BufferSaturation(t *testing.T) {
 	bus := NewEventBus()
 	// Channel is buffered at size 1
-	ch, unsubscribe := bus.Subscribe(EventNotificationsChanged)
+	ch, unsubscribe := bus.Subscribe(EventNotificationListChanged)
 	defer unsubscribe()
 
 	// Publish twice without reading
-	bus.Publish(EventNotificationsChanged)
-	bus.Publish(EventNotificationsChanged)
+	bus.Publish(EventNotificationListChanged)
+	bus.Publish(EventNotificationListChanged)
 
 	// Should not block and should have one item in buffer
 	select {
@@ -132,26 +132,26 @@ func TestEventBus_BufferSaturation(t *testing.T) {
 func BenchmarkEventBus_Publish(b *testing.B) {
 	bus := NewEventBus()
 	for i := 0; i < 10; i++ {
-		_, _ = bus.Subscribe(EventNotificationsChanged)
+		_, _ = bus.Subscribe(EventNotificationListChanged)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bus.Publish(EventNotificationsChanged)
+		bus.Publish(EventNotificationListChanged)
 	}
 }
 
 func TestEventBus_UnsubscribeRemovesSubscriber(t *testing.T) {
 	bus := NewEventBus()
 
-	ch1, unsubscribe1 := bus.Subscribe(EventNotificationsChanged)
-	_, unsubscribe2 := bus.Subscribe(EventNotificationsChanged)
+	ch1, unsubscribe1 := bus.Subscribe(EventNotificationListChanged)
+	_, unsubscribe2 := bus.Subscribe(EventNotificationListChanged)
 
-	assert.Len(t, bus.subscribers[EventNotificationsChanged], 2)
+	assert.Len(t, bus.subscribers[EventNotificationListChanged], 2)
 
 	unsubscribe1()
 
-	assert.Len(t, bus.subscribers[EventNotificationsChanged], 1)
+	assert.Len(t, bus.subscribers[EventNotificationListChanged], 1)
 
 	select {
 	case <-ch1:
@@ -159,7 +159,7 @@ func TestEventBus_UnsubscribeRemovesSubscriber(t *testing.T) {
 	default:
 	}
 
-	bus.Publish(EventNotificationsChanged)
+	bus.Publish(EventNotificationListChanged)
 
 	select {
 	case <-ch1:
@@ -168,9 +168,9 @@ func TestEventBus_UnsubscribeRemovesSubscriber(t *testing.T) {
 	}
 
 	unsubscribe1()
-	assert.Len(t, bus.subscribers[EventNotificationsChanged], 1)
+	assert.Len(t, bus.subscribers[EventNotificationListChanged], 1)
 
 	unsubscribe2()
-	_, ok := bus.subscribers[EventNotificationsChanged]
+	_, ok := bus.subscribers[EventNotificationListChanged]
 	assert.False(t, ok, "event subscriber entry should be removed when empty")
 }

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -147,8 +147,8 @@ func (s *MCPServer) Serve(ctx context.Context) error {
 }
 
 func (s *MCPServer) eventLoop(ctx context.Context) {
-	notifCh, unsubscribeNotif := s.engine.Bus.Subscribe(EventNotificationsChanged)
-	enrichCh, unsubscribeEnrich := s.engine.Bus.Subscribe(EventEnrichmentUpdated)
+	notifCh, unsubscribeNotif := s.engine.Bus.Subscribe(EventNotificationListChanged)
+	enrichCh, unsubscribeEnrich := s.engine.Bus.Subscribe(EventNotificationEnrichmentChanged)
 	defer unsubscribeNotif()
 	defer unsubscribeEnrich()
 

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -287,8 +287,8 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 			mockEnrich,
 			mockGH,
 			nil,
-			func() { bus.Publish(EventNotificationsChanged) },
-			func() { bus.Publish(EventEnrichmentUpdated) },
+			func() { bus.Publish(EventNotificationListChanged) },
+			func() { bus.Publish(EventNotificationEnrichmentChanged) },
 		)
 		require.NoError(t, err)
 
@@ -329,8 +329,8 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		require.Eventually(t, func() bool {
 			srv.engine.Bus.mu.RLock()
 			defer srv.engine.Bus.mu.RUnlock()
-			return len(srv.engine.Bus.subscribers[EventNotificationsChanged]) == 1 &&
-				len(srv.engine.Bus.subscribers[EventEnrichmentUpdated]) == 1
+			return len(srv.engine.Bus.subscribers[EventNotificationListChanged]) == 1 &&
+				len(srv.engine.Bus.subscribers[EventNotificationEnrichmentChanged]) == 1
 		}, time.Second, 10*time.Millisecond)
 
 		return sessionCtx, clientConn, bufio.NewReader(clientConn), func() {
@@ -629,8 +629,8 @@ func TestMCPServer_EventLoopUnsubscribesOnShutdown(t *testing.T) {
 		require.Eventually(t, func() bool {
 			bus.mu.RLock()
 			defer bus.mu.RUnlock()
-			return len(bus.subscribers[EventNotificationsChanged]) == 1 &&
-				len(bus.subscribers[EventEnrichmentUpdated]) == 1
+			return len(bus.subscribers[EventNotificationListChanged]) == 1 &&
+				len(bus.subscribers[EventNotificationEnrichmentChanged]) == 1
 		}, time.Second, 10*time.Millisecond)
 
 		cancel()
@@ -644,8 +644,8 @@ func TestMCPServer_EventLoopUnsubscribesOnShutdown(t *testing.T) {
 		}, time.Second, 10*time.Millisecond)
 
 		bus.mu.RLock()
-		_, notifOK := bus.subscribers[EventNotificationsChanged]
-		_, enrichOK := bus.subscribers[EventEnrichmentUpdated]
+		_, notifOK := bus.subscribers[EventNotificationListChanged]
+		_, enrichOK := bus.subscribers[EventNotificationEnrichmentChanged]
 		bus.mu.RUnlock()
 
 		assert.False(t, notifOK, "notification subscribers should return to baseline after shutdown")


### PR DESCRIPTION
## Summary
- rename the existing notification-list and enrichment EventBus constants to clearer semantic names
- update direct publishers and MCP subscribers to use the renamed event contracts
- keep wire-level event string values stable and limit the slice to semantic rename plus test updates

## Validation
- make go/test
- make go/check

Closes #377