### PR TITLE
refactor(api): clarify traffic controller task policy

### DIFF
--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -282,30 +282,57 @@ func (c *APITrafficController) runTask(t *apiTask) {
 	defer atomic.AddInt32(&c.activeWorkersCount, -1)
 	defer t.cleanup()
 
-	if t.ctx.Err() != nil {
+	if c.taskCanceledBeforeExecution(t) {
+		t.resp <- nil
+		return
+	}
+	if c.shouldSkipTaskDuringLockout(t) {
+		t.resp <- nil
+		return
+	}
+	if c.shouldSkipEnrichmentDueToLowQuota(t) {
 		t.resp <- nil
 		return
 	}
 
-	// Check lockout
-	if until := c.lockoutUntil.Load(); until != nil && time.Now().Before(*until) {
-		if t.priority != PriorityUser {
-			c.logger.WarnContext(t.ctx, "traffic controller: lockout active, skipping background task", "task_id", t.id)
-			t.resp <- nil
-			return
-		}
+	c.executeTask(t)
+}
+
+func (c *APITrafficController) taskCanceledBeforeExecution(t *apiTask) bool {
+	return t.ctx.Err() != nil
+}
+
+func (c *APITrafficController) shouldSkipTaskDuringLockout(t *apiTask) bool {
+	until := c.lockoutUntil.Load()
+	if until == nil || !time.Now().Before(*until) || c.requiresSerializedUserExecution(t) {
+		return false
 	}
 
-	// Dynamic Throttling: Skip low-priority enrichment if quota is critical
-	if t.priority == PriorityEnrich && c.Remaining() < 500 {
-		c.logger.WarnContext(t.ctx, "traffic controller: skipping enrichment due to low quota",
-			"task_id", t.id, "remaining", c.Remaining(), "threshold", 500)
-		t.resp <- nil
-		return
+	c.logger.WarnContext(t.ctx, "traffic controller: lockout active, skipping background task", "task_id", t.id)
+	return true
+}
+
+func (c *APITrafficController) shouldSkipEnrichmentDueToLowQuota(t *apiTask) bool {
+	if t.priority != PriorityEnrich {
+		return false
 	}
 
-	// Execution
-	if t.priority == PriorityUser {
+	remaining := c.Remaining()
+	if remaining >= 500 {
+		return false
+	}
+
+	c.logger.WarnContext(t.ctx, "traffic controller: skipping enrichment due to low quota",
+		"task_id", t.id, "remaining", remaining, "threshold", 500)
+	return true
+}
+
+func (c *APITrafficController) requiresSerializedUserExecution(t *apiTask) bool {
+	return t.priority == PriorityUser
+}
+
+func (c *APITrafficController) executeTask(t *apiTask) {
+	if c.requiresSerializedUserExecution(t) {
 		c.userMu.Lock()
 		defer c.userMu.Unlock()
 	}

--- a/internal/api/traffic_background_test.go
+++ b/internal/api/traffic_background_test.go
@@ -129,6 +129,24 @@ func TestAPITrafficController_LockoutClearsAfterHealthyRecovery(t *testing.T) {
 	})
 }
 
+func TestAPITrafficController_LockoutDeadlineEqualityAllowsBackgroundTask(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		tc := NewAPITrafficController(ctx, slog.Default())
+		defer tc.Shutdown(ctx)
+
+		reset := time.Now()
+		tc.UpdateRateLimit(ctx, models.RateLimitInfo{Remaining: 0, Reset: reset})
+
+		res, err := tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
+			return "allowed"
+		})
+		assert.NoError(t, err)
+		synctest.Wait()
+		assert.Equal(t, "allowed", <-res, "background task should run once lockout reaches its exact deadline")
+	})
+}
+
 func TestAPITrafficController_Shutdown_Channels(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
## Summary
- split APITrafficController runTask() policy checks into small intent-named helpers
- preserve the polling supervisor, queue semantics, lockout behavior, low-quota rule, and shutdown behavior
- add a regression test for the exact lockout-deadline equality case

## Validation
- make go/test
- make go/check

Closes #378