### PR TITLE
refactor(tui): unify mutation result handling

### DIFF
--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -41,9 +41,8 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 			return types.ErrMsg{Err: err}
 		}
 
-		return markReadReconciledMsg{
+		return mutationAppliedMsg{
 			notifications: result.Notifications,
-			status:        markReadReconcileStatus(result.Status),
 			err:           result.Err,
 			toast:         result.Toast,
 		}
@@ -57,7 +56,7 @@ func (m *Model) setPriorityByID(id string, priority int) tea.Cmd {
 		if err != nil {
 			return types.ErrMsg{Err: err}
 		}
-		return priorityUpdatedMsg{notifications: result.Notifications, toast: result.Toast, err: result.Err}
+		return mutationAppliedMsg{notifications: result.Notifications, toast: result.Toast, err: result.Err}
 	})
 }
 

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -233,9 +233,8 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	reconciled, ok := msg.(markReadReconciledMsg)
+	reconciled, ok := msg.(mutationAppliedMsg)
 	require.True(t, ok)
-	assert.Equal(t, markReadReconcileSuccess, reconciled.status)
 	assert.NoError(t, reconciled.err)
 
 	actions := m.Transition(reconciled, 0)
@@ -263,9 +262,8 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	reconciled, ok := msg.(markReadReconciledMsg)
+	reconciled, ok := msg.(mutationAppliedMsg)
 	require.True(t, ok)
-	assert.Equal(t, markReadReconcileSuccess, reconciled.status)
 	assert.NoError(t, reconciled.err)
 
 	actions := m.Transition(reconciled, 0)
@@ -294,9 +292,8 @@ func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T)
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	reconciled, ok := msg.(markReadReconciledMsg)
+	reconciled, ok := msg.(mutationAppliedMsg)
 	require.True(t, ok)
-	assert.Equal(t, markReadReconcileLocalFailure, reconciled.status)
 	assert.ErrorIs(t, reconciled.err, localErr)
 
 	actions := m.Transition(reconciled, 0)
@@ -324,9 +321,8 @@ func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t 
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	reconciled, ok := msg.(markReadReconciledMsg)
+	reconciled, ok := msg.(mutationAppliedMsg)
 	require.True(t, ok)
-	assert.Equal(t, markReadReconcileLocalFailure, reconciled.status)
 	assert.ErrorIs(t, reconciled.err, localErr)
 	actions := m.Transition(reconciled, 0)
 	assert.False(t, m.allNotifications[0].IsReadLocally)
@@ -354,9 +350,8 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 	require.NotNil(t, cmd)
 
 	msg := executeCmd(cmd)
-	reconciled, ok := msg.(markReadReconciledMsg)
+	reconciled, ok := msg.(mutationAppliedMsg)
 	require.True(t, ok)
-	assert.Equal(t, markReadReconcileRemoteFailure, reconciled.status)
 	assert.ErrorIs(t, reconciled.err, remoteErr)
 
 	actions := m.Transition(reconciled, 0)
@@ -376,7 +371,7 @@ func TestModel_Transition_EdgeCases(t *testing.T) {
 	assert.Equal(t, 0, len(actions))
 
 	// 2. Priority Updated
-	actions = m.Transition(priorityUpdatedMsg{toast: "updated"}, 0)
+	actions = m.Transition(mutationAppliedMsg{toast: "updated"}, 0)
 	assert.Contains(t, actions, ActionShowToast{Message: "updated"})
 
 	// 3. Sync Complete

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -420,25 +420,10 @@ type notificationsLoadedMsg struct {
 	IsManual      bool
 }
 
-type priorityUpdatedMsg struct {
+type mutationAppliedMsg struct {
 	notifications []triage.NotificationWithState
 	toast         string
 	err           error
-}
-
-type markReadReconcileStatus uint8
-
-const (
-	markReadReconcileSuccess markReadReconcileStatus = iota
-	markReadReconcileLocalFailure
-	markReadReconcileRemoteFailure
-)
-
-type markReadReconciledMsg struct {
-	notifications []triage.NotificationWithState
-	status        markReadReconcileStatus
-	err           error
-	toast         string
 }
 
 type syncCompleteMsg struct {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -65,10 +65,8 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		m.handleBackgroundColor(msg)
 	case notificationsLoadedMsg:
 		return m.handleNotificationsLoaded(msg)
-	case priorityUpdatedMsg:
-		return m.handlePriorityUpdated(msg)
-	case markReadReconciledMsg:
-		return m.handleMarkReadReconciled(msg)
+	case mutationAppliedMsg:
+		return m.handleMutationApplied(msg)
 	case syncCompleteMsg:
 		return m.handleSyncComplete(msg)
 	case enrichmentBatchCompleteMsg:
@@ -447,25 +445,13 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 	return actions
 }
 
-func (m *Model) handlePriorityUpdated(msg priorityUpdatedMsg) []Action {
+func (m *Model) handleMutationApplied(msg mutationAppliedMsg) []Action {
 	m.allNotifications = msg.notifications
 	m.applyFilters()
 	m.err = msg.err
 	if msg.toast == "" {
 		return nil
 	}
-	return []Action{ActionShowToast{Message: msg.toast}}
-}
-
-func (m *Model) handleMarkReadReconciled(msg markReadReconciledMsg) []Action {
-	m.allNotifications = msg.notifications
-	m.applyFilters()
-	m.err = msg.err
-
-	if msg.toast == "" {
-		return nil
-	}
-
 	return []Action{ActionShowToast{Message: msg.toast}}
 }
 


### PR DESCRIPTION
## Summary
- unify the duplicated read-state and priority TUI mutation-result path into one shared message and handler
- keep backend-owned reconciliation, optimistic read behavior, and toast behavior unchanged
- simplify transitionGlobal() by dispatching one shared mutation-result case

## Validation
- make go/test
- make go/check

Closes #379