### PR TITLE
refactor(api): reduce backend composition density

### DIFF
--- a/cmd/gh-orbit/main_lifecycle_test.go
+++ b/cmd/gh-orbit/main_lifecycle_test.go
@@ -45,7 +45,12 @@ func newRunProgramTestModel(t *testing.T, taskRoot context.Context, opts ...tui.
 
 	syncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	alerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-	appBackend, err := api.NewAppBackend("user", repo, syncer, enricher, nil, nil, nil, nil)
+	appBackend, err := api.NewAppBackend(api.AppBackendParams{
+		UserID:   "user",
+		Store:    repo,
+		Syncer:   syncer,
+		Enricher: enricher,
+	})
 	assert.NoError(t, err)
 
 	m, err := tui.NewModel(tui.ModelParams{

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -29,44 +29,51 @@ type AppBackend struct {
 	publishEnrichmentUpdated    func()
 }
 
-func NewAppBackend(
-	userID string,
-	store types.NotificationStore,
-	syncer types.Syncer,
-	enricher types.Enricher,
-	client github.Client,
-	resolveUserID func(context.Context) (string, error),
-	publishNotificationsChanged func(),
-	publishEnrichmentUpdated func(),
-) (*AppBackend, error) {
-	if store == nil {
+// AppBackendParams groups the concrete dependencies and local wiring hooks for
+// the in-process AppBackend owner without introducing a broader builder
+// abstraction.
+type AppBackendParams struct {
+	UserID   string
+	Store    types.NotificationStore
+	Client   github.Client
+	Syncer   types.Syncer
+	Enricher types.Enricher
+
+	ResolveUserID func(context.Context) (string, error)
+
+	PublishNotificationsChanged func()
+	PublishEnrichmentUpdated    func()
+}
+
+func NewAppBackend(params AppBackendParams) (*AppBackend, error) {
+	if params.Store == nil {
 		return nil, fmt.Errorf("notification store is required for AppBackend")
 	}
-	if syncer == nil {
+	if params.Syncer == nil {
 		return nil, fmt.Errorf("syncer is required for AppBackend")
 	}
-	if enricher == nil {
+	if params.Enricher == nil {
 		return nil, fmt.Errorf("enricher is required for AppBackend")
 	}
-	if userID == "" && resolveUserID == nil {
+	if params.UserID == "" && params.ResolveUserID == nil {
 		return nil, fmt.Errorf("user ID or resolver is required for AppBackend")
 	}
-	if publishNotificationsChanged == nil {
-		publishNotificationsChanged = func() {}
+	if params.PublishNotificationsChanged == nil {
+		params.PublishNotificationsChanged = func() {}
 	}
-	if publishEnrichmentUpdated == nil {
-		publishEnrichmentUpdated = func() {}
+	if params.PublishEnrichmentUpdated == nil {
+		params.PublishEnrichmentUpdated = func() {}
 	}
 
 	return &AppBackend{
-		UserID:                      userID,
-		Store:                       store,
-		Client:                      client,
-		Syncer:                      syncer,
-		Enricher:                    enricher,
-		resolveUserID:               resolveUserID,
-		publishNotificationsChanged: publishNotificationsChanged,
-		publishEnrichmentUpdated:    publishEnrichmentUpdated,
+		UserID:                      params.UserID,
+		Store:                       params.Store,
+		Client:                      params.Client,
+		Syncer:                      params.Syncer,
+		Enricher:                    params.Enricher,
+		resolveUserID:               params.ResolveUserID,
+		publishNotificationsChanged: params.PublishNotificationsChanged,
+		publishEnrichmentUpdated:    params.PublishEnrichmentUpdated,
 	}, nil
 }
 
@@ -80,7 +87,13 @@ func NewTUIBackendClient(
 	enricher types.Enricher,
 	client github.Client,
 ) (*AppBackend, error) {
-	return NewAppBackend(userID, store, syncer, enricher, client, nil, nil, nil)
+	return NewAppBackend(AppBackendParams{
+		UserID:   userID,
+		Store:    store,
+		Client:   client,
+		Syncer:   syncer,
+		Enricher: enricher,
+	})
 }
 
 func (b *AppBackend) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -21,16 +21,12 @@ func TestAppBackend_Shutdown_DoesNotOwnSharedServices(t *testing.T) {
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
 
-	appBackend, err := NewAppBackend(
-		"user-1",
-		mockRepo,
-		mockSyncer,
-		mockEnricher,
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	appBackend, err := NewAppBackend(AppBackendParams{
+		UserID:   "user-1",
+		Store:    mockRepo,
+		Syncer:   mockSyncer,
+		Enricher: mockEnricher,
+	})
 	require.NoError(t, err)
 
 	appBackend.Shutdown(context.Background())
@@ -52,16 +48,14 @@ func TestAppBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
-	appBackend, err := NewAppBackend(
-		"user-1",
-		mockRepo,
-		mockSyncer,
-		mockEnricher,
-		mockClient,
-		nil,
-		func() { published++ },
-		nil,
-	)
+	appBackend, err := NewAppBackend(AppBackendParams{
+		UserID:                      "user-1",
+		Store:                       mockRepo,
+		Client:                      mockClient,
+		Syncer:                      mockSyncer,
+		Enricher:                    mockEnricher,
+		PublishNotificationsChanged: func() { published++ },
+	})
 	require.NoError(t, err)
 
 	result, err := appBackend.MarkRead(context.Background(), "notif-1", true)
@@ -82,16 +76,13 @@ func TestAppBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(snapshot, nil).Once()
 
 	published := 0
-	appBackend, err := NewAppBackend(
-		"user-1",
-		mockRepo,
-		mockSyncer,
-		mockEnricher,
-		nil,
-		nil,
-		func() { published++ },
-		nil,
-	)
+	appBackend, err := NewAppBackend(AppBackendParams{
+		UserID:                      "user-1",
+		Store:                       mockRepo,
+		Syncer:                      mockSyncer,
+		Enricher:                    mockEnricher,
+		PublishNotificationsChanged: func() { published++ },
+	})
 	require.NoError(t, err)
 
 	result, err := appBackend.SetPriority(context.Background(), "notif-2", 3)
@@ -119,16 +110,13 @@ func TestAppBackend_PersistFetchedDetailPublishesEnrichmentUpdated(t *testing.T)
 		Once()
 
 	published := 0
-	appBackend, err := NewAppBackend(
-		"user-1",
-		mockRepo,
-		mockSyncer,
-		mockEnricher,
-		nil,
-		nil,
-		nil,
-		func() { published++ },
-	)
+	appBackend, err := NewAppBackend(AppBackendParams{
+		UserID:                   "user-1",
+		Store:                    mockRepo,
+		Syncer:                   mockSyncer,
+		Enricher:                 mockEnricher,
+		PublishEnrichmentUpdated: func() { published++ },
+	})
 	require.NoError(t, err)
 
 	require.NoError(t, appBackend.PersistFetchedDetail(context.Background(), "notif-3", "https://api.github.com/repos/o/r/pulls/1", res))

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -30,6 +30,11 @@ type options struct {
 	silentAlerts bool
 }
 
+type backendPublishHooks struct {
+	notificationsChanged func()
+	enrichmentChanged    func()
+}
+
 // Option defines a functional option for Engine configuration.
 type Option func(*options)
 
@@ -38,6 +43,35 @@ func WithSilentAlerts() Option {
 	return func(o *options) {
 		o.silentAlerts = true
 	}
+}
+
+func currentUserResolver(client github.Client) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		user, err := client.CurrentUser(ctx)
+		if err != nil {
+			return "", err
+		}
+		return user.Login, nil
+	}
+}
+
+func newBackendPublishHooks(bus *EventBus) backendPublishHooks {
+	return backendPublishHooks{
+		notificationsChanged: func() { bus.Publish(EventNotificationListChanged) },
+		enrichmentChanged:    func() { bus.Publish(EventNotificationEnrichmentChanged) },
+	}
+}
+
+func newAppBackend(database types.Repository, client github.Client, syncer types.Syncer, enricher types.Enricher, hooks backendPublishHooks) (*api.AppBackend, error) {
+	return api.NewAppBackend(api.AppBackendParams{
+		Store:                       database,
+		Client:                      client,
+		Syncer:                      syncer,
+		Enricher:                    enricher,
+		ResolveUserID:               currentUserResolver(client),
+		PublishNotificationsChanged: hooks.notificationsChanged,
+		PublishEnrichmentUpdated:    hooks.enrichmentChanged,
+	})
 }
 
 // NewCoreEngine initializes the engine with all its dependencies.
@@ -78,6 +112,7 @@ func NewCoreEngine(
 
 	// 3. Initialize Services
 	bus := NewEventBus()
+	hooks := newBackendPublishHooks(bus)
 	traffic := api.NewAPITrafficController(ctx, logger)
 
 	enricher, err := api.NewEnrichmentEngine(ctx, api.EnrichParams{
@@ -90,7 +125,7 @@ func NewCoreEngine(
 		_ = database.Close()
 		return nil, err
 	}
-	enricher.OnMutation = func() { bus.Publish(EventNotificationEnrichmentChanged) }
+	enricher.OnMutation = hooks.enrichmentChanged
 
 	alerter, err := api.NewAlertService(ctx, api.AlertParams{
 		Config:   cfg,
@@ -120,24 +155,9 @@ func NewCoreEngine(
 		_ = database.Close()
 		return nil, err
 	}
-	syncer.OnMutation = func() { bus.Publish(EventNotificationListChanged) }
+	syncer.OnMutation = hooks.notificationsChanged
 
-	appBackend, err := api.NewAppBackend(
-		"",
-		database,
-		syncer,
-		enricher,
-		client,
-		func(ctx context.Context) (string, error) {
-			user, err := client.CurrentUser(ctx)
-			if err != nil {
-				return "", err
-			}
-			return user.Login, nil
-		},
-		func() { bus.Publish(EventNotificationListChanged) },
-		func() { bus.Publish(EventNotificationEnrichmentChanged) },
-	)
+	appBackend, err := newAppBackend(database, client, syncer, enricher, hooks)
 	if err != nil {
 		_ = database.Close()
 		return nil, err

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -280,16 +280,15 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		mockEnrich := mocks.NewMockEnricher(t)
 		bus := NewEventBus()
 
-		appBackend, err := api.NewAppBackend(
-			"user-123",
-			mockRepo,
-			mockSync,
-			mockEnrich,
-			mockGH,
-			nil,
-			func() { bus.Publish(EventNotificationListChanged) },
-			func() { bus.Publish(EventNotificationEnrichmentChanged) },
-		)
+		appBackend, err := api.NewAppBackend(api.AppBackendParams{
+			UserID:                      "user-123",
+			Store:                       mockRepo,
+			Client:                      mockGH,
+			Syncer:                      mockSync,
+			Enricher:                    mockEnrich,
+			PublishNotificationsChanged: func() { bus.Publish(EventNotificationListChanged) },
+			PublishEnrichmentUpdated:    func() { bus.Publish(EventNotificationEnrichmentChanged) },
+		})
 		require.NoError(t, err)
 
 		eng := &CoreEngine{

--- a/internal/engine/tui_backend_contract_test.go
+++ b/internal/engine/tui_backend_contract_test.go
@@ -41,7 +41,13 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 				mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-1").Return(nil).Once()
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
 
-				backend, err := api.NewAppBackend("user-1", mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
+				backend, err := api.NewAppBackend(api.AppBackendParams{
+					UserID:   "user-1",
+					Store:    mockRepo,
+					Client:   mockClient,
+					Syncer:   mockSyncer,
+					Enricher: mockEnricher,
+				})
 				require.NoError(t, err)
 				return backend
 			},
@@ -121,7 +127,13 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 				mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-2").Return(remoteErr).Once()
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
 
-				backend, err := api.NewAppBackend("user-1", mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
+				backend, err := api.NewAppBackend(api.AppBackendParams{
+					UserID:   "user-1",
+					Store:    mockRepo,
+					Client:   mockClient,
+					Syncer:   mockSyncer,
+					Enricher: mockEnricher,
+				})
 				require.NoError(t, err)
 				return backend
 			},
@@ -203,7 +215,12 @@ func TestTUIBackendContract_SetPrioritySuccess(t *testing.T) {
 				mockRepo.EXPECT().SetPriority(mock.Anything, "notif-3", 3).Return(nil).Once()
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
 
-				backend, err := api.NewAppBackend("user-1", mockRepo, mockSyncer, mockEnricher, nil, nil, nil, nil)
+				backend, err := api.NewAppBackend(api.AppBackendParams{
+					UserID:   "user-1",
+					Store:    mockRepo,
+					Syncer:   mockSyncer,
+					Enricher: mockEnricher,
+				})
 				require.NoError(t, err)
 				return backend
 			},

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -25,7 +25,12 @@ func TestNewModel_Guards(t *testing.T) {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	appBackend, err := api.NewAppBackend("u", mockRepo, mockSyncer, mockEnricher, nil, nil, nil, nil)
+	appBackend, err := api.NewAppBackend(api.AppBackendParams{
+		UserID:   "u",
+		Store:    mockRepo,
+		Syncer:   mockSyncer,
+		Enricher: mockEnricher,
+	})
 	assert.NoError(t, err)
 
 	t.Run("Missing UserID", func(t *testing.T) {

--- a/internal/tui/test_utils_test.go
+++ b/internal/tui/test_utils_test.go
@@ -46,7 +46,13 @@ func newTestModelWithTaskRoot(t TestingT, taskRoot context.Context) *Model {
 	mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 	mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 
-	appBackend, err := api.NewAppBackend(userID, mockRepo, mockSyncer, mockEnricher, mockClient, nil, nil, nil)
+	appBackend, err := api.NewAppBackend(api.AppBackendParams{
+		UserID:   userID,
+		Store:    mockRepo,
+		Client:   mockClient,
+		Syncer:   mockSyncer,
+		Enricher: mockEnricher,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -130,7 +130,12 @@ func TestRenderHeader_States(t *testing.T) {
 		mockAlerter := mocks.NewMockAlerter(t)
 		mockSyncer.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
 		mockAlerter.EXPECT().BridgeStatus().Return(types.StatusHealthy).Maybe()
-		appBackend, err := api.NewAppBackend("user", mocks.NewMockRepository(t), mockSyncer, mocks.NewMockEnricher(t), nil, nil, nil, nil)
+		appBackend, err := api.NewAppBackend(api.AppBackendParams{
+			UserID:   "user",
+			Store:    mocks.NewMockRepository(t),
+			Syncer:   mockSyncer,
+			Enricher: mocks.NewMockEnricher(t),
+		})
 		assert.NoError(t, err)
 
 		m, err := NewModel(ModelParams{


### PR DESCRIPTION
## Summary
- replace the long positional AppBackend constructor with a concrete AppBackendParams bundle
- make NewCoreEngine composition easier to scan through small local wiring helpers only
- update adjacent tests to the new constructor shape without changing behavior or ownership semantics

## Validation
- GOCACHE=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/go-cache TMPDIR=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp HOME=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-home go test ./internal/api ./internal/engine
- make go/check

Closes #391