### PR TITLE
refactor(engine): clarify notification event translation

### DIFF
--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -8,7 +8,11 @@ import (
 type EngineEvent string
 
 const (
-	EventNotificationListChanged       EngineEvent = "notifications_changed"
+	// EventNotificationListChanged signals that the notification resource list
+	// shape changed, such as rows being added, removed, or locally mutated.
+	EventNotificationListChanged EngineEvent = "notifications_changed"
+	// EventNotificationEnrichmentChanged signals that already-listed
+	// notifications received refreshed detail/enrichment data.
 	EventNotificationEnrichmentChanged EngineEvent = "enrichment_updated"
 )
 

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -157,11 +157,18 @@ func (s *MCPServer) eventLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-notifCh:
-			s.server.SendNotificationToAllClients(mcp.MethodNotificationResourcesListChanged, nil)
+			s.notifyNotificationResourcesChanged()
 		case <-enrichCh:
-			s.server.SendNotificationToAllClients(mcp.MethodNotificationResourcesListChanged, nil)
+			s.notifyNotificationResourcesChanged()
 		}
 	}
+}
+
+func (s *MCPServer) notifyNotificationResourcesChanged() {
+	// MCP exposes both notification-list and enrichment mutations as coarse
+	// resource invalidation so clients can refetch without learning engine-only
+	// event categories.
+	s.server.SendNotificationToAllClients(mcp.MethodNotificationResourcesListChanged, nil)
 }
 
 func (s *MCPServer) handleStaleSocket() error {

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -370,6 +370,20 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		return readJSONLine(t, conn, reader, timeout)
 	}
 
+	t.Run("direct notification events send coarse resource invalidation", func(t *testing.T) {
+		srv, _, _ := newTestServer(t)
+		_, clientConn, reader, cleanup := newSession(t, srv)
+		defer cleanup()
+
+		srv.engine.Bus.Publish(EventNotificationListChanged)
+		notification := readNotification(t, clientConn, reader, time.Second)
+		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
+
+		srv.engine.Bus.Publish(EventNotificationEnrichmentChanged)
+		notification = readNotification(t, clientConn, reader, time.Second)
+		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
+	})
+
 	t.Run("set_priority success sends resources/list_changed", func(t *testing.T) {
 		srv, mockRepo, _ := newTestServer(t)
 		sessionCtx, clientConn, reader, cleanup := newSession(t, srv)


### PR DESCRIPTION
## Summary
- clarify the distinction between notification-list and enrichment engine events
- centralize the MCP translation that maps both internal events to coarse `resources/list_changed` invalidation
- add direct event-loop coverage for both internal event names

## Validation
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home go test ./internal/engine`
- `make go/check`

Closes #394