### PR TITLE
test(engine): pin event category isolation

### DIFF
--- a/internal/engine/events_test.go
+++ b/internal/engine/events_test.go
@@ -129,6 +129,40 @@ func TestEventBus_BufferSaturation(t *testing.T) {
 	}
 }
 
+func TestEventBus_InternalEventCategoriesStayIsolated(t *testing.T) {
+	bus := NewEventBus()
+	listChanged, unsubscribeList := bus.Subscribe(EventNotificationListChanged)
+	defer unsubscribeList()
+	enrichmentChanged, unsubscribeEnrichment := bus.Subscribe(EventNotificationEnrichmentChanged)
+	defer unsubscribeEnrichment()
+
+	bus.Publish(EventNotificationListChanged)
+
+	select {
+	case <-listChanged:
+	default:
+		t.Fatal("list-change subscriber should receive list-change event")
+	}
+	select {
+	case <-enrichmentChanged:
+		t.Fatal("enrichment subscriber should not receive list-change event")
+	default:
+	}
+
+	bus.Publish(EventNotificationEnrichmentChanged)
+
+	select {
+	case <-enrichmentChanged:
+	default:
+		t.Fatal("enrichment subscriber should receive enrichment event")
+	}
+	select {
+	case <-listChanged:
+		t.Fatal("list-change subscriber should not receive enrichment event")
+	default:
+	}
+}
+
 func BenchmarkEventBus_Publish(b *testing.B) {
 	bus := NewEventBus()
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Related Issue

Fixes #395

## Objective

Reduce surprise around the internal event-observation seam by locking down that EventBus categories remain distinct internally.

## Changes

- Added `TestEventBus_InternalEventCategoriesStayIsolated` to assert list-change subscribers only receive list-change events and enrichment subscribers only receive enrichment-change events.
- Kept the slice test-only with no production behavior or instrumentation expansion.

## Verification Results

- `make go/test` passed.
- `make go/check` passed.
- `make check` exited successfully; Swift semantic lint/tests were skipped by the Makefile after sandbox DNS dependency fetch failures, while Go checks and lint passed.

## Checklist

- [x] All checks passed (`make check`)
- [x] Documentation updated (if applicable; not needed for test-only change)