### PR TITLE
fix(tui): hide ignored repositories

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -728,6 +728,91 @@ func TestModel_ApplyFilters_UsesGitHubUpdatedAtInsteadOfRecentLocalActivity(t *t
 	assert.Equal(t, "recent", item.notification.GitHubID)
 }
 
+func TestModel_ApplyFilters_HidesIgnoredRepositoriesAcrossTabs(t *testing.T) {
+	m := newTestModel(t)
+	m.config.Notifications.IgnoreRepos = []string{" hirakiuc/test-repo "}
+	m.config.Notifications.MaxVisibleAgeDays = 0
+
+	ignored := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:           "ignored",
+			SubjectType:        triage.SubjectPullRequest,
+			RepositoryFullName: "hirakiuc/test-repo",
+			UpdatedAt:          time.Now(),
+		},
+		State: triage.State{
+			Priority: 1,
+		},
+	}
+	visible := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:           "visible",
+			SubjectType:        triage.SubjectPullRequest,
+			RepositoryFullName: "hirakiuc/kept-repo",
+			UpdatedAt:          time.Now(),
+		},
+		State: triage.State{
+			Priority: 1,
+		},
+	}
+	m.allNotifications = []triage.NotificationWithState{ignored, visible}
+
+	for _, tab := range []int{TabInbox, TabUnread, TabTriaged, TabAll} {
+		m.listView.activeTab = tab
+		m.applyFilters()
+
+		require.Len(t, m.listView.list.Items(), 1, "tab %d should only show the non-ignored repo", tab)
+		item, ok := m.listView.list.Items()[0].(item)
+		require.True(t, ok)
+		assert.Equal(t, "visible", item.notification.GitHubID)
+	}
+}
+
+func TestModel_HandleNotificationsLoaded_KeepsIgnoredRepositoriesHiddenAfterReload(t *testing.T) {
+	m := newTestModel(t)
+	m.listView.activeTab = TabAll
+	m.listView.list.SetSize(100, 100)
+	m.config.Notifications.IgnoreRepos = []string{"hirakiuc/test-repo"}
+	m.config.Notifications.MaxVisibleAgeDays = 0
+
+	ignored := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:           "ignored",
+			SubjectType:        triage.SubjectPullRequest,
+			RepositoryFullName: "hirakiuc/test-repo",
+			UpdatedAt:          time.Now(),
+		},
+	}
+	visible := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:           "visible",
+			SubjectType:        triage.SubjectPullRequest,
+			RepositoryFullName: "hirakiuc/kept-repo",
+			UpdatedAt:          time.Now(),
+		},
+	}
+
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{
+		notifications: []triage.NotificationWithState{ignored, visible},
+		IsManual:      true,
+	})
+
+	require.Len(t, m.listView.list.Items(), 1)
+	item, ok := m.listView.list.Items()[0].(item)
+	require.True(t, ok)
+	assert.Equal(t, "visible", item.notification.GitHubID)
+
+	for _, action := range actions {
+		enrichAction, ok := action.(ActionEnrichItems)
+		if !ok {
+			continue
+		}
+		for _, n := range enrichAction.Notifications {
+			assert.NotEqual(t, "ignored", n.GitHubID, "ignored repo should not be scheduled from visible-list enrichment")
+		}
+	}
+}
+
 func TestHelpers(t *testing.T) {
 	// extractNumberFromURL
 	assert.Equal(t, "123", extractNumberFromURL("https://api.github.com/repos/o/r/pulls/123"))

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -344,11 +345,33 @@ func (m *Model) shouldKeepNotification(n triage.NotificationWithState, now time.
 		}
 	}
 
+	if keep && m.isIgnoredRepository(n.RepositoryFullName) {
+		keep = false
+	}
+
 	if keep && !m.isNotificationWithinVisibleAge(n, now) {
 		keep = false
 	}
 
 	return keep
+}
+
+func (m *Model) isIgnoredRepository(repoFullName string) bool {
+	if m.config == nil {
+		return false
+	}
+
+	repoFullName = strings.TrimSpace(repoFullName)
+	if repoFullName == "" {
+		return false
+	}
+
+	for _, ignored := range m.config.Notifications.IgnoreRepos {
+		if strings.TrimSpace(ignored) == repoFullName {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Model) restoreFilterState(filter string) {


### PR DESCRIPTION
## Summary

- apply `notifications.ignore_repos` as a TUI-only visibility filter
- keep sync, persistence, and backend list behavior unchanged
- add regression tests for ignored repositories across tabs and after notification reload

Closes #404.

## Validation

- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make go/test`
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make go/check`
- `GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make check`

`make check` exited successfully. The Swift semantic/test portions reported dependency clone DNS failures and were skipped by the existing Makefile resilience path; no worktree changes were produced by the check.
