### PR TITLE
fix(sync): reconcile GitHub notification read state

### DIFF
--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -202,6 +202,8 @@ func (s *SyncEngine) processSyncResults(ctx context.Context, notifications []git
 			SubjectURL:         n.Subject.URL,
 			SubjectType:        triage.SubjectType(n.Subject.Type),
 			Reason:             n.Reason,
+			ReadStateKnown:     true,
+			Unread:             n.Unread,
 			RepositoryFullName: n.Repository.FullName,
 			SubjectNodeID:      n.Subject.NodeID,
 			HTMLURL:            "", // Will be enriched in later phases if needed
@@ -233,6 +235,10 @@ func (s *SyncEngine) triggerAlerts(ctx context.Context, notifications []github.N
 func (s *SyncEngine) shouldTriggerAlert(ctx context.Context, n github.Notification, lastSyncAt time.Time) bool {
 	// We only trigger alerts for notifications arriving AFTER the established baseline
 	// AND that we haven't notified for yet.
+	if !n.Unread {
+		return false
+	}
+
 	state, err := s.db.GetNotification(ctx, n.ID)
 	if err != nil || state == nil || state.IsNotified {
 		return false

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -60,13 +60,18 @@ func TestSyncEngine_Sync(t *testing.T) {
 		}
 
 		notifs := []github.Notification{
-			{ID: "1", UpdatedAt: time.Now()},
+			{ID: "1", Unread: true, UpdatedAt: time.Now()},
 		}
 
 		mockRepo.EXPECT().GetSyncMeta(mock.Anything, userID, "notifications").Return(meta, nil).Once()
 		mockAlerter.EXPECT().SyncStart(mock.Anything).Return().Once()
 		mockFetcher.EXPECT().FetchNotifications(mock.Anything, meta, false).Return(notifs, meta, models.RateLimitInfo{}, nil).Once()
-		mockRepo.EXPECT().UpsertNotifications(mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.EXPECT().UpsertNotifications(mock.Anything, mock.MatchedBy(func(notifications []triage.Notification) bool {
+			return len(notifications) == 1 &&
+				notifications[0].GitHubID == "1" &&
+				notifications[0].ReadStateKnown &&
+				notifications[0].Unread
+		})).Return(nil).Once()
 		mockRepo.EXPECT().GetNotification(mock.Anything, "1").Return(&triage.NotificationWithState{
 			State: triage.State{IsNotified: false},
 		}, nil).Once()
@@ -90,6 +95,43 @@ func TestSyncEngine_Sync(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, published)
+	})
+
+	t.Run("GitHub Read Notifications Do Not Trigger Alerts", func(t *testing.T) {
+		mockFetcher := mocks.NewMockFetcher(t)
+		mockRepo := mocks.NewMockSyncRepository(t)
+		mockAlerter := mocks.NewMockAlerter(t)
+
+		meta := &models.SyncMeta{
+			UserID: userID,
+			Key:    "notifications",
+		}
+
+		notifs := []github.Notification{
+			{ID: "read-on-github", Unread: false, UpdatedAt: time.Now()},
+		}
+
+		mockRepo.EXPECT().GetSyncMeta(mock.Anything, userID, "notifications").Return(meta, nil).Once()
+		mockAlerter.EXPECT().SyncStart(mock.Anything).Return().Once()
+		mockFetcher.EXPECT().FetchNotifications(mock.Anything, meta, false).Return(notifs, meta, models.RateLimitInfo{}, nil).Once()
+		mockRepo.EXPECT().UpsertNotifications(mock.Anything, mock.MatchedBy(func(notifications []triage.Notification) bool {
+			return len(notifications) == 1 &&
+				notifications[0].GitHubID == "read-on-github" &&
+				notifications[0].ReadStateKnown &&
+				!notifications[0].Unread
+		})).Return(nil).Once()
+		mockRepo.EXPECT().UpdateSyncMeta(mock.Anything, mock.Anything).Return(nil).Once()
+
+		engine, err := NewSyncEngine(SyncParams{
+			Fetcher: mockFetcher,
+			DB:      mockRepo,
+			Alerts:  mockAlerter,
+			Logger:  logger,
+		})
+		require.NoError(t, err)
+		_, err = engine.Sync(ctx, userID, false)
+
+		require.NoError(t, err)
 	})
 
 	t.Run("Skips Sync When Interval Not Reached", func(t *testing.T) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -123,6 +123,58 @@ func TestUpsertPreservesLocalState(t *testing.T) {
 	assert.True(t, ns.IsReadLocally)
 }
 
+func TestUpsertReconcilesKnownGitHubReadState(t *testing.T) {
+	logger := slog.Default()
+	ctx := context.Background()
+	db, err := OpenInMemory(ctx, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	id := "read-state"
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
+		GitHubID:  id,
+		UpdatedAt: time.Now(),
+	}}))
+
+	require.NoError(t, db.UpdateOrbitState(ctx, triage.State{
+		NotificationID: id,
+		Priority:       3,
+		Status:         "archived",
+		IsReadLocally:  true,
+		IsNotified:     true,
+	}))
+
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
+		GitHubID:       id,
+		ReadStateKnown: true,
+		Unread:         true,
+		UpdatedAt:      time.Now(),
+	}}))
+
+	ns, err := db.GetNotification(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, ns)
+	assert.False(t, ns.IsReadLocally)
+	assert.Equal(t, 3, ns.Priority)
+	assert.Equal(t, "archived", ns.Status)
+	assert.True(t, ns.IsNotified)
+
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
+		GitHubID:       id,
+		ReadStateKnown: true,
+		Unread:         false,
+		UpdatedAt:      time.Now(),
+	}}))
+
+	ns, err = db.GetNotification(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, ns)
+	assert.True(t, ns.IsReadLocally)
+	assert.Equal(t, 3, ns.Priority)
+	assert.Equal(t, "archived", ns.Status)
+	assert.True(t, ns.IsNotified)
+}
+
 func TestMarkNotifiedBatch(t *testing.T) {
 	logger := slog.Default()
 	ctx := context.Background()

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -146,6 +146,16 @@ func (db *DB) UpsertNotifications(ctx context.Context, notifications []triage.No
 		if _, err := stmtState.ExecContext(ctx, n.GitHubID); err != nil {
 			return fmt.Errorf("failed to ensure orbit state for %s: %w", n.GitHubID, err)
 		}
+
+		if n.ReadStateKnown {
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE orbit_state
+				SET is_read_locally = ?
+				WHERE notification_id = ?
+			`, !n.Unread, n.GitHubID); err != nil {
+				return fmt.Errorf("failed to reconcile read state for %s: %w", n.GitHubID, err)
+			}
+		}
 	}
 
 	return tx.Commit()

--- a/internal/github/fetcher.go
+++ b/internal/github/fetcher.go
@@ -153,6 +153,7 @@ func (f *NotificationFetcher) parsePage(resp *http.Response) ([]Notification, er
 	var rawPage []struct {
 		ID         string    `json:"id"`
 		Reason     string    `json:"reason"`
+		Unread     bool      `json:"unread"`
 		UpdatedAt  time.Time `json:"updated_at"`
 		Repository struct {
 			FullName string `json:"full_name"`
@@ -174,6 +175,7 @@ func (f *NotificationFetcher) parsePage(resp *http.Response) ([]Notification, er
 		notifications[i] = Notification{
 			ID:        p.ID,
 			Reason:    p.Reason,
+			Unread:    p.Unread,
 			UpdatedAt: p.UpdatedAt,
 			Repository: struct {
 				FullName string `json:"full_name"`

--- a/internal/github/fetcher_test.go
+++ b/internal/github/fetcher_test.go
@@ -42,6 +42,36 @@ func TestNotificationFetcher_FetchNotifications(t *testing.T) {
 		assert.Equal(t, 5000, rl.Remaining)
 	})
 
+	t.Run("Parses Unread State", func(t *testing.T) {
+		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+			body := `[
+				{
+					"id": "unread",
+					"unread": true,
+					"updated_at": "2026-06-05T00:00:00Z",
+					"repository": {"full_name": "owner/repo"},
+					"subject": {"title": "Needs review", "url": "https://api.github.com/repos/owner/repo/pulls/1", "type": "PullRequest", "node_id": "PR_kw"}
+				},
+				{
+					"id": "read",
+					"unread": false,
+					"updated_at": "2026-06-05T00:01:00Z",
+					"repository": {"full_name": "owner/repo"},
+					"subject": {"title": "Already handled", "url": "https://api.github.com/repos/owner/repo/pulls/2", "type": "PullRequest", "node_id": "PR_kx"}
+				}
+			]`
+			return newJSONResponse(http.StatusOK, body, nil), nil
+		}), "https://api.test/")
+		fetcher := NewNotificationFetcher(client, slog.Default())
+
+		notifs, _, _, err := fetcher.FetchNotifications(context.Background(), &models.SyncMeta{}, false)
+
+		require.NoError(t, err)
+		require.Len(t, notifs, 2)
+		assert.True(t, notifs[0].Unread)
+		assert.False(t, notifs[1].Unread)
+	})
+
 	t.Run("304 Not Modified", func(t *testing.T) {
 		client := NewTestClient(newHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 			assert.Equal(t, "etag-old", r.Header.Get("If-None-Match"))

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -28,6 +28,7 @@ func (u User) LogValue() slog.Value {
 type Notification struct {
 	ID         string    `json:"id"`
 	Reason     string    `json:"reason"`
+	Unread     bool      `json:"unread"`
 	UpdatedAt  time.Time `json:"updated_at"`
 	Repository struct {
 		FullName string `json:"full_name"`

--- a/internal/triage/types.go
+++ b/internal/triage/types.go
@@ -32,6 +32,8 @@ type Notification struct {
 	SubjectURL         string       `json:"subject_url"`
 	SubjectType        SubjectType  `json:"subject_type"`
 	Reason             string       `json:"reason"`
+	ReadStateKnown     bool         `json:"read_state_known"`
+	Unread             bool         `json:"unread"`
 	RepositoryFullName string       `json:"repository_full_name"`
 	HTMLURL            string       `json:"html_url"`
 	Body               string       `json:"body"`


### PR DESCRIPTION
## Summary
- Parse GitHub notification `unread` from REST responses and propagate it through sync with an explicit known-state guard.
- Reconcile `orbit_state.is_read_locally` from GitHub-sourced sync results while preserving priority, status, and alert-notified state.
- Suppress native alerts for notifications GitHub already reports as read.

Closes #403.

## Validation
- `make go/test`
- `make go/check`
- `make check` exited 0. In this sandbox, Swift semantic lint/tests emitted warnings because remote Swift dependencies could not be fetched with network blocked; the Makefile treated those phases as skipped warnings.

## Review
- Agent implementation review signed off in `.agents/feedback.md` for commit `fea636f6a93e13be4c712be03b3bf32d169cd353`.
