### PR TITLE
fix(tui): force enrichment on manual refresh

### DIFF
--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -441,6 +441,95 @@ func TestModel_HandleNotificationsLoaded_ManualUpdatedShowsToast(t *testing.T) {
 	assert.Empty(t, m.manualSyncSnapshot)
 }
 
+func TestModel_HandleNotificationsLoaded_ManualForceEnrichesVisiblePage(t *testing.T) {
+	m := newTestModel(t)
+	fresh := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "fresh",
+			SubjectType: triage.SubjectPullRequest,
+			IsEnriched:  true,
+			EnrichedAt:  sql.NullTime{Time: time.Now(), Valid: true},
+			UpdatedAt:   time.Now(),
+		},
+	}
+
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{
+		notifications: []triage.NotificationWithState{fresh},
+		IsForced:      true,
+		IsManual:      true,
+	})
+
+	require.Len(t, actions, 2)
+	enrich, ok := actions[0].(ActionEnrichItems)
+	require.True(t, ok)
+	assert.True(t, enrich.Force)
+	assert.Equal(t, []triage.NotificationWithState{fresh}, enrich.Notifications)
+}
+
+func TestModel_HandleNotificationsLoaded_BackgroundKeepsFreshTTLItems(t *testing.T) {
+	m := newTestModel(t)
+	fresh := triage.NotificationWithState{
+		Notification: triage.Notification{
+			GitHubID:    "fresh",
+			SubjectType: triage.SubjectPullRequest,
+			IsEnriched:  true,
+			EnrichedAt:  sql.NullTime{Time: time.Now(), Valid: true},
+			UpdatedAt:   time.Now(),
+		},
+	}
+
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{
+		notifications: []triage.NotificationWithState{fresh},
+		IsForced:      false,
+		IsManual:      false,
+	})
+
+	require.Len(t, actions, 1)
+	enrich, ok := actions[0].(ActionEnrichItems)
+	require.True(t, ok)
+	assert.False(t, enrich.Force)
+	assert.Empty(t, enrich.Notifications)
+}
+
+func TestModel_ReloadEnrichmentCandidates_ManualDedupesSelectedVisibleItem(t *testing.T) {
+	m := newTestModel(t)
+	notifs := []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "selected", SubjectType: triage.SubjectPullRequest, IsEnriched: true, UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "visible", SubjectType: triage.SubjectPullRequest, IsEnriched: true, UpdatedAt: time.Now()}},
+	}
+
+	m.allNotifications = notifs
+	m.applyFilters()
+	m.listView.list.Select(0)
+	m.listView.list.Paginator.PerPage = 2
+
+	candidates := m.getReloadEnrichmentCandidates(true, true)
+
+	require.Len(t, candidates, 2)
+	assert.Equal(t, "selected", candidates[0].GitHubID)
+	assert.Equal(t, "visible", candidates[1].GitHubID)
+}
+
+func TestModel_FilterSelectedDetailRefreshCandidate_RemovesSelectedDuplicate(t *testing.T) {
+	m := newTestModel(t)
+	notifs := []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "selected", SubjectType: triage.SubjectPullRequest, IsEnriched: true, UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "visible", SubjectType: triage.SubjectPullRequest, IsEnriched: true, UpdatedAt: time.Now()}},
+	}
+
+	m.allNotifications = notifs
+	m.applyFilters()
+	m.listView.list.Paginator.PerPage = 2
+	m.listView.list.Select(0)
+	m.state = StateDetail
+
+	candidates := m.getReloadEnrichmentCandidates(true, true)
+	filtered := m.filterSelectedDetailRefreshCandidate(candidates)
+
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "visible", filtered[0].GitHubID)
+}
+
 func TestModel_HandleTransitionError_ManualSyncShowsFailureToast(t *testing.T) {
 	m := newTestModel(t)
 	m.manualSyncPending = true
@@ -527,6 +616,8 @@ func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {
 	m.state = StateDetail
 
 	actions := m.Transition(keyPress("r"), 0)
+	assert.Contains(t, actions, ActionSetSyncing{Enabled: true})
+	assert.Contains(t, actions, ActionSyncNotifications{Force: true, IsManual: true})
 	assert.Contains(t, actions, ActionSetFetching{Enabled: true})
 	assert.Contains(t, actions, ActionFetchDetail{
 		ID:          notif.GitHubID,

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -144,6 +144,7 @@ func (m *Model) transitionDetail(msg tea.Msg) []Action {
 			m.state = StateList
 		case key.Matches(msg, m.keys.Sync):
 			if n, ok := m.selectedNotification(); ok {
+				actions = append(actions, m.handleSyncKey()...)
 				actions = append(actions, ActionSetFetching{Enabled: true}, ActionFetchDetail{
 					ID:          n.GitHubID,
 					URL:         n.SubjectURL,
@@ -205,13 +206,21 @@ func (m *Model) getPriorityToast(p int) string {
 }
 
 func (m *Model) getVisibleNotifications(force bool) []triage.NotificationWithState {
+	return m.getReloadEnrichmentCandidates(force, false)
+}
+
+func (m *Model) getReloadEnrichmentCandidates(force bool, includeSelected bool) []triage.NotificationWithState {
 	start, end := m.listView.list.Paginator.GetSliceBounds(len(m.listView.list.Items()))
 	if start < 0 || end > len(m.listView.list.Items()) || start >= end {
-		return nil
+		if !includeSelected {
+			return nil
+		}
+		start, end = 0, 0
 	}
 	visible := m.listView.list.Items()[start:end]
 
 	var items []triage.NotificationWithState
+	seen := make(map[string]struct{})
 	now := time.Now()
 
 	statusTTL := 2 * time.Minute
@@ -222,10 +231,20 @@ func (m *Model) getVisibleNotifications(force bool) []triage.NotificationWithSta
 	for _, li := range visible {
 		if i, ok := li.(item); ok {
 			if m.isEnrichmentNeeded(i, statusTTL, force, now) {
+				seen[i.notification.GitHubID] = struct{}{}
 				items = append(items, i.notification)
 			}
 		}
 	}
+
+	if includeSelected {
+		if n, ok := m.selectedNotification(); ok {
+			if _, exists := seen[n.GitHubID]; !exists && m.isEnrichmentNeeded(item{notification: n}, statusTTL, force, now) {
+				items = append(items, n)
+			}
+		}
+	}
+
 	return items
 }
 
@@ -474,8 +493,16 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 		m.refreshDetailView()
 	}
 
+	candidates := m.getReloadEnrichmentCandidates(msg.IsForced, msg.IsManual)
+	if msg.IsManual {
+		candidates = m.filterSelectedDetailRefreshCandidate(candidates)
+	}
+
 	actions := []Action{
-		ActionEnrichItems{Notifications: m.getVisibleNotifications(msg.IsForced), Force: msg.IsForced},
+		ActionEnrichItems{
+			Notifications: candidates,
+			Force:         msg.IsForced,
+		},
 	}
 
 	if msg.IsManual {
@@ -494,6 +521,25 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 	}
 
 	return actions
+}
+
+func (m *Model) filterSelectedDetailRefreshCandidate(notifications []triage.NotificationWithState) []triage.NotificationWithState {
+	if m.state != StateDetail {
+		return notifications
+	}
+
+	selected, ok := m.selectedNotification()
+	if !ok {
+		return notifications
+	}
+
+	filtered := notifications[:0]
+	for _, n := range notifications {
+		if n.GitHubID != selected.GitHubID {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
 }
 
 func (m *Model) handleMutationApplied(msg mutationAppliedMsg) []Action {


### PR DESCRIPTION
## Summary
- Force manual notification reloads to schedule enrichment for the visible list page, even when items are still within the normal enrichment TTL.
- Preserve background/non-forced TTL behavior.
- Make detail-mode `r` start manual notification sync while also force-fetching the selected detail, with selected-item dedupe for the later batch path.

Closes #406.

## Validation
- `go test ./internal/tui`
- `make go/test`
- `make go/check`
- `make check` exited 0. In this sandbox, Swift semantic lint/tests emitted warnings because remote Swift dependencies could not be fetched with network blocked; the Makefile treated those phases as skipped warnings.

## Review
- Agent implementation review signed off in `.agents/feedback.md` for commit `651cbd55422fba8d7fa314deb7a41557225178d0`.
