### PR TITLE
Show PR review decision in TUI rows

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -23,6 +23,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 	const (
 		indicatorCellWidth = 6
 		badgeWidth         = 12
+		reviewBadgeWidth   = 7
 		dividerWidth       = 3
 		priorityWidth      = 6
 	)
@@ -43,7 +44,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 	}
 
 	// 2. Calculate flexible space (30/70 ratio for Repo vs Title)
-	fixedSpace := indicatorCellWidth + badgeWidth + dividerWidth + priorityWidth + idWidth + timeWidth
+	fixedSpace := indicatorCellWidth + badgeWidth + reviewBadgeWidth + dividerWidth + priorityWidth + idWidth + timeWidth
 	flexibleSpace := ctx.Width - fixedSpace
 	if flexibleSpace < 20 {
 		flexibleSpace = 20
@@ -62,6 +63,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 	indicatorCell := renderCell(indicator+icon+unread, indicatorCellWidth, false)
 
 	badge := renderCell(renderResourceStateBadge(ctx, n.ResourceState), badgeWidth, false)
+	reviewBadge := renderCell(renderReviewDecisionBadge(ctx, n), reviewBadgeWidth, false)
 	repo := renderCell(renderRepoColumn(ctx.Styles, n.RepositoryFullName, repoWidth), repoWidth, false)
 	divider := renderCell(ctx.Styles.Separator.Render(" │ "), dividerWidth, false)
 	title := renderCell(renderNotificationTitle(ctx, n, titleWidth), titleWidth, false)
@@ -83,6 +85,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 		lipgloss.Bottom,
 		indicatorCell,
 		badge,
+		reviewBadge,
 		repo,
 		divider,
 		title,
@@ -90,6 +93,37 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 		timeCell,
 		priority,
 	)
+}
+
+func renderReviewDecisionBadge(ctx RenderContext, n triage.NotificationWithState) string {
+	if n.SubjectType != triage.SubjectPullRequest || n.ResourceSubState == "" {
+		return ""
+	}
+
+	label, style := reviewDecisionBadgeLabelAndStyle(ctx.Styles, n.ResourceSubState)
+	return style.Render(label)
+}
+
+func reviewDecisionBadgeLabelAndStyle(styles Styles, subState string) (string, lipgloss.Style) {
+	switch strings.ToUpper(subState) {
+	case "APPROVED", "COMPLETED", "RESOLVED":
+		return " ✓ APPR", styles.Assign
+	case "CHANGES_REQUESTED", "NOT_PLANNED", "DUPLICATE":
+		return " ! CHG", styles.ActionRequired
+	case "REVIEW_REQUIRED":
+		return " ? REV", styles.ReviewRequested
+	case "OUTDATED":
+		return " ? OLD", styles.Subscribed
+	default:
+		clean := strings.ReplaceAll(strings.ToUpper(subState), "_", "")
+		if clean == "" {
+			return "", styles.Subscribed
+		}
+		if len([]rune(clean)) > 4 {
+			clean = string([]rune(clean)[:4])
+		}
+		return " " + clean, styles.Subscribed
+	}
 }
 
 func renderCell(content string, width int, styleDefault bool) string {

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -17,7 +17,7 @@ type item struct {
 func (i item) Title() string       { return i.notification.SubjectTitle }
 func (i item) Description() string { return i.notification.RepositoryFullName }
 func (i item) FilterValue() string {
-	return i.notification.SubjectTitle + " " + i.notification.RepositoryFullName + " " + i.notification.ResourceState
+	return i.notification.SubjectTitle + " " + i.notification.RepositoryFullName + " " + i.notification.ResourceState + " " + i.notification.ResourceSubState
 }
 
 type itemDelegate struct {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -107,6 +107,74 @@ func TestRenderNotificationRow_EmptyState(t *testing.T) {
 	assert.Equal(t, lipgloss.Width(plainOpen), lipgloss.Width(plainEmpty), "Row lengths must be equal for consistent alignment")
 }
 
+func TestRenderNotificationRow_PRReviewDecisionBadges(t *testing.T) {
+	ctx := RenderContext{
+		Styles: DefaultStyles(true),
+		Width:  100,
+	}
+
+	tests := []struct {
+		name     string
+		subState string
+		want     string
+	}{
+		{name: "Approved", subState: "APPROVED", want: "APPR"},
+		{name: "Review required", subState: "REVIEW_REQUIRED", want: "REV"},
+		{name: "Changes requested", subState: "CHANGES_REQUESTED", want: "CHG"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notif := triage.NotificationWithState{
+				Notification: triage.Notification{
+					SubjectType:        triage.SubjectPullRequest,
+					SubjectTitle:       "Title",
+					SubjectURL:         "https://github.com/o/r/pull/123",
+					RepositoryFullName: "owner/repo",
+					ResourceState:      "OPEN",
+					ResourceSubState:   tt.subState,
+				},
+			}
+
+			out := RenderNotificationRow(ctx, notif)
+			plain := stripANSI(out)
+
+			assert.Contains(t, plain, "OPEN")
+			assert.Contains(t, plain, tt.want)
+			assert.NotContains(t, out, "\n", "Row must not contain newlines")
+			assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
+			assert.LessOrEqual(t, lipgloss.Width(plain), ctx.Width, "Row must not exceed available width")
+		})
+	}
+}
+
+func TestRenderNotificationRow_NonPRHidesReviewDecisionBadge(t *testing.T) {
+	ctx := RenderContext{
+		Styles: DefaultStyles(true),
+		Width:  100,
+	}
+
+	notif := triage.NotificationWithState{
+		Notification: triage.Notification{
+			SubjectType:        triage.SubjectIssue,
+			SubjectTitle:       "Title",
+			SubjectURL:         "https://github.com/o/r/issues/123",
+			RepositoryFullName: "owner/repo",
+			ResourceState:      "OPEN",
+			ResourceSubState:   "APPROVED",
+		},
+	}
+
+	out := RenderNotificationRow(ctx, notif)
+	plain := stripANSI(out)
+
+	assert.Contains(t, plain, "OPEN")
+	assert.NotContains(t, plain, "APPR")
+	assert.NotContains(t, out, "\n", "Row must not contain newlines")
+	assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
+	assert.LessOrEqual(t, lipgloss.Width(plain), ctx.Width, "Row must not exceed available width")
+}
+
 func TestRenderHeader(t *testing.T) {
 	m := newTestModel(t)
 	m.width = 100
@@ -243,7 +311,7 @@ func TestRenderNotificationRow_LongRepo(t *testing.T) {
 	assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
 
 	// Verify truncation of repo name
-	assert.Contains(t, plain, "a-very-long-repos...", "Repo name must be truncated with ellipsis")
+	assert.Contains(t, plain, "a-very-long-rep...", "Repo name must be truncated with ellipsis")
 }
 
 func TestRenderMarkdown(t *testing.T) {


### PR DESCRIPTION
Closes #405.

## Summary

- Add a compact PR-only review decision badge to main TUI notification rows using enriched ResourceSubState data.
- Keep the existing lifecycle state badge visible and preserve one-line row layout.
- Include ResourceSubState in list filtering so review decision text can be searched.

## Validation

- `go test ./internal/tui`
- `make go/test`
- `make go/check`
- `make check`

Note: local `make check` exited 0. Swift semantic lint/test phases reported sandbox DNS fetch warnings for SwiftPM dependencies and followed the Makefile warning path.
