### PR TITLE
Improve PR review badge readability

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -18,12 +18,13 @@ type RenderContext struct {
 }
 
 // RenderNotificationRow provides a consistent, high-density Repo-First row layout.
-// Layout: [Indicator+Icon+Unread] [Badge] [Repo] │ [Title] [#ID] [Time] [Priority]
+// Layout: [Indicator+Icon+Unread] [Badge] [Review] [Repo] │ [Title] [#ID] [Time] [Priority]
 func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) string {
 	const (
 		indicatorCellWidth = 6
 		badgeWidth         = 12
-		reviewBadgeWidth   = 7
+		reviewBadgeWidth   = 8
+		reviewSpacerWidth  = 2
 		dividerWidth       = 3
 		priorityWidth      = 6
 	)
@@ -44,7 +45,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 	}
 
 	// 2. Calculate flexible space (30/70 ratio for Repo vs Title)
-	fixedSpace := indicatorCellWidth + badgeWidth + reviewBadgeWidth + dividerWidth + priorityWidth + idWidth + timeWidth
+	fixedSpace := indicatorCellWidth + badgeWidth + reviewBadgeWidth + reviewSpacerWidth + dividerWidth + priorityWidth + idWidth + timeWidth
 	flexibleSpace := ctx.Width - fixedSpace
 	if flexibleSpace < 20 {
 		flexibleSpace = 20
@@ -64,6 +65,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 
 	badge := renderCell(renderResourceStateBadge(ctx, n.ResourceState), badgeWidth, false)
 	reviewBadge := renderCell(renderReviewDecisionBadge(ctx, n), reviewBadgeWidth, false)
+	reviewSpacer := renderCell("", reviewSpacerWidth, false)
 	repo := renderCell(renderRepoColumn(ctx.Styles, n.RepositoryFullName, repoWidth), repoWidth, false)
 	divider := renderCell(ctx.Styles.Separator.Render(" │ "), dividerWidth, false)
 	title := renderCell(renderNotificationTitle(ctx, n, titleWidth), titleWidth, false)
@@ -86,6 +88,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 		indicatorCell,
 		badge,
 		reviewBadge,
+		reviewSpacer,
 		repo,
 		divider,
 		title,
@@ -111,7 +114,7 @@ func reviewDecisionBadgeLabelAndStyle(styles Styles, subState string) (string, l
 	case "CHANGES_REQUESTED", "NOT_PLANNED", "DUPLICATE":
 		return " ! CHG", styles.ActionRequired
 	case "REVIEW_REQUIRED":
-		return " ? REV", styles.ReviewRequested
+		return " REVIEW", styles.ReviewRequested
 	case "OUTDATED":
 		return " ? OLD", styles.Subscribed
 	default:

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -108,42 +109,50 @@ func TestRenderNotificationRow_EmptyState(t *testing.T) {
 }
 
 func TestRenderNotificationRow_PRReviewDecisionBadges(t *testing.T) {
-	ctx := RenderContext{
-		Styles: DefaultStyles(true),
-		Width:  100,
-	}
-
 	tests := []struct {
 		name     string
 		subState string
 		want     string
+		notWant  string
 	}{
 		{name: "Approved", subState: "APPROVED", want: "APPR"},
-		{name: "Review required", subState: "REVIEW_REQUIRED", want: "REV"},
+		{name: "Review required", subState: "REVIEW_REQUIRED", want: "REVIEW", notWant: "? REV"},
 		{name: "Changes requested", subState: "CHANGES_REQUESTED", want: "CHG"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			notif := triage.NotificationWithState{
-				Notification: triage.Notification{
-					SubjectType:        triage.SubjectPullRequest,
-					SubjectTitle:       "Title",
-					SubjectURL:         "https://github.com/o/r/pull/123",
-					RepositoryFullName: "owner/repo",
-					ResourceState:      "OPEN",
-					ResourceSubState:   tt.subState,
-				},
+			for _, width := range []int{100, 80} {
+				t.Run(fmt.Sprintf("width_%d", width), func(t *testing.T) {
+					ctx := RenderContext{
+						Styles: DefaultStyles(true),
+						Width:  width,
+					}
+					notif := triage.NotificationWithState{
+						Notification: triage.Notification{
+							SubjectType:        triage.SubjectPullRequest,
+							SubjectTitle:       "Title",
+							SubjectURL:         "https://github.com/o/r/pull/123",
+							RepositoryFullName: "owner/repo",
+							ResourceState:      "OPEN",
+							ResourceSubState:   tt.subState,
+						},
+					}
+
+					out := RenderNotificationRow(ctx, notif)
+					plain := stripANSI(out)
+
+					assert.Contains(t, plain, "OPEN")
+					assert.Contains(t, plain, tt.want)
+					if tt.notWant != "" {
+						assert.NotContains(t, plain, tt.notWant)
+					}
+					assert.Regexp(t, tt.want+`\s{2,}owner/repo`, plain, "Review badge must be visually separated from repo")
+					assert.NotContains(t, out, "\n", "Row must not contain newlines")
+					assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
+					assert.LessOrEqual(t, lipgloss.Width(plain), ctx.Width, "Row must not exceed available width")
+				})
 			}
-
-			out := RenderNotificationRow(ctx, notif)
-			plain := stripANSI(out)
-
-			assert.Contains(t, plain, "OPEN")
-			assert.Contains(t, plain, tt.want)
-			assert.NotContains(t, out, "\n", "Row must not contain newlines")
-			assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
-			assert.LessOrEqual(t, lipgloss.Width(plain), ctx.Width, "Row must not exceed available width")
 		})
 	}
 }
@@ -311,7 +320,7 @@ func TestRenderNotificationRow_LongRepo(t *testing.T) {
 	assert.Equal(t, 1, lipgloss.Height(out), "Row height must be exactly 1")
 
 	// Verify truncation of repo name
-	assert.Contains(t, plain, "a-very-long-rep...", "Repo name must be truncated with ellipsis")
+	assert.Contains(t, plain, "a-very-long-re...", "Repo name must be truncated with ellipsis")
 }
 
 func TestRenderMarkdown(t *testing.T) {


### PR DESCRIPTION
Closes #411.

## Summary

- Replace the ambiguous `? REV` main-row PR review badge with `REVIEW`.
- Add an explicit spacer between the review badge column and repository column.
- Strengthen row rendering tests for readable labels, badge/repo separation, and width-bounded one-line layout at widths 100 and 80.

## Validation

- `go test ./internal/tui`
- `make go/test`
- `make go/check`
- `make check`

Note: local `make check` exited 0. Swift semantic lint/test phases reported sandbox DNS fetch warnings for SwiftPM dependencies and followed the Makefile warning path.
