### PR TITLE
feat(native): model terminal pane lifecycle

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -112,7 +112,8 @@ struct TerminalHostView: View {
 
     var body: some View {
         VStack {
-            if let error = terminalManager.launchError {
+            switch terminalManager.state(for: paneName) {
+            case .failed(let error):
                 VStack(spacing: 20) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.largeTitle)
@@ -121,15 +122,32 @@ struct TerminalHostView: View {
                         .font(.headline)
                         .multilineTextAlignment(.center)
                     Button("Retry") {
-                        terminalManager.launchError = nil
                         terminalManager.launch(paneName)
                     }
                     .buttonStyle(.borderedProminent)
                 }
                 .padding()
-            } else if let engine = terminalManager.engines[paneName] {
-                TerminalContainer(engine: engine, isFocused: true)
-            } else {
+            case .running:
+                if let engine = terminalManager.engine(for: paneName) {
+                    TerminalContainer(engine: engine, isFocused: true)
+                } else {
+                    ProgressView()
+                }
+            case .exited(let exitCode):
+                VStack(spacing: 20) {
+                    Image(systemName: "terminal")
+                        .font(.largeTitle)
+                        .foregroundColor(.secondary)
+                    Text("Session ended with exit code \(exitCode)")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                    Button("Restart TUI") {
+                        terminalManager.launch(paneName)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            case .launching, .none:
                 VStack(spacing: 12) {
                     ProgressView()
                     Text("Initializing Engine...")
@@ -145,10 +163,35 @@ struct TerminalHostView: View {
 }
 
 @MainActor
+enum TerminalPaneState: Equatable {
+    case launching
+    case running
+    case exited(exitCode: Int32)
+    case failed(message: String)
+}
+
+@MainActor
+protocol TerminalProcessSession: AnyObject {
+    var engine: OrbitTerminalEngine { get }
+    func terminateProcess()
+}
+
+extension SwiftTermAdapter: TerminalProcessSession {
+    var engine: OrbitTerminalEngine {
+        self
+    }
+}
+
+@MainActor
+struct TerminalPaneSession {
+    var state: TerminalPaneState
+    var session: TerminalProcessSession?
+}
+
+@MainActor
 class TerminalManager: ObservableObject {
-    @Published var engines: [String: OrbitTerminalEngine] = [:]
+    @Published private var panes: [String: TerminalPaneSession] = [:]
     @Published var engineManager: NativeEngineManager?
-    @Published var launchError: String?
 
     private var isDark: Bool = true
     private var cancellables = Set<AnyCancellable>()
@@ -176,26 +219,51 @@ class TerminalManager: ObservableObject {
 
     func updateTheme(isDark: Bool) {
         self.isDark = isDark
-        for engine in engines.values {
-            engine.isDarkMode(isDark)
+        for pane in panes.values {
+            pane.session?.engine.isDarkMode(isDark)
         }
     }
 
+    func state(for name: String) -> TerminalPaneState? {
+        panes[name]?.state
+    }
+
+    func engine(for name: String) -> OrbitTerminalEngine? {
+        panes[name]?.session?.engine
+    }
+
+    func installSession(_ session: TerminalProcessSession, for name: String, state: TerminalPaneState = .running) {
+        panes[name] = TerminalPaneSession(state: state, session: session)
+    }
+
     func launch(_ name: String) {
-        if engines[name] != nil || launchTasks[name] != nil {
+        if launchTasks[name] != nil {
             return
         }
 
-        let task = Task {
+        if let state = panes[name]?.state, state == .launching || state == .running {
+            return
+        }
+
+        panes[name] = TerminalPaneSession(state: .launching, session: nil)
+
+        let task = Task { @MainActor in
             defer { launchTasks[name] = nil }
-            let adapter = SwiftTermAdapter(onLog: onLog)
+            let adapter = SwiftTermAdapter(
+                onLog: onLog,
+                onTerminate: { [weak self] exitCode in
+                    self?.processTerminated(name: name, exitCode: exitCode)
+                })
             adapter.isDarkMode(isDark)
 
             onLog?("Resolving gh-orbit binary...", .debug)
             // 1. Resolve binary
             guard let executableURL = PathResolver.resolveBinary(onLog: onLog) else {
                 onLog?("gh-orbit binary not found. Launch aborted.", .error)
-                self.launchError = "gh-orbit binary not found. Please ensure it's in your PATH or set GH_ORBIT_BIN."
+                panes[name] = TerminalPaneSession(
+                    state: .failed(
+                        message: "gh-orbit binary not found. Please ensure it's in your PATH or set GH_ORBIT_BIN."),
+                    session: nil)
                 return
             }
             onLog?("Final binary resolved to: \(executableURL.path)", .debug)
@@ -218,7 +286,7 @@ class TerminalManager: ObservableObject {
                     break
                 case .failed(let message):
                     onLog?("Engine verification failed. Aborting pane launch.", .error)
-                    self.launchError = message
+                    panes[name] = TerminalPaneSession(state: .failed(message: message), session: nil)
                     return
                 }
             }
@@ -232,9 +300,13 @@ class TerminalManager: ObservableObject {
             onLog?("Launching TUI process with args: \(args)", .debug)
             adapter.startProcess(
                 executable: executableURL, args: args, environment: env.map { "\($0.key)=\($0.value)" })
-            engines[name] = adapter
+            panes[name] = TerminalPaneSession(state: .running, session: adapter)
         }
         launchTasks[name] = task
+    }
+
+    func processTerminated(name: String, exitCode: Int32?) {
+        panes[name] = TerminalPaneSession(state: .exited(exitCode: exitCode ?? -1), session: nil)
     }
 
     func shutdown() {
@@ -242,6 +314,9 @@ class TerminalManager: ObservableObject {
             task.cancel()
         }
         launchTasks.removeAll()
+        for pane in panes.values where pane.state == .running {
+            pane.session?.terminateProcess()
+        }
         engineManager?.stopEngine()
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -6,13 +6,15 @@ import SwiftTerm
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
     private let onLog: ((String, LogLevel) -> Void)?
+    private let onTerminate: ((Int32?) -> Void)?
 
     var view: NSView {
         return terminalView
     }
 
-    init(onLog: ((String, LogLevel) -> Void)? = nil) {
+    init(onLog: ((String, LogLevel) -> Void)? = nil, onTerminate: ((Int32?) -> Void)? = nil) {
         self.onLog = onLog
+        self.onTerminate = onTerminate
         self.terminalView = LocalProcessTerminalView(frame: .zero)
         super.init()
         self.terminalView.processDelegate = self
@@ -108,6 +110,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         let message = "\r\n\r\n[Process terminated with exit code \(code)]\r\n"
         let bytes = [UInt8](message.utf8)
         source.feed(byteArray: bytes[...])
+        onTerminate?(exitCode)
     }
 
     func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {
@@ -122,5 +125,9 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
             environment: environment,
             execName: nil
         )
+    }
+
+    func terminateProcess() {
+        terminalView.terminate()
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -1,8 +1,43 @@
+import AppKit
 import Combine
 import Foundation
 import Testing
 
 @testable import OrbitCockpit
+
+@MainActor
+final class MockTerminalEngine: OrbitTerminalEngine {
+    let view = NSView()
+    var isDarkModeCalls: [Bool] = []
+
+    func feed(data: Data) {}
+
+    func send(string: String) {}
+
+    func resize(cols: Int, rows: Int) {}
+
+    func getBuffer() -> String {
+        ""
+    }
+
+    func isDarkMode(_ isDark: Bool) {
+        isDarkModeCalls.append(isDark)
+    }
+}
+
+@MainActor
+final class MockTerminalSession: TerminalProcessSession {
+    let engine: OrbitTerminalEngine
+    var terminateCalls = 0
+
+    init(engine: OrbitTerminalEngine = MockTerminalEngine()) {
+        self.engine = engine
+    }
+
+    func terminateProcess() {
+        terminateCalls += 1
+    }
+}
 
 @Suite("Terminal Manager Tests")
 struct TerminalManagerTests {
@@ -12,19 +47,59 @@ struct TerminalManagerTests {
     func testInitialization() async throws {
         let monitor = ActivityMonitor()
         let manager = TerminalManager(monitor: monitor)
-        #expect(manager.engines.isEmpty)
+        #expect(manager.state(for: "TUI") == nil)
+        #expect(manager.engine(for: "TUI") == nil)
     }
 
-    @Test("Engine mapping preservation")
+    @Test("Running session exposes engine")
     @MainActor
-    func testEngineStorage() async throws {
+    func testRunningSessionExposesEngine() async throws {
         let monitor = ActivityMonitor()
         let manager = TerminalManager(monitor: monitor)
-        let mockEngine = SwiftTermAdapter(onLog: nil)
+        let mockEngine = MockTerminalEngine()
+        let mockSession = MockTerminalSession(engine: mockEngine)
 
-        manager.engines["TUI"] = mockEngine
-        let stored = try #require(manager.engines["TUI"])
+        manager.installSession(mockSession, for: "TUI")
+
+        let stored = try #require(manager.engine(for: "TUI"))
         #expect(stored === mockEngine)
+        #expect(manager.state(for: "TUI") == .running)
+    }
+
+    @Test("Process termination marks pane exited")
+    @MainActor
+    func testProcessTerminationMarksPaneExited() async throws {
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
+        let mockSession = MockTerminalSession()
+
+        manager.installSession(mockSession, for: "TUI")
+        manager.engineManager?.isEngineReady = true
+        manager.processTerminated(name: "TUI", exitCode: 0)
+
+        #expect(manager.state(for: "TUI") == .exited(exitCode: 0))
+        #expect(manager.engine(for: "TUI") == nil)
+        #expect(manager.engineManager?.isEngineReady == true)
+        #expect(mockSession.terminateCalls == 0)
+    }
+
+    @Test("Shutdown terminates running pane processes")
+    @MainActor
+    func testShutdownTerminatesRunningPaneProcesses() async throws {
+        let monitor = ActivityMonitor()
+        let manager = TerminalManager(monitor: monitor)
+        let runningSession = MockTerminalSession()
+        let exitedSession = MockTerminalSession()
+
+        manager.installSession(runningSession, for: "TUI")
+        manager.installSession(exitedSession, for: "Agent Alpha", state: .exited(exitCode: 0))
+        manager.engineManager?.isEngineReady = true
+
+        manager.shutdown()
+
+        #expect(runningSession.terminateCalls == 1)
+        #expect(exitedSession.terminateCalls == 0)
+        #expect(manager.engineManager?.isEngineReady == false)
     }
 
     @Test("Nested State Propagation")


### PR DESCRIPTION
## Summary
- add explicit lifecycle state for embedded terminal panes
- mark panes exited when SwiftTerm child processes terminate and show a restart action
- terminate running embedded terminal processes during app shutdown without stopping the background engine on normal pane exit

## Validation
- make check

Closes #415