### PR TITLE
feat(tui): focus tabs on active triage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"syscall"
 
 	"gopkg.in/yaml.v3"
@@ -99,9 +100,9 @@ func DefaultConfig() *Config {
 			PriorityDown:     []string{"shift+down", "J"},
 			PriorityNone:     []string{"0"},
 			Inbox:            []string{"1"},
-			Unread:           []string{"2"},
-			Triaged:          []string{"3"},
-			All:              []string{"4"},
+			Unread:           []string{},
+			Triaged:          []string{"2"},
+			All:              []string{"3"},
 			CopyURL:          []string{"y"},
 			ToggleRead:       []string{"m"},
 			NextTab:          []string{"]", "tab"},
@@ -213,12 +214,29 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid config.yml (check for typos): %w", err)
 	}
 
+	normalizeKeyMap(&cfg.Keys)
+
 	// 3. Semantic Validation
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("config validation failed: %w", err)
 	}
 
 	return cfg, nil
+}
+
+func normalizeKeyMap(keys *KeyMapConfig) {
+	if isOldDefaultTabKeyMap(*keys) {
+		keys.Unread = nil
+		keys.Triaged = []string{"2"}
+		keys.All = []string{"3"}
+	}
+}
+
+func isOldDefaultTabKeyMap(keys KeyMapConfig) bool {
+	return slices.Equal(keys.Inbox, []string{"1"}) &&
+		slices.Equal(keys.Unread, []string{"2"}) &&
+		slices.Equal(keys.Triaged, []string{"3"}) &&
+		slices.Equal(keys.All, []string{"4"})
 }
 
 // Save saves the current configuration to disk.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,6 +142,48 @@ keys:
 		assert.Equal(t, []string{"r"}, DefaultConfig().Keys.Sync) // Default was 'r'
 		assert.Equal(t, []string{"m"}, cfg.Keys.ToggleRead)       // Still 'm'
 	})
+
+	t.Run("Old Default Tab Keys Normalize To Three Tabs", func(t *testing.T) {
+		content := `
+version: 1
+keys:
+  inbox: ["1"]
+  unread: ["2"]
+  triaged: ["3"]
+  all: ["4"]
+`
+		err := os.WriteFile(expectedPath, []byte(content), 0o600)
+		require.NoError(t, err)
+
+		cfg, err := Load()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"1"}, cfg.Keys.Inbox)
+		assert.Empty(t, cfg.Keys.Unread)
+		assert.Equal(t, []string{"2"}, cfg.Keys.Triaged)
+		assert.Equal(t, []string{"3"}, cfg.Keys.All)
+	})
+
+	t.Run("Custom Tab Keys Are Preserved", func(t *testing.T) {
+		content := `
+version: 1
+keys:
+  inbox: ["g", "i"]
+  unread: ["u"]
+  triaged: ["t"]
+  all: ["a"]
+`
+		err := os.WriteFile(expectedPath, []byte(content), 0o600)
+		require.NoError(t, err)
+
+		cfg, err := Load()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"g", "i"}, cfg.Keys.Inbox)
+		assert.Equal(t, []string{"u"}, cfg.Keys.Unread)
+		assert.Equal(t, []string{"t"}, cfg.Keys.Triaged)
+		assert.Equal(t, []string{"a"}, cfg.Keys.All)
+	})
 }
 
 func TestConfig_Persistence(t *testing.T) {

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -14,7 +14,6 @@ type KeyMap struct {
 	Tab1             key.Binding
 	Tab2             key.Binding
 	Tab3             key.Binding
-	Tab4             key.Binding
 	CopyURL          key.Binding
 	ToggleRead       key.Binding
 	NextTab          key.Binding
@@ -56,14 +55,10 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 			key.WithHelp(k.Inbox[0], "inbox"),
 		),
 		Tab2: key.NewBinding(
-			key.WithKeys(k.Unread...),
-			key.WithHelp(k.Unread[0], "unread"),
-		),
-		Tab3: key.NewBinding(
 			key.WithKeys(k.Triaged...),
 			key.WithHelp(k.Triaged[0], "triaged"),
 		),
-		Tab4: key.NewBinding(
+		Tab3: key.NewBinding(
 			key.WithKeys(k.All...),
 			key.WithHelp(k.All[0], "all"),
 		),
@@ -143,7 +138,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Sync, k.CopyURL, k.OpenBrowser, k.ViewContextual},
 		{k.ToggleDetail, k.Back, k.FilterPR, k.FilterIssue, k.FilterDiscussion},
 		{k.PriorityUp, k.PriorityDown, k.PriorityNone},
-		{k.Tab1, k.Tab2, k.Tab3, k.Tab4},
+		{k.Tab1, k.Tab2, k.Tab3},
 		{k.NextTab, k.PrevTab, k.CheckoutPR, k.Help, k.Quit},
 	}
 }

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -42,6 +42,18 @@ func keyPress(s string) tea.KeyPressMsg {
 	}
 }
 
+func assertListNotificationIDs(t *testing.T, m *Model, expected []string) {
+	t.Helper()
+
+	items := m.listView.list.Items()
+	require.Len(t, items, len(expected))
+	for idx, expectedID := range expected {
+		item, ok := items[idx].(item)
+		require.True(t, ok)
+		assert.Equal(t, expectedID, item.notification.GitHubID)
+	}
+}
+
 func TestInterpreter_Execute(t *testing.T) {
 	m := newTestModel(t)
 	interp := NewInterpreter(m)
@@ -641,6 +653,51 @@ func TestModel_Transition_Tabs(t *testing.T) {
 	msg = keyPress("shift+tab")
 	_ = m.Transition(msg, 0)
 	assert.Equal(t, initialTab, m.listView.activeTab)
+
+	m.setActiveTab(TabAll)
+	_ = m.Transition(keyPress("tab"), 0)
+	assert.Equal(t, TabInbox, m.listView.activeTab)
+
+	_ = m.Transition(keyPress("shift+tab"), 0)
+	assert.Equal(t, TabAll, m.listView.activeTab)
+
+	_ = m.Transition(keyPress("1"), 0)
+	assert.Equal(t, TabInbox, m.listView.activeTab)
+	_ = m.Transition(keyPress("2"), 0)
+	assert.Equal(t, TabTriaged, m.listView.activeTab)
+	_ = m.Transition(keyPress("3"), 0)
+	assert.Equal(t, TabAll, m.listView.activeTab)
+}
+
+func TestModel_ApplyFilters_ActiveTriageTabs(t *testing.T) {
+	m := newTestModel(t)
+	m.config.Notifications.MaxVisibleAgeDays = 0
+
+	unread := triage.NotificationWithState{
+		Notification: triage.Notification{GitHubID: "unread", UpdatedAt: time.Now()},
+		State:        triage.State{IsReadLocally: false, Priority: 0},
+	}
+	prioritizedRead := triage.NotificationWithState{
+		Notification: triage.Notification{GitHubID: "prioritized-read", UpdatedAt: time.Now()},
+		State:        triage.State{IsReadLocally: true, Priority: 2},
+	}
+	done := triage.NotificationWithState{
+		Notification: triage.Notification{GitHubID: "done", UpdatedAt: time.Now()},
+		State:        triage.State{IsReadLocally: true, Priority: 0},
+	}
+	m.allNotifications = []triage.NotificationWithState{unread, prioritizedRead, done}
+
+	m.listView.activeTab = TabInbox
+	m.applyFilters()
+	assertListNotificationIDs(t, m, []string{"unread", "prioritized-read"})
+
+	m.listView.activeTab = TabTriaged
+	m.applyFilters()
+	assertListNotificationIDs(t, m, []string{"prioritized-read"})
+
+	m.listView.activeTab = TabAll
+	m.applyFilters()
+	assertListNotificationIDs(t, m, []string{"unread", "prioritized-read", "done"})
 }
 
 func TestModel_Transition_Enrichment(t *testing.T) {
@@ -848,7 +905,7 @@ func TestModel_ApplyFilters_HidesIgnoredRepositoriesAcrossTabs(t *testing.T) {
 	}
 	m.allNotifications = []triage.NotificationWithState{ignored, visible}
 
-	for _, tab := range []int{TabInbox, TabUnread, TabTriaged, TabAll} {
+	for _, tab := range []int{TabInbox, TabTriaged, TabAll} {
 		m.listView.activeTab = tab
 		m.applyFilters()
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -24,9 +24,9 @@ type AppState int
 
 const (
 	TabInbox = iota
-	TabUnread
 	TabTriaged
 	TabAll
+	tabCount
 )
 
 const (

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -349,9 +349,7 @@ func (m *Model) shouldKeepNotification(n triage.NotificationWithState, now time.
 	keep := false
 	switch m.listView.activeTab {
 	case TabInbox:
-		keep = !n.IsReadLocally && n.Status != "archived"
-	case TabUnread:
-		keep = !n.IsReadLocally
+		keep = !n.IsReadLocally || n.Priority > 0
 	case TabTriaged:
 		keep = n.Priority > 0
 	case TabAll:
@@ -735,10 +733,8 @@ func (m *Model) handleTabKeys(msg tea.KeyMsg) []Action {
 	case key.Matches(msg, m.keys.Tab1):
 		m.setActiveTab(TabInbox)
 	case key.Matches(msg, m.keys.Tab2):
-		m.setActiveTab(TabUnread)
-	case key.Matches(msg, m.keys.Tab3):
 		m.setActiveTab(TabTriaged)
-	case key.Matches(msg, m.keys.Tab4):
+	case key.Matches(msg, m.keys.Tab3):
 		m.setActiveTab(TabAll)
 	default:
 		return nil
@@ -880,7 +876,7 @@ func (m *Model) selectedNotification() (triage.NotificationWithState, bool) {
 }
 
 func (m *Model) cycleTab(delta int) {
-	m.listView.activeTab = (m.listView.activeTab + delta + 4) % 4
+	m.listView.activeTab = (m.listView.activeTab + delta + tabCount) % tabCount
 	m.applyFilters()
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -49,7 +49,7 @@ func (m *Model) View() tea.View {
 
 func (m *Model) renderHeader() string {
 	// 1. Current Tab Bar
-	tabs := []string{" Inbox ", " Unread ", " Triaged ", " All "}
+	tabs := []string{" Inbox ", " Triaged ", " All "}
 	var renderedTabs []string
 
 	for i, t := range tabs {


### PR DESCRIPTION
## Summary
- reduce the main TUI tabs to Inbox, Triaged, and All
- make Inbox show unread or prioritized notifications
- normalize old generated tab key defaults to the new 1/2/3 order while preserving custom keymaps

## Validation
- go test ./internal/config ./internal/tui
- make go/test
- make check

Closes #417