### PR TITLE
feat(tui): separate handled state from read state

### DIFF
--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -272,6 +272,7 @@ func withReadState(notifications []triage.NotificationWithState, id string, read
 	for idx := range cloned {
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsReadLocally = read
+			cloned[idx].IsHandledLocally = read
 			break
 		}
 	}

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -40,7 +40,7 @@ func TestAppBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	mockSyncer := mocks.NewMockSyncer(t)
 	mockEnricher := mocks.NewMockEnricher(t)
 	mockClient := mocks.NewMockClient(t)
-	snapshot := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true}}}
+	snapshot := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}}}
 
 	mockRepo.EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif-1"}}}, nil).Once()
 	mockRepo.EXPECT().MarkReadLocally(mock.Anything, "notif-1", true).Return(nil).Once()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -47,6 +47,7 @@ func TestUpsertAndGetNotification(t *testing.T) {
 	assert.Equal(t, 0, ns.Priority)
 	assert.Equal(t, "entry", ns.Status)
 	assert.False(t, ns.IsReadLocally)
+	assert.False(t, ns.IsHandledLocally)
 }
 
 func TestUpsertNotificationsBatch(t *testing.T) {
@@ -103,10 +104,11 @@ func TestUpsertPreservesLocalState(t *testing.T) {
 
 	// Manually set some triage state
 	err = db.UpdateOrbitState(ctx, triage.State{
-		NotificationID: id,
-		Priority:       3,
-		Status:         "archived",
-		IsReadLocally:  true,
+		NotificationID:   id,
+		Priority:         3,
+		Status:           "archived",
+		IsReadLocally:    true,
+		IsHandledLocally: true,
 	})
 	require.NoError(t, err)
 
@@ -121,6 +123,7 @@ func TestUpsertPreservesLocalState(t *testing.T) {
 	assert.Equal(t, 3, ns.Priority)
 	assert.Equal(t, "archived", ns.Status)
 	assert.True(t, ns.IsReadLocally)
+	assert.True(t, ns.IsHandledLocally)
 }
 
 func TestUpsertReconcilesKnownGitHubReadState(t *testing.T) {
@@ -137,11 +140,12 @@ func TestUpsertReconcilesKnownGitHubReadState(t *testing.T) {
 	}}))
 
 	require.NoError(t, db.UpdateOrbitState(ctx, triage.State{
-		NotificationID: id,
-		Priority:       3,
-		Status:         "archived",
-		IsReadLocally:  true,
-		IsNotified:     true,
+		NotificationID:   id,
+		Priority:         3,
+		Status:           "archived",
+		IsReadLocally:    true,
+		IsHandledLocally: true,
+		IsNotified:       true,
 	}))
 
 	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{
@@ -155,6 +159,7 @@ func TestUpsertReconcilesKnownGitHubReadState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.False(t, ns.IsReadLocally)
+	assert.True(t, ns.IsHandledLocally)
 	assert.Equal(t, 3, ns.Priority)
 	assert.Equal(t, "archived", ns.Status)
 	assert.True(t, ns.IsNotified)
@@ -170,6 +175,7 @@ func TestUpsertReconcilesKnownGitHubReadState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.True(t, ns.IsReadLocally)
+	assert.True(t, ns.IsHandledLocally)
 	assert.Equal(t, 3, ns.Priority)
 	assert.Equal(t, "archived", ns.Status)
 	assert.True(t, ns.IsNotified)
@@ -230,12 +236,14 @@ func TestRepository_Actions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.True(t, ns.IsReadLocally)
+	assert.True(t, ns.IsHandledLocally)
 
 	require.NoError(t, db.MarkReadLocally(ctx, id, false))
 	ns, err = db.GetNotification(ctx, id)
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.False(t, ns.IsReadLocally)
+	assert.False(t, ns.IsHandledLocally)
 
 	// 3. Archive/Unarchive
 	require.NoError(t, db.ArchiveThread(ctx, id))

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -125,8 +125,8 @@ func (db *DB) UpsertNotifications(ctx context.Context, notifications []triage.No
 	defer func() { _ = stmtNotifications.Close() }()
 
 	stmtState, err := tx.PrepareContext(ctx, `
-		INSERT INTO orbit_state (notification_id, priority, status, is_read_locally)
-		VALUES (?, 0, 'entry', FALSE)
+		INSERT INTO orbit_state (notification_id, priority, status, is_read_locally, is_handled_locally)
+		VALUES (?, 0, 'entry', FALSE, FALSE)
 		ON CONFLICT(notification_id) DO NOTHING
 	`)
 	if err != nil {
@@ -167,7 +167,7 @@ func baseNotificationSelect() string {
 			n.github_id, n.subject_title, n.subject_url, n.subject_type, n.reason, n.repository_full_name, n.html_url,
 			COALESCE(n.body, ''), COALESCE(n.author_login, ''), COALESCE(n.resource_state, ''), COALESCE(n.resource_sub_state, ''), COALESCE(n.subject_node_id, ''),
 			n.is_enriched, n.enriched_at, n.updated_at,
-			s.priority, s.status, s.is_read_locally, s.is_notified
+			s.priority, s.status, s.is_read_locally, s.is_handled_locally, s.is_notified
 		FROM notifications n
 		JOIN orbit_state s ON n.github_id = s.notification_id
 	`
@@ -181,7 +181,7 @@ func (db *DB) GetNotification(ctx context.Context, id string) (*triage.Notificat
 	err := row.Scan(
 		&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL,
 		&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.ResourceSubState, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
-		&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsNotified,
+		&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsHandledLocally, &ns.IsNotified,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -207,7 +207,7 @@ func (db *DB) ListNotifications(ctx context.Context) ([]triage.NotificationWithS
 		err := rows.Scan(
 			&ns.GitHubID, &ns.SubjectTitle, &ns.SubjectURL, &ns.SubjectType, &ns.Reason, &ns.RepositoryFullName, &ns.HTMLURL,
 			&ns.Body, &ns.AuthorLogin, &ns.ResourceState, &ns.ResourceSubState, &ns.SubjectNodeID, &ns.IsEnriched, &ns.EnrichedAt, &ns.UpdatedAt,
-			&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsNotified,
+			&ns.Priority, &ns.Status, &ns.IsReadLocally, &ns.IsHandledLocally, &ns.IsNotified,
 		)
 		if err != nil {
 			return nil, err
@@ -221,19 +221,19 @@ func (db *DB) ListNotifications(ctx context.Context) ([]triage.NotificationWithS
 func (db *DB) UpdateOrbitState(ctx context.Context, state triage.State) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE orbit_state
-		SET priority = ?, status = ?, is_read_locally = ?, is_notified = ?
+		SET priority = ?, status = ?, is_read_locally = ?, is_handled_locally = ?, is_notified = ?
 		WHERE notification_id = ?
-	`, state.Priority, state.Status, state.IsReadLocally, state.IsNotified, state.NotificationID)
+	`, state.Priority, state.Status, state.IsReadLocally, state.IsHandledLocally, state.IsNotified, state.NotificationID)
 	return err
 }
 
-// MarkReadLocally updates the local read state of a notification.
+// MarkReadLocally updates the local read state and local handled state of a notification.
 func (db *DB) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE orbit_state
-		SET is_read_locally = ?
+		SET is_read_locally = ?, is_handled_locally = ?
 		WHERE notification_id = ?
-	`, isRead, id)
+	`, isRead, isRead, id)
 	return err
 }
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -63,4 +63,6 @@ var migrations = []string{
 	// Version 11: Generalize review_decision to resource_sub_state
 	`ALTER TABLE notifications ADD COLUMN resource_sub_state TEXT DEFAULT '';
 	 UPDATE notifications SET resource_sub_state = review_decision;`,
+	// Version 12: Separate local handled state from GitHub read state
+	`ALTER TABLE orbit_state ADD COLUMN is_handled_locally BOOLEAN DEFAULT FALSE;`,
 }

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -395,6 +395,7 @@ func applyReadState(notifications []triage.NotificationWithState, id string, rea
 	for idx := range cloned {
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsReadLocally = read
+			cloned[idx].IsHandledLocally = read
 			break
 		}
 	}

--- a/internal/engine/tui_backend_contract_test.go
+++ b/internal/engine/tui_backend_contract_test.go
@@ -21,7 +21,7 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 		{Notification: triage.Notification{GitHubID: "notif-1"}},
 	}
 	after := []triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
 	}
 
 	testCases := []struct {
@@ -106,7 +106,7 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 		{Notification: triage.Notification{GitHubID: "notif-2"}},
 	}
 	after := []triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "notif-2"}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "notif-2"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
 	}
 	remoteErr := errors.New("boom")
 

--- a/internal/triage/types.go
+++ b/internal/triage/types.go
@@ -18,11 +18,12 @@ const (
 
 // State represents the local triage state for a notification.
 type State struct {
-	NotificationID string `json:"notification_id"`
-	Priority       int    `json:"priority"`
-	Status         string `json:"status"`
-	IsReadLocally  bool   `json:"is_read_locally"`
-	IsNotified     bool   `json:"is_notified"`
+	NotificationID   string `json:"notification_id"`
+	Priority         int    `json:"priority"`
+	Status           string `json:"status"`
+	IsReadLocally    bool   `json:"is_read_locally"`
+	IsHandledLocally bool   `json:"is_handled_locally"`
+	IsNotified       bool   `json:"is_notified"`
 }
 
 // Notification represents the core notification entity.

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -28,6 +28,7 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 	for idx, n := range m.allNotifications {
 		if n.GitHubID == id {
 			m.allNotifications[idx].IsReadLocally = read
+			m.allNotifications[idx].IsHandledLocally = read
 			break
 		}
 	}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -238,7 +238,7 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	}, nil).Once()
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -251,6 +251,7 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
+	assert.True(t, m.allNotifications[0].IsHandledLocally)
 	assert.Nil(t, actions)
 	assert.NoError(t, m.err)
 }
@@ -267,7 +268,7 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -280,6 +281,7 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
+	assert.True(t, m.allNotifications[0].IsHandledLocally)
 	assert.Nil(t, actions)
 	assert.NoError(t, m.err)
 }
@@ -310,6 +312,7 @@ func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T)
 
 	actions := m.Transition(reconciled, 0)
 	assert.False(t, m.allNotifications[0].IsReadLocally)
+	assert.False(t, m.allNotifications[0].IsHandledLocally)
 	assert.ErrorIs(t, m.err, localErr)
 	assert.Contains(t, actions, ActionShowToast{Message: "Failed to update read state"})
 }
@@ -338,6 +341,7 @@ func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t 
 	assert.ErrorIs(t, reconciled.err, localErr)
 	actions := m.Transition(reconciled, 0)
 	assert.False(t, m.allNotifications[0].IsReadLocally)
+	assert.False(t, m.allNotifications[0].IsHandledLocally)
 	assert.ErrorIs(t, m.err, localErr)
 	assert.Contains(t, actions, ActionShowToast{Message: "Failed to update read state"})
 }
@@ -355,7 +359,7 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(remoteErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -368,6 +372,7 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
+	assert.True(t, m.allNotifications[0].IsHandledLocally)
 	assert.ErrorIs(t, m.err, remoteErr)
 	assert.Contains(t, actions, ActionShowToast{Message: "Marked read locally; GitHub sync failed"})
 }
@@ -675,15 +680,15 @@ func TestModel_ApplyFilters_ActiveTriageTabs(t *testing.T) {
 
 	unread := triage.NotificationWithState{
 		Notification: triage.Notification{GitHubID: "unread", UpdatedAt: time.Now()},
-		State:        triage.State{IsReadLocally: false, Priority: 0},
+		State:        triage.State{IsReadLocally: true, IsHandledLocally: false, Priority: 0},
 	}
 	prioritizedRead := triage.NotificationWithState{
 		Notification: triage.Notification{GitHubID: "prioritized-read", UpdatedAt: time.Now()},
-		State:        triage.State{IsReadLocally: true, Priority: 2},
+		State:        triage.State{IsReadLocally: true, IsHandledLocally: true, Priority: 2},
 	}
 	done := triage.NotificationWithState{
 		Notification: triage.Notification{GitHubID: "done", UpdatedAt: time.Now()},
-		State:        triage.State{IsReadLocally: true, Priority: 0},
+		State:        triage.State{IsReadLocally: true, IsHandledLocally: true, Priority: 0},
 	}
 	m.allNotifications = []triage.NotificationWithState{unread, prioritizedRead, done}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -349,7 +349,7 @@ func (m *Model) shouldKeepNotification(n triage.NotificationWithState, now time.
 	keep := false
 	switch m.listView.activeTab {
 	case TabInbox:
-		keep = !n.IsReadLocally || n.Priority > 0
+		keep = !n.IsHandledLocally || n.Priority > 0
 	case TabTriaged:
 		keep = n.Priority > 0
 	case TabAll:


### PR DESCRIPTION
## Summary
- add persisted local handled state separate from GitHub read state
- make Inbox use local handled state or priority instead of GitHub read state
- update local mark-read/unread flows and tests for sync, backend, and TUI filtering

## Validation
- GOCACHE=$(pwd)/tmp/go-cache GOMODCACHE=/private/tmp/gh-orbit-go-mod-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make go/test
- GOCACHE=$(pwd)/tmp/go-cache GOMODCACHE=/private/tmp/gh-orbit-go-mod-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home make go/check

Closes #419