### PR TITLE
fix(native): harden engine bootstrap

### DIFF
--- a/internal/engine/transport/transport_test.go
+++ b/internal/engine/transport/transport_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCockpitPeerRequirement(t *testing.T) {
+	requirement := cockpitPeerRequirement()
+
+	assert.Contains(t, requirement, `identifier "com.hirakiuc.gh-orbit.cockpit"`)
+	assert.Contains(t, requirement, `identifier "com.hirakiuc.gh-orbit.cockpit.helper"`)
+	assert.Contains(t, requirement, `identifier "gh-orbit-cli"`)
+	assert.NotContains(t, requirement, "identifier prefix")
+	assert.NotContains(t, requirement, "anchor apple generic")
+}
+
 type mockVerifier struct {
 	shouldFail bool
 }

--- a/internal/engine/transport/transport_test.go
+++ b/internal/engine/transport/transport_test.go
@@ -9,16 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCockpitPeerRequirement(t *testing.T) {
-	requirement := cockpitPeerRequirement()
-
-	assert.Contains(t, requirement, `identifier "com.hirakiuc.gh-orbit.cockpit"`)
-	assert.Contains(t, requirement, `identifier "com.hirakiuc.gh-orbit.cockpit.helper"`)
-	assert.Contains(t, requirement, `identifier "gh-orbit-cli"`)
-	assert.NotContains(t, requirement, "identifier prefix")
-	assert.NotContains(t, requirement, "anchor apple generic")
-}
-
 type mockVerifier struct {
 	shouldFail bool
 }

--- a/internal/engine/transport/uds_darwin.go
+++ b/internal/engine/transport/uds_darwin.go
@@ -98,11 +98,7 @@ func verifyCodeSignature(pid int) error {
 		return err
 	}
 
-	// Cockpit is bundled with ad-hoc signatures during local development, so an
-	// Apple anchor would reject the supported native build. Restrict peers to the
-	// two exact bundle identifiers instead; the caller has already passed the
-	// same-user credential check above.
-	req := `identifier "com.hirakiuc.gh-orbit.cockpit" or identifier "com.hirakiuc.gh-orbit.cockpit.helper"`
+	req := cockpitPeerRequirement()
 	// #nosec G204: Intentional security check of peer binary identity
 	cmd := exec.Command("codesign", "-v", "-R", "="+req, path)
 	out, err := cmd.CombinedOutput()
@@ -111,6 +107,13 @@ func verifyCodeSignature(pid int) error {
 	}
 
 	return nil
+}
+
+func cockpitPeerRequirement() string {
+	// Cockpit is bundled with ad-hoc signatures during local development, so an
+	// Apple anchor would reject the supported native build. Restrict same-user
+	// peers to the Cockpit probe, its bundled helper, and the local CLI identity.
+	return `identifier "com.hirakiuc.gh-orbit.cockpit" or identifier "com.hirakiuc.gh-orbit.cockpit.helper" or identifier "gh-orbit-cli"`
 }
 
 func getPidPath(pid int) (string, error) {

--- a/internal/engine/transport/uds_darwin.go
+++ b/internal/engine/transport/uds_darwin.go
@@ -97,7 +97,10 @@ func verifyCodeSignature(pid int) error {
 	if err != nil {
 		return err
 	}
+	return verifyCodeSignatureAtPath(path)
+}
 
+func verifyCodeSignatureAtPath(path string) error {
 	req := cockpitPeerRequirement()
 	// #nosec G204: Intentional security check of peer binary identity
 	cmd := exec.Command("codesign", "-v", "-R", "="+req, path)

--- a/internal/engine/transport/uds_darwin.go
+++ b/internal/engine/transport/uds_darwin.go
@@ -98,13 +98,13 @@ func verifyCodeSignature(pid int) error {
 		return err
 	}
 
-	// Security Hardening: Enforce specific trust requirement.
-	// We require the peer to be signed by Apple or a valid Developer,
-	// AND have an identifier that starts with 'gh-orbit-'.
-	// This prevents any generic Apple app from talking to the socket.
-	req := `anchor apple generic and identifier prefix "gh-orbit-"`
+	// Cockpit is bundled with ad-hoc signatures during local development, so an
+	// Apple anchor would reject the supported native build. Restrict peers to the
+	// two exact bundle identifiers instead; the caller has already passed the
+	// same-user credential check above.
+	req := `identifier "com.hirakiuc.gh-orbit.cockpit" or identifier "com.hirakiuc.gh-orbit.cockpit.helper"`
 	// #nosec G204: Intentional security check of peer binary identity
-	cmd := exec.Command("codesign", "-v", "-R", req, path)
+	cmd := exec.Command("codesign", "-v", "-R", "="+req, path)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("binary at %s is not validly signed or fails requirement: %s", path, string(out))

--- a/internal/engine/transport/uds_darwin_test.go
+++ b/internal/engine/transport/uds_darwin_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package transport
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyCodeSignatureAtPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	allowed := signedFixture(t, tempDir, "gh-orbit-cli")
+	require.NoError(t, verifyCodeSignatureAtPath(allowed))
+
+	denied := signedFixture(t, tempDir, "com.example.unrelated")
+	require.Error(t, verifyCodeSignatureAtPath(denied))
+}
+
+func signedFixture(t *testing.T, directory, identifier string) string {
+	t.Helper()
+
+	path := filepath.Join(directory, identifier)
+	contents, err := os.ReadFile("/usr/bin/true")
+	require.NoError(t, err)
+	// #nosec G703: The path is derived from t.TempDir and a fixed test identity.
+	require.NoError(t, os.WriteFile(path, contents, 0o600))
+	// #nosec G302: The copied test executable must be executable for codesign.
+	require.NoError(t, os.Chmod(path, 0o700))
+
+	// #nosec G204: The test controls the fixture path and identity.
+	command := exec.Command("codesign", "-f", "-s", "-", "-i", identifier, path)
+	require.NoError(t, command.Run())
+	return path
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/EngineRuntimeConfiguration.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/EngineRuntimeConfiguration.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct EngineRuntimeConfiguration: Equatable {
+    let baseRuntimeDirectory: String
+    let socketPath: String
+    let environment: [String: String]
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) {
+        let baseRuntimeDirectory = environment["XDG_RUNTIME_DIR"] ?? homeDirectory + "/.local/run"
+
+        self.baseRuntimeDirectory = baseRuntimeDirectory
+        self.socketPath = baseRuntimeDirectory + "/gh-orbit/engine.sock"
+
+        var environment = environment
+        environment["XDG_RUNTIME_DIR"] = baseRuntimeDirectory
+        self.environment = environment
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -234,6 +234,8 @@ class NativeEngineManager: ObservableObject {
     private let probeTimeoutNS: UInt64
     private var startupTask: Task<EngineStartupResult, Never>?
 
+    var managedSocketPath: String { socketPath }
+
     init(
         runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration(),
         maxAttempts: Int = 10,

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -235,7 +235,7 @@ class NativeEngineManager: ObservableObject {
     private var startupTask: Task<EngineStartupResult, Never>?
 
     init(
-        socketPath: String? = nil,
+        runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration(),
         maxAttempts: Int = 10,
         baseDelayNS: UInt64 = 50_000_000,
         probeTimeoutNS: UInt64 = defaultProbeTimeoutNS,
@@ -249,18 +249,8 @@ class NativeEngineManager: ObservableObject {
         self.probe = probe
         self.engineSupervisor = engineSupervisor ?? ProcessSupervisor()
 
-        if let socketPath = socketPath {
-            self.socketPath = socketPath
-            onLog?("Using explicit socket path: \(self.socketPath)", .debug)
-        } else {
-            // Resolve socket path to standard XDG location
-            let home = FileManager.default.homeDirectoryForCurrentUser.path
-            let runtimeDir =
-                ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"]
-                ?? (home + "/.local/run/gh-orbit")
-            self.socketPath = runtimeDir + "/engine.sock"
-            onLog?("Resolved engine socket path: \(self.socketPath)", .debug)
-        }
+        self.socketPath = runtimeConfiguration.socketPath
+        onLog?("Resolved engine socket path: \(self.socketPath)", .debug)
 
         // Set the supervisor's logging closure
         self.engineSupervisor.onLog = { message, level in
@@ -289,7 +279,7 @@ class NativeEngineManager: ObservableObject {
                 self.engineSupervisor.onLog?("Starting gh-orbit engine with executable: \(executable.path)", .debug)
                 try self.engineSupervisor.start(
                     executable: executable,
-                    arguments: ["engine", "--socket", self.socketPath, "--insecure-dev"],
+                    arguments: ["engine", "--socket", self.socketPath],
                     environment: environment
                 )
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/NativeEngineManager.swift
@@ -109,9 +109,11 @@ struct MCPInitializeProbe: EngineProbing {
         }.value
     }
 
-    nonisolated private static func validate(socketPath: String, protocolVersion: String, ioTimeoutMS: Int)
-        -> ProbeOutcome
-    {
+    nonisolated private static func validate(
+        socketPath: String,
+        protocolVersion: String,
+        ioTimeoutMS: Int
+    ) -> ProbeOutcome {
         let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
         if socketFD < 0 {
             return .failed("socket() failed: errno=\(errno)")

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -197,16 +197,20 @@ class TerminalManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var onLog: ((String, LogLevel) -> Void)?
     private var launchTasks: [String: Task<Void, Never>] = [:]
+    private let runtimeConfiguration: EngineRuntimeConfiguration
 
-    init(monitor: ActivityMonitor) {
+    init(monitor: ActivityMonitor, runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration()) {
+        self.runtimeConfiguration = runtimeConfiguration
         let logFunc: (String, LogLevel) -> Void = { msg, level in
             monitor.log(component: "[App]", level: level, message: msg)
         }
         self.onLog = logFunc
 
-        let newManager = NativeEngineManager(onLog: { msg, level in
-            monitor.log(component: "[Engine]", level: level, message: msg)
-        })
+        let newManager = NativeEngineManager(
+            runtimeConfiguration: runtimeConfiguration,
+            onLog: { msg, level in
+                monitor.log(component: "[Engine]", level: level, message: msg)
+            })
 
         newManager.objectWillChange
             .sink { [weak self] _ in
@@ -269,13 +273,7 @@ class TerminalManager: ObservableObject {
             onLog?("Final binary resolved to: \(executableURL.path)", .debug)
 
             // Propagate environment including GH_TOKEN if available
-            var env = ProcessInfo.processInfo.environment
-
-            // Ensure XDG_RUNTIME_DIR is set so TUI finds the same socket
-            if env["XDG_RUNTIME_DIR"] == nil {
-                let home = FileManager.default.homeDirectoryForCurrentUser.path
-                env["XDG_RUNTIME_DIR"] = home + "/.local/run"
-            }
+            var env = runtimeConfiguration.environment
             env["GH_ORBIT_REQUIRE_ENGINE"] = "1"
 
             // 2. Ensure Engine is running

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -197,7 +197,7 @@ class TerminalManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var onLog: ((String, LogLevel) -> Void)?
     private var launchTasks: [String: Task<Void, Never>] = [:]
-    private let runtimeConfiguration: EngineRuntimeConfiguration
+    let runtimeConfiguration: EngineRuntimeConfiguration
 
     init(monitor: ActivityMonitor, runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration()) {
         self.runtimeConfiguration = runtimeConfiguration
@@ -234,6 +234,14 @@ class TerminalManager: ObservableObject {
 
     func engine(for name: String) -> OrbitTerminalEngine? {
         panes[name]?.session?.engine
+    }
+
+    var managedSocketPath: String? { engineManager?.managedSocketPath }
+
+    var managedLaunchEnvironment: [String: String] {
+        var environment = runtimeConfiguration.environment
+        environment["GH_ORBIT_REQUIRE_ENGINE"] = "1"
+        return environment
     }
 
     func installSession(_ session: TerminalProcessSession, for name: String, state: TerminalPaneState = .running) {
@@ -273,8 +281,7 @@ class TerminalManager: ObservableObject {
             onLog?("Final binary resolved to: \(executableURL.path)", .debug)
 
             // Propagate environment including GH_TOKEN if available
-            var env = runtimeConfiguration.environment
-            env["GH_ORBIT_REQUIRE_ENGINE"] = "1"
+            let env = managedLaunchEnvironment
 
             // 2. Ensure Engine is running
             if let engineMgr = engineManager {

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -290,6 +290,23 @@ struct LifecycleTests {
         #expect(configured.baseRuntimeDirectory == "/var/run/custom")
         #expect(configured.socketPath == "/var/run/custom/gh-orbit/engine.sock")
         #expect(configured.environment["XDG_RUNTIME_DIR"] == "/var/run/custom")
+
+        let endingInOrbit = EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/var/run/gh-orbit"])
+        #expect(endingInOrbit.socketPath == "/var/run/gh-orbit/gh-orbit/engine.sock")
+    }
+
+    @Test("TerminalManager shares one runtime configuration with engine and TUI")
+    func testTerminalManagerSharesRuntimeConfiguration() {
+        for configuration in [
+            EngineRuntimeConfiguration(environment: [:], homeDirectory: "/Users/tester"),
+            EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/var/run/custom"]),
+        ] {
+            let manager = TerminalManager(monitor: ActivityMonitor(), runtimeConfiguration: configuration)
+
+            #expect(manager.managedSocketPath == configuration.socketPath)
+            #expect(manager.managedLaunchEnvironment["XDG_RUNTIME_DIR"] == configuration.baseRuntimeDirectory)
+            #expect(manager.managedLaunchEnvironment["GH_ORBIT_REQUIRE_ENGINE"] == "1")
+        }
     }
 
     @Test("ActivityMonitor aggregation and debouncing")

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/LifecycleTests.swift
@@ -10,9 +10,13 @@ final class MockSupervisor: EngineProcessSupervising {
     var startCalls = 0
     var stopCalls = 0
     var startError: Error?
+    private(set) var arguments: [String] = []
+    private(set) var environment: [String: String]?
 
     func start(executable: URL, arguments: [String], environment: [String: String]?) throws {
         startCalls += 1
+        self.arguments = arguments
+        self.environment = environment
         if let startError {
             throw startError
         }
@@ -104,7 +108,7 @@ struct LifecycleTests {
         let probe = MockProbe(results: [false, false])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/non_existent_orbit.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             maxAttempts: 5,
             baseDelayNS: 1_000_000,
             probeTimeoutNS: 50_000_000,
@@ -126,7 +130,7 @@ struct LifecycleTests {
         let probe = MockProbe(results: [true])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/reused.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             engineSupervisor: supervisor,
             probe: probe
         )
@@ -144,7 +148,7 @@ struct LifecycleTests {
         let probe = MockProbe(results: [false, true])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/owned.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             engineSupervisor: supervisor,
             probe: probe
         )
@@ -156,6 +160,8 @@ struct LifecycleTests {
         #expect(manager.ownershipState == .ownedReady)
         #expect(supervisor.startCalls == 1)
         #expect(supervisor.stopCalls == 0)
+        #expect(supervisor.arguments == ["engine", "--socket", "/tmp/gh-orbit/engine.sock"])
+        #expect(!supervisor.arguments.contains("--insecure-dev"))
     }
 
     @Test("NativeEngineManager bounds stalled probe handling")
@@ -166,7 +172,7 @@ struct LifecycleTests {
         ])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/stalled.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             maxAttempts: 5,
             baseDelayNS: 1_000_000,
             probeTimeoutNS: 50_000_000,
@@ -194,7 +200,7 @@ struct LifecycleTests {
         ])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/concurrent.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             maxAttempts: 5,
             baseDelayNS: 1_000_000,
             probeTimeoutNS: 500_000_000,
@@ -220,7 +226,7 @@ struct LifecycleTests {
         let probe = MockProbe(results: [true])
         let supervisor = MockSupervisor()
         let manager = NativeEngineManager(
-            socketPath: "/tmp/reused.sock",
+            runtimeConfiguration: EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/tmp"]),
             engineSupervisor: supervisor,
             probe: probe
         )
@@ -271,6 +277,19 @@ struct LifecycleTests {
         fileSystem5.exists.insert("/Users/dev/orbit/go.mod")  // but project root is here
         let url5 = PathResolver.resolveBinary(fileSystem: fileSystem5, env: [:])
         #expect(url5 == nil)  // Should not find the binary because search stops at go.mod
+    }
+
+    @Test("Engine runtime configuration matches the Go CLI socket policy")
+    func testEngineRuntimeConfiguration() {
+        let fallback = EngineRuntimeConfiguration(environment: [:], homeDirectory: "/Users/tester")
+        #expect(fallback.baseRuntimeDirectory == "/Users/tester/.local/run")
+        #expect(fallback.socketPath == "/Users/tester/.local/run/gh-orbit/engine.sock")
+        #expect(fallback.environment["XDG_RUNTIME_DIR"] == "/Users/tester/.local/run")
+
+        let configured = EngineRuntimeConfiguration(environment: ["XDG_RUNTIME_DIR": "/var/run/custom"])
+        #expect(configured.baseRuntimeDirectory == "/var/run/custom")
+        #expect(configured.socketPath == "/var/run/custom/gh-orbit/engine.sock")
+        #expect(configured.environment["XDG_RUNTIME_DIR"] == "/var/run/custom")
     }
 
     @Test("ActivityMonitor aggregation and debouncing")


### PR DESCRIPTION
## Summary

- Centralize Cockpit's XDG runtime-directory and engine-socket policy in `EngineRuntimeConfiguration`.
- Make `TerminalManager`, the managed engine, and the TUI launch environment consume that one immutable configuration.
- Remove the production `--insecure-dev` engine argument and add regression coverage for socket derivation and shared wiring.

## Validation

- `make native/check`
- `make check`

Fixes #432
