### PR TITLE
feat(native): add exact-commit worktree lifecycle (#428)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,9 @@ native/test:
 	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
 		cd native/OrbitCockpit && \
 			HOME=$(PROJECT_TMP)/swift-home \
-			swift test --disable-sandbox --build-path $(PROJECT_TMP)/swift-build; \
+			swift test --disable-sandbox --build-path $(PROJECT_TMP)/swift-build --disable-xctest --enable-swift-testing; \
 	else \
-		if cd native/OrbitCockpit && HOME=$(PROJECT_TMP)/swift-home swift test --disable-sandbox --build-path $(PROJECT_TMP)/swift-build 2>/dev/null; then \
+		if cd native/OrbitCockpit && HOME=$(PROJECT_TMP)/swift-home swift test --disable-sandbox --build-path $(PROJECT_TMP)/swift-build --disable-xctest --enable-swift-testing 2>/dev/null; then \
 			echo "Swift tests passed."; \
 		else \
 			echo "Warning: Swift tests skipped or failed (likely due to missing XCTest/Testing module in this shell). Architectural integrity verified via build."; \

--- a/native/OrbitCockpit/Sources/OrbitCockpit/EngineRuntimeConfiguration.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/EngineRuntimeConfiguration.swift
@@ -3,16 +3,24 @@ import Foundation
 struct EngineRuntimeConfiguration: Equatable {
     let baseRuntimeDirectory: String
     let socketPath: String
+    let reviewWorkspaceRoot: String
     let environment: [String: String]
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        applicationSupportDirectory: String? = nil,
+        reviewWorkspaceRoot: String? = nil
     ) {
         let baseRuntimeDirectory = environment["XDG_RUNTIME_DIR"] ?? homeDirectory + "/.local/run"
+        let appSupportDirectory =
+            applicationSupportDirectory
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.path
+            ?? homeDirectory + "/Library/Application Support"
 
         self.baseRuntimeDirectory = baseRuntimeDirectory
         self.socketPath = baseRuntimeDirectory + "/gh-orbit/engine.sock"
+        self.reviewWorkspaceRoot = reviewWorkspaceRoot ?? appSupportDirectory + "/gh-orbit/worktrees"
 
         var environment = environment
         environment["XDG_RUNTIME_DIR"] = baseRuntimeDirectory

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -16,7 +16,18 @@ struct OrbitCockpitApp: App {
         _activityMonitor = StateObject(wrappedValue: monitor)
         let terminalManager = TerminalManager(monitor: monitor)
         _terminalManager = StateObject(wrappedValue: terminalManager)
-        _reviewWorkspaceManager = StateObject(wrappedValue: ReviewWorkspaceManager(terminalManager: terminalManager))
+        let runtimeConfiguration = terminalManager.runtimeConfiguration
+        let workspacePaths = ReviewWorkspacePaths(
+            root: URL(fileURLWithPath: runtimeConfiguration.reviewWorkspaceRoot, isDirectory: true))
+        let lifecycleController = ReviewWorkspaceLifecycleController(
+            store: ReviewWorkspaceMetadataStore(paths: workspacePaths),
+            service: ReviewWorkspaceGitService(
+                git: URL(fileURLWithPath: "/usr/bin/git"),
+                paths: workspacePaths))
+        _reviewWorkspaceManager = StateObject(
+            wrappedValue: ReviewWorkspaceManager(
+                terminalManager: terminalManager,
+                lifecycleController: lifecycleController))
     }
 
     var body: some Scene {
@@ -94,6 +105,12 @@ struct ReviewWorkspaceHostView: View {
 
     var body: some View {
         switch workspace.state {
+        case .available:
+            if let path = workspace.record?.worktreePath.path {
+                Text("Managed worktree is available at \(path).").foregroundColor(.secondary)
+            } else {
+                Text("Managed worktree is available.").foregroundColor(.secondary)
+            }
         case .running:
             terminalView(or: "Terminal session is unavailable.")
         case .exited(let code):
@@ -102,6 +119,16 @@ struct ReviewWorkspaceHostView: View {
             } else {
                 Text("Terminal session exited (\(code)).").foregroundColor(.secondary)
             }
+        case .cleanupRequired(let message):
+            ContentUnavailableView(
+                "Review workspace requires cleanup",
+                systemImage: "externaldrive.badge.exclamationmark",
+                description: Text(message))
+        case .missing(let message):
+            ContentUnavailableView(
+                "Review workspace missing",
+                systemImage: "externaldrive.badge.questionmark",
+                description: Text(message))
         case .preparing:
             ProgressView("Preparing review workspace…")
         case .terminating:
@@ -165,9 +192,12 @@ struct Sidebar: View {
     private func workspaceStatus(_ state: ReviewWorkspace.State) -> String {
         switch state {
         case .preparing: "Preparing"
+        case .available: "Available"
         case .running: "Running"
         case .terminating: "Stopping"
         case .exited(let code): "Exited (\(code))"
+        case .missing: "Missing"
+        case .cleanupRequired: "Cleanup required"
         case .failed(let message): message
         }
     }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -94,6 +94,7 @@ struct ContentView: View {
         }
         .onAppear {
             terminalManager.updateTheme(isDark: colorScheme == .dark)
+            reviewWorkspaceManager.restoreManagedWorkspacesIfNeeded()
         }
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -1,12 +1,63 @@
 import Combine
 import Foundation
 
+protocol ReviewWorkspaceLifecycleControlling {
+    func createWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        workspaceID: UUID,
+        now: Date
+    ) throws -> ReviewWorkspaceRecord
+    func restoreWorkspaces(now: Date) throws -> ReviewWorkspaceReconciliationResult
+    func cleanupWorkspace(_ record: ReviewWorkspaceRecord, now: Date) throws -> ReviewWorkspaceCleanupResult
+}
+
+struct ReviewWorkspaceLifecycleController: ReviewWorkspaceLifecycleControlling {
+    private let store: ReviewWorkspaceMetadataStore
+    private let service: ReviewWorkspaceGitService
+
+    init(store: ReviewWorkspaceMetadataStore, service: ReviewWorkspaceGitService) {
+        self.store = store
+        self.service = service
+    }
+
+    func createWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        workspaceID: UUID,
+        now: Date
+    ) throws -> ReviewWorkspaceRecord {
+        let record = try service.createWorkspace(for: pullRequest, workspaceID: workspaceID, now: now)
+        try store.upsert(record)
+        return record
+    }
+
+    func restoreWorkspaces(now: Date) throws -> ReviewWorkspaceReconciliationResult {
+        let records = try store.load()
+        let result = try service.reconcile(records, now: now)
+        try store.save(result.records)
+        return result
+    }
+
+    func cleanupWorkspace(_ record: ReviewWorkspaceRecord, now: Date) throws -> ReviewWorkspaceCleanupResult {
+        let result = service.cleanupWorkspace(record, now: now)
+        switch result {
+        case .removed:
+            try store.remove(workspaceID: record.id)
+        case .cleanupRequired(let updated):
+            try store.upsert(updated)
+        }
+        return result
+    }
+}
+
 struct ReviewWorkspace: Identifiable, Equatable {
     enum State: Equatable {
         case preparing
+        case available
         case running
         case terminating
         case exited(Int32)
+        case missing(String)
+        case cleanupRequired(String)
         case failed(String)
     }
 
@@ -14,6 +65,7 @@ struct ReviewWorkspace: Identifiable, Equatable {
     let id: UUID
     var displayName: String
     var state: State
+    var record: ReviewWorkspaceRecord?
 
     var paneName: String { "review-workspace:\(id.uuidString.lowercased())" }
 }
@@ -22,8 +74,19 @@ struct ReviewWorkspace: Identifiable, Equatable {
 final class ReviewWorkspaceManager: ObservableObject {
     @Published private(set) var workspaces: [ReviewWorkspace] = []
     private let terminalManager: TerminalManager
+    private let lifecycleController: ReviewWorkspaceLifecycleControlling?
+    private let now: () -> Date
 
-    init(terminalManager: TerminalManager) { self.terminalManager = terminalManager }
+    init(
+        terminalManager: TerminalManager,
+        lifecycleController: ReviewWorkspaceLifecycleControlling? = nil,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.terminalManager = terminalManager
+        self.lifecycleController = lifecycleController
+        self.now = now
+        restoreManagedWorkspaces()
+    }
 
     func workspace(forPaneName paneName: String) -> ReviewWorkspace? {
         workspaces.first { $0.paneName == paneName }
@@ -31,10 +94,40 @@ final class ReviewWorkspaceManager: ObservableObject {
 
     @discardableResult
     func createFixtureWorkspace(named name: String, workspaceID: UUID = UUID()) -> ReviewWorkspace? {
-        let workspace = ReviewWorkspace(id: workspaceID, displayName: name, state: .preparing)
+        let workspace = ReviewWorkspace(id: workspaceID, displayName: name, state: .preparing, record: nil)
         guard terminalManager.reserveWorkspacePane(workspace.paneName) else { return nil }
         workspaces.append(workspace)
         return workspace
+    }
+
+    @discardableResult
+    func attachManagedWorkspace(
+        _ record: ReviewWorkspaceRecord,
+        displayName: String,
+        initialState: ReviewWorkspace.State? = nil
+    ) -> ReviewWorkspace? {
+        let initialState = initialState ?? restoredState(for: record)
+        let workspace = ReviewWorkspace(
+            id: record.id, displayName: displayName, state: initialState, record: record)
+        guard terminalManager.reserveWorkspacePane(workspace.paneName) else { return nil }
+        workspaces.append(workspace)
+        return workspace
+    }
+
+    @discardableResult
+    func createManagedWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        displayName: String,
+        workspaceID: UUID = UUID()
+    ) -> ReviewWorkspace? {
+        guard let lifecycleController else { return nil }
+        do {
+            let record = try lifecycleController.createWorkspace(
+                for: pullRequest, workspaceID: workspaceID, now: now())
+            return attachManagedWorkspace(record, displayName: displayName, initialState: .preparing)
+        } catch {
+            return nil
+        }
     }
 
     func install(_ session: TerminalProcessSession, for workspaceID: UUID) {
@@ -46,7 +139,7 @@ final class ReviewWorkspaceManager: ObservableObject {
 
     func requestTermination(for workspaceID: UUID) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
-              workspaces[index].state == .running
+            workspaces[index].state == .running
         else {
             return
         }
@@ -57,29 +150,87 @@ final class ReviewWorkspaceManager: ObservableObject {
     func reportTerminalExit(for workspaceID: UUID, exitCode: Int32?) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         switch workspaces[index].state {
-        case .preparing, .running, .terminating: break
-        case .exited, .failed: return
+        case .preparing, .available, .running, .terminating: break
+        case .exited, .missing, .cleanupRequired, .failed: return
         }
         terminalManager.workspaceProcessTerminated(workspaces[index].paneName, exitCode: exitCode)
-        workspaces[index].state = .exited(exitCode ?? -1)
+        guard let record = workspaces[index].record, workspaces[index].state == .terminating, let lifecycleController
+        else {
+            workspaces[index].state = .exited(exitCode ?? -1)
+            return
+        }
+        do {
+            let cleanup = try lifecycleController.cleanupWorkspace(record, now: now())
+            switch cleanup {
+            case .removed:
+                workspaces[index].record = nil
+                workspaces[index].state = .exited(exitCode ?? -1)
+            case .cleanupRequired(let updated):
+                workspaces[index].record = updated
+                workspaces[index].state = .cleanupRequired("Cleanup required for \(updated.worktreePath.path).")
+            }
+        } catch {
+            workspaces[index].state = .cleanupRequired("Cleanup required for \(record.worktreePath.path).")
+        }
     }
 
     func reportSetupFailure(for workspaceID: UUID, message: String) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         switch workspaces[index].state {
         case .preparing, .running: break
-        case .terminating, .exited, .failed: return
+        case .available, .terminating, .exited, .missing, .cleanupRequired, .failed: return
         }
         workspaces[index].state = .failed(message)
+    }
+
+    func reportCleanupRequired(for workspaceID: UUID, message: String, record: ReviewWorkspaceRecord? = nil) {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+        terminalManager.workspaceProcessTerminated(workspaces[index].paneName, exitCode: nil)
+        if let record {
+            workspaces[index].record = record
+        }
+        workspaces[index].state = .cleanupRequired(message)
     }
 
     func dismiss(_ workspaceID: UUID) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         switch workspaces[index].state {
-        case .exited, .failed: break
+        case .available, .exited, .missing, .cleanupRequired, .failed: break
         default: return
         }
         terminalManager.releaseWorkspacePane(workspaces[index].paneName)
         workspaces.remove(at: index)
+    }
+
+    private func restoreManagedWorkspaces() {
+        guard let lifecycleController else { return }
+        do {
+            let result = try lifecycleController.restoreWorkspaces(now: now())
+            for record in result.records {
+                let displayName = "PR #\(record.pullRequestNumber)"
+                _ = attachManagedWorkspace(record, displayName: displayName)
+            }
+            for orphaned in result.orphanedWorktrees {
+                let workspaceID = UUID()
+                let workspace = ReviewWorkspace(
+                    id: workspaceID,
+                    displayName: orphaned.worktreePath.lastPathComponent,
+                    state: .cleanupRequired("Orphaned managed worktree at \(orphaned.worktreePath.path)."),
+                    record: nil)
+                guard terminalManager.reserveWorkspacePane(workspace.paneName) else { continue }
+                workspaces.append(workspace)
+            }
+        } catch {}
+    }
+
+    private func restoredState(for record: ReviewWorkspaceRecord) -> ReviewWorkspace.State {
+        switch record.state {
+        case .active:
+            .available
+        case .cleanupRequired:
+            .cleanupRequired("Cleanup required for \(record.worktreePath.path).")
+        case .missing:
+            .missing("Managed worktree missing at \(record.worktreePath.path).")
+        }
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -76,6 +76,7 @@ final class ReviewWorkspaceManager: ObservableObject {
     private let terminalManager: TerminalManager
     private let lifecycleController: ReviewWorkspaceLifecycleControlling?
     private let now: () -> Date
+    private var didRestoreManagedWorkspaces = false
 
     init(
         terminalManager: TerminalManager,
@@ -85,7 +86,6 @@ final class ReviewWorkspaceManager: ObservableObject {
         self.terminalManager = terminalManager
         self.lifecycleController = lifecycleController
         self.now = now
-        restoreManagedWorkspaces()
     }
 
     func workspace(forPaneName paneName: String) -> ReviewWorkspace? {
@@ -200,6 +200,12 @@ final class ReviewWorkspaceManager: ObservableObject {
         }
         terminalManager.releaseWorkspacePane(workspaces[index].paneName)
         workspaces.remove(at: index)
+    }
+
+    func restoreManagedWorkspacesIfNeeded() {
+        guard !didRestoreManagedWorkspaces else { return }
+        didRestoreManagedWorkspaces = true
+        restoreManagedWorkspaces()
     }
 
     private func restoreManagedWorkspaces() {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspaceLifecycle.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspaceLifecycle.swift
@@ -1,0 +1,321 @@
+import Foundation
+
+enum ReviewWorkspacePersistenceState: String, Codable, Equatable {
+    case active
+    case cleanupRequired
+    case missing
+}
+
+struct ReviewWorkspaceRecord: Codable, Equatable, Identifiable {
+    // swiftlint:disable:next identifier_name
+    let id: UUID
+    let repository: RepositoryIdentity
+    let pullRequestNumber: Int
+    let pullRequestURL: URL
+    let sourceClonePath: URL
+    let sourceCloneRemoteURL: String
+    let headRepository: RepositoryIdentity
+    let headCloneURL: URL
+    let headBranch: String
+    let headSHA: String
+    let worktreePath: URL
+    let createdAt: Date
+    var updatedAt: Date
+    var state: ReviewWorkspacePersistenceState
+}
+
+struct OrphanedReviewWorkspace: Equatable {
+    let sourceClonePath: URL
+    let worktreePath: URL
+}
+
+struct ReviewWorkspaceReconciliationResult: Equatable {
+    let records: [ReviewWorkspaceRecord]
+    let orphanedWorktrees: [OrphanedReviewWorkspace]
+}
+
+enum ReviewWorkspaceCleanupResult: Equatable {
+    case removed
+    case cleanupRequired(ReviewWorkspaceRecord)
+}
+
+enum ReviewWorkspaceLifecycleError: Error, Equatable {
+    case invalidHeadSHA
+    case worktreePathInsideSourceClone
+    case worktreePathOutsideManagedRoot
+    case fetchedRefMismatch(expected: String, actual: String)
+    case checkedOutHeadMismatch(expected: String, actual: String)
+}
+
+struct ReviewWorkspacePaths {
+    let root: URL
+
+    var metadataFileURL: URL {
+        root.appendingPathComponent("metadata.json", isDirectory: false)
+    }
+
+    func worktreePath(for pullRequest: ResolvedPullRequest) throws -> URL {
+        guard pullRequest.headSHA.range(of: #"^[0-9a-fA-F]{7,40}$"#, options: .regularExpression) != nil else {
+            throw ReviewWorkspaceLifecycleError.invalidHeadSHA
+        }
+
+        let shortSHA = String(pullRequest.headSHA.prefix(12)).lowercased()
+        let candidate =
+            root
+            .appendingPathComponent(pullRequest.base.host, isDirectory: true)
+            .appendingPathComponent(pullRequest.base.owner, isDirectory: true)
+            .appendingPathComponent(pullRequest.base.name, isDirectory: true)
+            .appendingPathComponent("pr-\(pullRequest.number)-\(shortSHA)", isDirectory: true)
+            .standardizedFileURL
+
+        let managedRoot = root.standardizedFileURL
+        guard Self.isDescendant(candidate, of: managedRoot) else {
+            throw ReviewWorkspaceLifecycleError.worktreePathOutsideManagedRoot
+        }
+        let sourceClone = pullRequest.localClonePath.standardizedFileURL
+        guard !Self.isDescendant(candidate, of: sourceClone) else {
+            throw ReviewWorkspaceLifecycleError.worktreePathInsideSourceClone
+        }
+        return candidate
+    }
+
+    private static func isDescendant(_ candidate: URL, of parent: URL) -> Bool {
+        let parentPath = parent.path.hasSuffix("/") ? parent.path : parent.path + "/"
+        let candidatePath = candidate.path
+        return candidatePath == parent.path || candidatePath.hasPrefix(parentPath)
+    }
+}
+
+struct ReviewWorkspaceMetadataStore {
+    let paths: ReviewWorkspacePaths
+    let fileManager: FileManager
+
+    init(paths: ReviewWorkspacePaths, fileManager: FileManager = .default) {
+        self.paths = paths
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [ReviewWorkspaceRecord] {
+        let url = paths.metadataFileURL
+        guard fileManager.fileExists(atPath: url.path) else { return [] }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder.reviewWorkspaceDecoder.decode([ReviewWorkspaceRecord].self, from: data)
+    }
+
+    func save(_ records: [ReviewWorkspaceRecord]) throws {
+        let directory = paths.root
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder.reviewWorkspaceEncoder.encode(records)
+        try data.write(to: paths.metadataFileURL, options: .atomic)
+    }
+
+    func upsert(_ record: ReviewWorkspaceRecord) throws {
+        var records = try load()
+        if let index = records.firstIndex(where: { $0.id == record.id }) {
+            records[index] = record
+        } else {
+            records.append(record)
+        }
+        try save(records)
+    }
+
+    func remove(workspaceID: UUID) throws {
+        let records = try load().filter { $0.id != workspaceID }
+        try save(records)
+    }
+}
+
+extension JSONEncoder {
+    fileprivate static var reviewWorkspaceEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+extension JSONDecoder {
+    fileprivate static var reviewWorkspaceDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+struct ReviewWorkspaceGitService {
+    let runner: CommandRunning
+    let git: URL
+    let fileManager: FileManager
+    let paths: ReviewWorkspacePaths
+
+    init(
+        runner: CommandRunning = ProcessCommandRunner(),
+        git: URL,
+        fileManager: FileManager = .default,
+        paths: ReviewWorkspacePaths
+    ) {
+        self.runner = runner
+        self.git = git
+        self.fileManager = fileManager
+        self.paths = paths
+    }
+
+    func privateRef(for pullRequest: ResolvedPullRequest) -> String {
+        "refs/gh-orbit/review-worktrees/\(pullRequest.base.host)/\(pullRequest.base.owner)/\(pullRequest.base.name)/pr-\(pullRequest.number)/\(pullRequest.headSHA.lowercased())"
+    }
+
+    func createWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        workspaceID: UUID = UUID(),
+        now: Date = Date()
+    ) throws -> ReviewWorkspaceRecord {
+        let worktreePath = try paths.worktreePath(for: pullRequest)
+        try fileManager.createDirectory(at: paths.root, withIntermediateDirectories: true)
+
+        let localRef = privateRef(for: pullRequest)
+        try materializePrivateRef(for: pullRequest, localRef: localRef)
+
+        let fetchedSHA = try resolveRevision(localRef, workingDirectory: pullRequest.localClonePath)
+        guard fetchedSHA == pullRequest.headSHA else {
+            throw ReviewWorkspaceLifecycleError.fetchedRefMismatch(
+                expected: pullRequest.headSHA, actual: fetchedSHA)
+        }
+
+        _ = try runner.run(
+            .init(
+                executable: git,
+                arguments: ["worktree", "add", "--detach", worktreePath.path, localRef],
+                workingDirectory: pullRequest.localClonePath))
+
+        let checkedOutSHA = try resolveRevision("HEAD", workingDirectory: worktreePath)
+        guard checkedOutSHA == pullRequest.headSHA else {
+            throw ReviewWorkspaceLifecycleError.checkedOutHeadMismatch(
+                expected: pullRequest.headSHA, actual: checkedOutSHA)
+        }
+
+        return .init(
+            id: workspaceID,
+            repository: pullRequest.base,
+            pullRequestNumber: pullRequest.number,
+            pullRequestURL: pullRequest.url,
+            sourceClonePath: pullRequest.localClonePath,
+            sourceCloneRemoteURL: pullRequest.localCloneRemoteURL,
+            headRepository: pullRequest.head,
+            headCloneURL: pullRequest.headCloneURL,
+            headBranch: pullRequest.headBranch,
+            headSHA: pullRequest.headSHA,
+            worktreePath: worktreePath,
+            createdAt: now,
+            updatedAt: now,
+            state: .active)
+    }
+
+    func cleanupWorkspace(_ record: ReviewWorkspaceRecord, now: Date = Date()) -> ReviewWorkspaceCleanupResult {
+        do {
+            _ = try runner.run(
+                .init(
+                    executable: git,
+                    arguments: ["worktree", "remove", record.worktreePath.path],
+                    workingDirectory: record.sourceClonePath))
+            return .removed
+        } catch {
+            var updated = record
+            updated.state = .cleanupRequired
+            updated.updatedAt = now
+            return .cleanupRequired(updated)
+        }
+    }
+
+    func reconcile(
+        _ records: [ReviewWorkspaceRecord],
+        now: Date = Date()
+    ) throws -> ReviewWorkspaceReconciliationResult {
+        let groupedByClone = Dictionary(grouping: records, by: \.sourceClonePath)
+        var reconciledRecords: [ReviewWorkspaceRecord] = []
+        var orphanedWorktrees: [OrphanedReviewWorkspace] = []
+
+        for (clonePath, cloneRecords) in groupedByClone {
+            let listedPaths = try Set(listManagedWorktrees(sourceClonePath: clonePath))
+            let knownPaths = Set(cloneRecords.map(\.worktreePath))
+
+            for record in cloneRecords {
+                var updated = record
+                if listedPaths.contains(record.worktreePath) {
+                    if updated.state == .missing {
+                        updated.state = .active
+                        updated.updatedAt = now
+                    }
+                } else if updated.state != .missing {
+                    updated.state = .missing
+                    updated.updatedAt = now
+                }
+                reconciledRecords.append(updated)
+            }
+
+            let managedRoot = paths.root.standardizedFileURL
+            for path in listedPaths.subtracting(knownPaths) where Self.isDescendant(path, of: managedRoot) {
+                orphanedWorktrees.append(.init(sourceClonePath: clonePath, worktreePath: path))
+            }
+        }
+
+        return .init(
+            records: reconciledRecords.sorted { $0.worktreePath.path < $1.worktreePath.path },
+            orphanedWorktrees: orphanedWorktrees.sorted { $0.worktreePath.path < $1.worktreePath.path })
+    }
+
+    private func materializePrivateRef(for pullRequest: ResolvedPullRequest, localRef: String) throws {
+        let remote = remoteArgument(for: pullRequest.headCloneURL)
+        let exactRefSpec = "\(pullRequest.headSHA):\(localRef)"
+
+        do {
+            _ = try runner.run(
+                .init(
+                    executable: git,
+                    arguments: ["fetch", "--no-tags", "--force", remote, exactRefSpec],
+                    workingDirectory: pullRequest.localClonePath))
+            return
+        } catch {
+            let branchRefSpec = "+refs/heads/\(pullRequest.headBranch):\(localRef)"
+            _ = try runner.run(
+                .init(
+                    executable: git,
+                    arguments: ["fetch", "--no-tags", "--force", remote, branchRefSpec],
+                    workingDirectory: pullRequest.localClonePath))
+        }
+    }
+
+    private func remoteArgument(for url: URL) -> String {
+        url.isFileURL ? url.path : url.absoluteString
+    }
+
+    private func resolveRevision(_ revision: String, workingDirectory: URL) throws -> String {
+        try runner.run(
+            .init(
+                executable: git,
+                arguments: ["rev-parse", revision],
+                workingDirectory: workingDirectory)
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func listManagedWorktrees(sourceClonePath: URL) throws -> [URL] {
+        let output = try runner.run(
+            .init(
+                executable: git,
+                arguments: ["worktree", "list", "--porcelain"],
+                workingDirectory: sourceClonePath))
+
+        return
+            output
+            .split(separator: "\n")
+            .compactMap { line -> URL? in
+                guard line.hasPrefix("worktree ") else { return nil }
+                return URL(fileURLWithPath: String(line.dropFirst("worktree ".count))).standardizedFileURL
+            }
+    }
+
+    private static func isDescendant(_ candidate: URL, of parent: URL) -> Bool {
+        let parentPath = parent.path.hasSuffix("/") ? parent.path : parent.path + "/"
+        let candidatePath = candidate.standardizedFileURL.path
+        return candidatePath == parent.path || candidatePath.hasPrefix(parentPath)
+    }
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceLifecycleTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceLifecycleTests.swift
@@ -1,0 +1,331 @@
+import Foundation
+import Testing
+
+@testable import OrbitCockpit
+
+@Suite("Review workspace exact-commit lifecycle")
+struct ReviewWorkspaceLifecycleTests {
+    @Test
+    func buildsDeterministicManagedPathOutsideSourceClone() throws {
+        let paths = ReviewWorkspacePaths(root: URL(fileURLWithPath: "/tmp/root", isDirectory: true))
+        let pullRequest = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: URL(fileURLWithPath: "/tmp/source/orbit", isDirectory: true),
+            localCloneRemoteURL: "git@github.example.com:acme/orbit.git",
+            number: 42,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/42")!,
+            head: .init(host: "github.example.com", owner: "contributor", name: "orbit-fork"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/remotes/orbit-fork.git", isDirectory: true),
+            headBranch: "feature/review-worktree",
+            headSHA: "0123456789abcdef0123456789abcdef01234567")
+
+        let worktreePath = try paths.worktreePath(for: pullRequest)
+
+        #expect(
+            worktreePath.path
+                == "/tmp/root/github.example.com/acme/orbit/pr-42-0123456789ab")
+        #expect(!worktreePath.path.hasPrefix("/tmp/source/orbit/"))
+    }
+
+    @Test
+    func createsDetachedWorktreeAtExactCommit() throws {
+        let fixture = try GitFixture()
+        let remote = try fixture.createBareRemote(named: "origin.git")
+        let seed = try fixture.clone(remote: remote, into: "seed")
+        let headSHA = try fixture.commitFile(
+            repository: seed, relativePath: "README.md", contents: "hello main\n", message: "initial")
+        _ = try fixture.runGit(["push", "origin", "main"], in: seed)
+        let localClone = try fixture.clone(remote: remote, into: "local")
+
+        let service = ReviewWorkspaceGitService(
+            git: fixture.git,
+            paths: .init(root: fixture.root.appendingPathComponent("managed-root", isDirectory: true)))
+        let pullRequest = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: remote.path,
+            number: 7,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/7")!,
+            head: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: remote,
+            headBranch: "main",
+            headSHA: headSHA)
+
+        let workspaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let record = try service.createWorkspace(
+            for: pullRequest,
+            workspaceID: workspaceID,
+            now: Date(timeIntervalSince1970: 10))
+
+        let fetchedSHA = try fixture.revParse(service.privateRef(for: pullRequest), in: localClone)
+        let worktreeSHA = try fixture.revParse("HEAD", in: record.worktreePath)
+        let headState = try fixture.runGit(["branch", "--show-current"], in: record.worktreePath)
+
+        #expect(record.state == .active)
+        #expect(record.headSHA == headSHA)
+        #expect(fetchedSHA == headSHA)
+        #expect(worktreeSHA == headSHA)
+        #expect(headState.isEmpty)
+    }
+
+    @Test
+    func fetchesForkHeadWithoutConfiguredRemoteAndVerifiesExactCommit() throws {
+        let fixture = try GitFixture()
+        let baseRemote = try fixture.createBareRemote(named: "origin.git")
+        let baseSeed = try fixture.clone(remote: baseRemote, into: "base-seed")
+        _ = try fixture.commitFile(
+            repository: baseSeed, relativePath: "README.md", contents: "base\n", message: "base")
+        _ = try fixture.runGit(["push", "origin", "main"], in: baseSeed)
+
+        let forkRemote = try fixture.createBareRemote(named: "fork.git")
+        let forkSeed = try fixture.clone(remote: baseRemote, into: "fork-seed")
+        _ = try fixture.runGit(["remote", "add", "fork", forkRemote.path], in: forkSeed)
+        _ = try fixture.runGit(["checkout", "-b", "feature/review"], in: forkSeed)
+        let forkHeadSHA = try fixture.commitFile(
+            repository: forkSeed, relativePath: "feature.txt", contents: "fork head\n", message: "feature")
+        _ = try fixture.runGit(["push", "fork", "feature/review"], in: forkSeed)
+
+        let localClone = try fixture.clone(remote: baseRemote, into: "local")
+
+        let service = ReviewWorkspaceGitService(
+            git: fixture.git,
+            paths: .init(root: fixture.root.appendingPathComponent("managed-root", isDirectory: true)))
+        let pullRequest = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: baseRemote.path,
+            number: 12,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/12")!,
+            head: .init(host: "github.example.com", owner: "contributor", name: "fork"),
+            headCloneURL: forkRemote,
+            headBranch: "feature/review",
+            headSHA: forkHeadSHA)
+
+        let record = try service.createWorkspace(for: pullRequest)
+
+        let fetchedSHA = try fixture.revParse(service.privateRef(for: pullRequest), in: localClone)
+        let worktreeSHA = try fixture.revParse("HEAD", in: record.worktreePath)
+        let remotes = try fixture.runGit(["remote"], in: localClone)
+
+        #expect(fetchedSHA == forkHeadSHA)
+        #expect(worktreeSHA == forkHeadSHA)
+        #expect(!remotes.split(whereSeparator: \.isNewline).contains("fork"))
+    }
+
+    @Test
+    func cleanTerminationRemovesWorktreeAndMetadata() throws {
+        let fixture = try GitFixture()
+        let remote = try fixture.createBareRemote(named: "origin.git")
+        let seed = try fixture.clone(remote: remote, into: "seed")
+        let headSHA = try fixture.commitFile(
+            repository: seed, relativePath: "README.md", contents: "hello\n", message: "initial")
+        _ = try fixture.runGit(["push", "origin", "main"], in: seed)
+        let localClone = try fixture.clone(remote: remote, into: "local")
+
+        let paths = ReviewWorkspacePaths(root: fixture.root.appendingPathComponent("managed-root", isDirectory: true))
+        let service = ReviewWorkspaceGitService(git: fixture.git, paths: paths)
+        let store = ReviewWorkspaceMetadataStore(paths: paths)
+        let pullRequest = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: remote.path,
+            number: 4,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/4")!,
+            head: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: remote,
+            headBranch: "main",
+            headSHA: headSHA)
+
+        let record = try service.createWorkspace(for: pullRequest)
+        try store.upsert(record)
+        #expect(FileManager.default.fileExists(atPath: record.worktreePath.path))
+
+        let cleanup = service.cleanupWorkspace(record, now: Date(timeIntervalSince1970: 20))
+        switch cleanup {
+        case .removed:
+            try store.remove(workspaceID: record.id)
+        case .cleanupRequired:
+            Issue.record("expected clean worktree removal")
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: record.worktreePath.path))
+        #expect(try store.load().isEmpty)
+    }
+
+    @Test
+    func dirtyTerminationPreservesWorktreeAndTransitionsToCleanupRequired() throws {
+        let fixture = try GitFixture()
+        let remote = try fixture.createBareRemote(named: "origin.git")
+        let seed = try fixture.clone(remote: remote, into: "seed")
+        let headSHA = try fixture.commitFile(
+            repository: seed, relativePath: "README.md", contents: "hello\n", message: "initial")
+        _ = try fixture.runGit(["push", "origin", "main"], in: seed)
+        let localClone = try fixture.clone(remote: remote, into: "local")
+
+        let service = ReviewWorkspaceGitService(
+            git: fixture.git,
+            paths: .init(root: fixture.root.appendingPathComponent("managed-root", isDirectory: true)))
+        let pullRequest = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: remote.path,
+            number: 9,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/9")!,
+            head: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: remote,
+            headBranch: "main",
+            headSHA: headSHA)
+        let record = try service.createWorkspace(for: pullRequest)
+
+        let dirtyFile = record.worktreePath.appendingPathComponent("README.md")
+        try "modified\n".write(to: dirtyFile, atomically: true, encoding: .utf8)
+
+        let cleanup = service.cleanupWorkspace(record, now: Date(timeIntervalSince1970: 30))
+
+        switch cleanup {
+        case .removed:
+            Issue.record("expected cleanupRequired for dirty worktree")
+        case .cleanupRequired(let updated):
+            #expect(updated.state == .cleanupRequired)
+            #expect(updated.updatedAt == Date(timeIntervalSince1970: 30))
+            #expect(FileManager.default.fileExists(atPath: updated.worktreePath.path))
+        }
+    }
+
+    @Test
+    func reconciliationMarksMissingAndSurfacesOrphanedManagedWorktrees() throws {
+        let fixture = try GitFixture()
+        let remote = try fixture.createBareRemote(named: "origin.git")
+        let seed = try fixture.clone(remote: remote, into: "seed")
+        let headSHA = try fixture.commitFile(
+            repository: seed, relativePath: "README.md", contents: "hello\n", message: "initial")
+        _ = try fixture.runGit(["push", "origin", "main"], in: seed)
+        let localClone = try fixture.clone(remote: remote, into: "local")
+
+        let paths = ReviewWorkspacePaths(root: fixture.root.appendingPathComponent("managed-root", isDirectory: true))
+        let service = ReviewWorkspaceGitService(git: fixture.git, paths: paths)
+        let first = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: remote.path,
+            number: 1,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/1")!,
+            head: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: remote,
+            headBranch: "main",
+            headSHA: headSHA)
+        let second = ResolvedPullRequest(
+            base: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            localClonePath: localClone,
+            localCloneRemoteURL: remote.path,
+            number: 2,
+            url: URL(string: "https://github.example.com/acme/orbit/pull/2")!,
+            head: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: remote,
+            headBranch: "main",
+            headSHA: headSHA)
+
+        let existingRecord = try service.createWorkspace(for: first)
+        let missingRecord = try service.createWorkspace(for: second)
+        _ = try fixture.runGit(["worktree", "remove", missingRecord.worktreePath.path], in: localClone)
+
+        let orphanPath = paths.root
+            .appendingPathComponent("github.example.com", isDirectory: true)
+            .appendingPathComponent("acme", isDirectory: true)
+            .appendingPathComponent("orbit", isDirectory: true)
+            .appendingPathComponent("pr-999-orphaned", isDirectory: true)
+        _ = try fixture.runGit(["worktree", "add", "--detach", orphanPath.path, headSHA], in: localClone)
+
+        let result = try service.reconcile(
+            [existingRecord, missingRecord],
+            now: Date(timeIntervalSince1970: 40))
+
+        let reconciledExisting = try #require(result.records.first { $0.id == existingRecord.id })
+        let reconciledMissing = try #require(result.records.first { $0.id == missingRecord.id })
+
+        #expect(reconciledExisting.state == .active)
+        #expect(reconciledMissing.state == .missing)
+        #expect(reconciledMissing.updatedAt == Date(timeIntervalSince1970: 40))
+        #expect(
+            result.orphanedWorktrees == [
+                .init(sourceClonePath: localClone, worktreePath: orphanPath.standardizedFileURL)
+            ])
+    }
+
+    @Test
+    func metadataStoreRoundTripsPersistedWorkspaceRecords() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = ReviewWorkspacePaths(root: root)
+        let store = ReviewWorkspaceMetadataStore(paths: paths)
+        let workspaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let record = ReviewWorkspaceRecord(
+            id: workspaceID,
+            repository: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 1,
+            pullRequestURL: URL(string: "https://github.example.com/acme/orbit/pull/1")!,
+            sourceClonePath: URL(fileURLWithPath: "/tmp/source"),
+            sourceCloneRemoteURL: "git@github.example.com:acme/orbit.git",
+            headRepository: .init(host: "github.example.com", owner: "acme", name: "orbit"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/origin.git"),
+            headBranch: "main",
+            headSHA: "0123456789abcdef0123456789abcdef01234567",
+            worktreePath: URL(fileURLWithPath: "/tmp/worktree"),
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            state: .cleanupRequired)
+
+        try store.upsert(record)
+        #expect(try store.load() == [record])
+
+        try store.remove(workspaceID: record.id)
+        #expect(try store.load().isEmpty)
+    }
+}
+
+private struct GitFixture {
+    let root: URL
+    let git = URL(fileURLWithPath: "/usr/bin/git")
+    private let runner = ProcessCommandRunner()
+    private let fileManager = FileManager.default
+
+    init() throws {
+        let base = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+        root = base
+    }
+
+    func createBareRemote(named name: String) throws -> URL {
+        let remote = root.appendingPathComponent(name, isDirectory: true)
+        _ = try runGit(["init", "--bare", remote.path], in: root)
+        return remote
+    }
+
+    func clone(remote: URL, into name: String) throws -> URL {
+        let destination = root.appendingPathComponent(name, isDirectory: true)
+        _ = try runGit(["clone", remote.path, destination.path], in: root)
+        _ = try runGit(["config", "user.name", "Orbit Test"], in: destination)
+        _ = try runGit(["config", "user.email", "orbit@example.com"], in: destination)
+        return destination
+    }
+
+    func commitFile(repository: URL, relativePath: String, contents: String, message: String) throws -> String {
+        let fileURL = repository.appendingPathComponent(relativePath, isDirectory: false)
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        _ = try runGit(["add", relativePath], in: repository)
+        _ = try runGit(["commit", "-m", message], in: repository)
+        return try revParse("HEAD", in: repository)
+    }
+
+    func revParse(_ revision: String, in repository: URL) throws -> String {
+        try runGit(["rev-parse", revision], in: repository).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func runGit(_ arguments: [String], in repository: URL) throws -> String {
+        try runner.run(.init(executable: git, arguments: arguments, workingDirectory: repository))
+    }
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -127,12 +127,15 @@ struct ReviewWorkspaceTests {
             ])
 
         let manager = ReviewWorkspaceManager(terminalManager: terminalManager, lifecycleController: lifecycle)
+        manager.restoreManagedWorkspacesIfNeeded()
 
         #expect(lifecycle.restoreCallCount == 1)
         #expect(manager.workspaces.count == 2)
         #expect(manager.workspaces[0].state == .available)
         #expect(manager.workspaces[0].record == record)
         #expect(manager.workspaces[1].state == .cleanupRequired("Orphaned managed worktree at /tmp/orphan."))
+        manager.restoreManagedWorkspacesIfNeeded()
+        #expect(lifecycle.restoreCallCount == 1)
     }
 
     @Test @MainActor

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -1,6 +1,50 @@
+import Foundation
 import Testing
 
 @testable import OrbitCockpit
+
+private final class MockReviewWorkspaceLifecycleController: ReviewWorkspaceLifecycleControlling {
+    var restoredResult: ReviewWorkspaceReconciliationResult = .init(records: [], orphanedWorktrees: [])
+    var createdRecord: ReviewWorkspaceRecord?
+    var cleanupResult: ReviewWorkspaceCleanupResult = .removed
+    var restoreCallCount = 0
+    var cleanupCalls: [ReviewWorkspaceRecord] = []
+
+    func createWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        workspaceID: UUID,
+        now: Date
+    ) throws -> ReviewWorkspaceRecord {
+        if let createdRecord {
+            return createdRecord
+        }
+        return .init(
+            id: workspaceID,
+            repository: pullRequest.base,
+            pullRequestNumber: pullRequest.number,
+            pullRequestURL: pullRequest.url,
+            sourceClonePath: pullRequest.localClonePath,
+            sourceCloneRemoteURL: pullRequest.localCloneRemoteURL,
+            headRepository: pullRequest.head,
+            headCloneURL: pullRequest.headCloneURL,
+            headBranch: pullRequest.headBranch,
+            headSHA: pullRequest.headSHA,
+            worktreePath: URL(fileURLWithPath: "/tmp/\(workspaceID.uuidString)", isDirectory: true),
+            createdAt: now,
+            updatedAt: now,
+            state: .active)
+    }
+
+    func restoreWorkspaces(now: Date) throws -> ReviewWorkspaceReconciliationResult {
+        restoreCallCount += 1
+        return restoredResult
+    }
+
+    func cleanupWorkspace(_ record: ReviewWorkspaceRecord, now: Date) throws -> ReviewWorkspaceCleanupResult {
+        cleanupCalls.append(record)
+        return cleanupResult
+    }
+}
 
 @Suite("Review workspace lifecycle")
 struct ReviewWorkspaceTests {
@@ -51,5 +95,96 @@ struct ReviewWorkspaceTests {
         manager.dismiss(first.id)
         #expect(manager.workspace(forPaneName: first.paneName) == nil)
         #expect(manager.workspace(forPaneName: second.paneName)?.state == .failed("setup failed"))
+    }
+
+    @Test @MainActor
+    func restoresPersistedManagedWorkspacesAndOrphansOnStartup() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let workspaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let pullRequestURL = try #require(URL(string: "https://github.com/acme/orbit/pull/12"))
+        let record = ReviewWorkspaceRecord(
+            id: workspaceID,
+            repository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 12,
+            pullRequestURL: pullRequestURL,
+            sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+            sourceCloneRemoteURL: "git@github.com:acme/orbit.git",
+            headRepository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/origin.git", isDirectory: true),
+            headBranch: "main",
+            headSHA: "0123456789abcdef0123456789abcdef01234567",
+            worktreePath: URL(fileURLWithPath: "/tmp/worktree", isDirectory: true),
+            createdAt: .distantPast,
+            updatedAt: .distantPast,
+            state: .active)
+        lifecycle.restoredResult = .init(
+            records: [record],
+            orphanedWorktrees: [
+                .init(
+                    sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+                    worktreePath: URL(fileURLWithPath: "/tmp/orphan", isDirectory: true))
+            ])
+
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager, lifecycleController: lifecycle)
+
+        #expect(lifecycle.restoreCallCount == 1)
+        #expect(manager.workspaces.count == 2)
+        #expect(manager.workspaces[0].state == .available)
+        #expect(manager.workspaces[0].record == record)
+        #expect(manager.workspaces[1].state == .cleanupRequired("Orphaned managed worktree at /tmp/orphan."))
+    }
+
+    @Test @MainActor
+    func terminalExitTriggersManagedCleanupHandling() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager, lifecycleController: lifecycle)
+        let workspaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let pullRequestURL = try #require(URL(string: "https://github.com/acme/orbit/pull/12"))
+        let record = ReviewWorkspaceRecord(
+            id: workspaceID,
+            repository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 12,
+            pullRequestURL: pullRequestURL,
+            sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+            sourceCloneRemoteURL: "git@github.com:acme/orbit.git",
+            headRepository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/origin.git", isDirectory: true),
+            headBranch: "main",
+            headSHA: "0123456789abcdef0123456789abcdef01234567",
+            worktreePath: URL(fileURLWithPath: "/tmp/worktree", isDirectory: true),
+            createdAt: .distantPast,
+            updatedAt: .distantPast,
+            state: .active)
+        let workspace = try #require(
+            manager.attachManagedWorkspace(record, displayName: "PR #12", initialState: .preparing))
+        let session = MockTerminalSession()
+
+        manager.install(session, for: workspace.id)
+        let updatedRecord = ReviewWorkspaceRecord(
+            id: record.id,
+            repository: record.repository,
+            pullRequestNumber: record.pullRequestNumber,
+            pullRequestURL: record.pullRequestURL,
+            sourceClonePath: record.sourceClonePath,
+            sourceCloneRemoteURL: record.sourceCloneRemoteURL,
+            headRepository: record.headRepository,
+            headCloneURL: record.headCloneURL,
+            headBranch: record.headBranch,
+            headSHA: record.headSHA,
+            worktreePath: record.worktreePath,
+            createdAt: record.createdAt,
+            updatedAt: .now,
+            state: .cleanupRequired)
+        lifecycle.cleanupResult = .cleanupRequired(updatedRecord)
+
+        manager.requestTermination(for: workspace.id)
+        manager.reportTerminalExit(for: workspace.id, exitCode: 0)
+
+        #expect(lifecycle.cleanupCalls == [record])
+        #expect(
+            manager.workspace(forPaneName: workspace.paneName)?.state
+                == .cleanupRequired("Cleanup required for /tmp/worktree."))
     }
 }


### PR DESCRIPTION
## Summary
- add a native exact-commit review-worktree lifecycle that materializes immutable PR head SHAs into detached managed worktrees
- persist managed workspace metadata, reconcile saved records against `git worktree list --porcelain` at startup, and surface missing/orphaned worktrees for recovery
- wire lifecycle restore and termination cleanup into `OrbitCockpitApp` and `ReviewWorkspaceManager`, including `cleanupRequired` behavior for dirty or failed removals
- cover same-repo heads, fork heads, cleanup, reconciliation, and manager integration with local Git fixture tests

## Behavior
- fetch the immutable PR head SHA into a private namespaced local ref and verify that both the fetched ref and detached worktree `HEAD` match `ResolvedPullRequest.headSHA`
- create deterministic managed worktree paths under the configured app-managed root and keep them outside the source clone
- persist workspace identity, repository and PR metadata, source clone, worktree path, head SHA, timestamps, and lifecycle state
- attempt normal `git worktree remove` only after terminal shutdown; failed or dirty cleanup preserves the worktree and transitions the record to `cleanupRequired`
- restore persisted workspaces on startup and surface orphaned managed worktrees for manual recovery UX

## Testing
- `export HOME=$(pwd)/tmp/swift-home TMPDIR=$(pwd)/tmp; rtk swift test --package-path native/OrbitCockpit --disable-sandbox --build-path ./tmp/swift-build`
- `export GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home; rtk make native/check`
- `export GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home; rtk make check`

Refs #428
