### PR TITLE
feat(native): launch Codex in managed review workspaces (#431)

### DIFF
--- a/native/OrbitCockpit/Docs/CodexReviewPromptContract.md
+++ b/native/OrbitCockpit/Docs/CodexReviewPromptContract.md
@@ -1,0 +1,27 @@
+# Codex Review Prompt Contract
+
+Version: `gh-orbit-review-contract/v1`
+
+This contract defines the initial prompt sent to Codex CLI when Orbit Cockpit launches a managed review workspace session.
+
+Required context:
+
+- repository identity
+- pull request number and URL
+- head repository, branch, and SHA
+- prepared review worktree path
+- repository instructions loaded from `AGENTS.md` when available
+- review-only objective and expected terminal-only output
+
+Constraints:
+
+- launch Codex via direct executable and argument invocation
+- pass the prepared review worktree as the terminal launch working directory
+- do not interpolate PR metadata into a shell command
+- do not include clone URLs, credentials, tokens, or other secrets in the prompt
+- do not instruct Codex to push, merge, comment on GitHub, or persist structured review output in this phase
+
+Expected behavior:
+
+- Codex prints findings and completion status directly to the attached terminal session
+- Orbit Cockpit supervises only the terminal process lifecycle and does not parse or store structured review results

--- a/native/OrbitCockpit/Sources/OrbitCockpit/CodexReviewLauncher.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/CodexReviewLauncher.swift
@@ -119,7 +119,7 @@ struct CodexReviewPromptBuilder: CodexReviewPromptBuilding {
 
     func buildPrompt(for record: ReviewWorkspaceRecord) -> CodexReviewPromptContract {
         let instructions =
-            instructionReader.readInstructions(from: record.sourceClonePath)
+            instructionReader.readInstructions(from: record.worktreePath)
             ?? "No repository-specific AGENTS.md instructions were found."
 
         let renderedPrompt = """

--- a/native/OrbitCockpit/Sources/OrbitCockpit/CodexReviewLauncher.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/CodexReviewLauncher.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+struct TerminalLaunchRequest: Equatable {
+    let executable: URL
+    let arguments: [String]
+    let environment: [String: String]?
+    let currentDirectoryURL: URL?
+}
+
+@MainActor
+protocol TerminalSessionCreating {
+    func makeSession(
+        request: TerminalLaunchRequest,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession
+}
+
+protocol CodexExecutableResolving {
+    func resolve() throws -> URL
+}
+
+enum CodexExecutableResolutionError: Error, Equatable, LocalizedError {
+    case missingExecutable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingExecutable(let message):
+            message
+        }
+    }
+}
+
+struct CodexExecutableResolver: CodexExecutableResolving {
+    private let fileManager: FileManager
+    private let environment: [String: String]
+
+    init(fileManager: FileManager = .default, environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.fileManager = fileManager
+        self.environment = environment
+    }
+
+    func resolve() throws -> URL {
+        if let override = environment["CODEX_BIN"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if fileManager.isExecutableFile(atPath: url.path) {
+                return url
+            }
+        }
+
+        let paths = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+
+        for path in paths {
+            let url = URL(fileURLWithPath: path).appendingPathComponent("codex")
+            if fileManager.isExecutableFile(atPath: url.path) {
+                return url
+            }
+        }
+
+        let fallbacks = [
+            "/usr/local/bin/codex",
+            "/opt/homebrew/bin/codex",
+        ]
+
+        for path in fallbacks {
+            let url = URL(fileURLWithPath: path)
+            if fileManager.isExecutableFile(atPath: url.path) {
+                return url
+            }
+        }
+
+        throw CodexExecutableResolutionError.missingExecutable(
+            "Codex CLI not found. Install `codex` or set CODEX_BIN to the executable path.")
+    }
+}
+
+protocol RepositoryInstructionReading {
+    func readInstructions(from repositoryRoot: URL) -> String?
+}
+
+struct RepositoryInstructionFileReader: RepositoryInstructionReading {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func readInstructions(from repositoryRoot: URL) -> String? {
+        let url = repositoryRoot.appendingPathComponent("AGENTS.md", isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url),
+            let contents = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !contents.isEmpty
+        else {
+            return nil
+        }
+        return contents
+    }
+}
+
+struct CodexReviewPromptContract: Equatable {
+    static let version = 1
+
+    let renderedPrompt: String
+}
+
+protocol CodexReviewPromptBuilding {
+    func buildPrompt(for record: ReviewWorkspaceRecord) -> CodexReviewPromptContract
+}
+
+struct CodexReviewPromptBuilder: CodexReviewPromptBuilding {
+    let instructionReader: RepositoryInstructionReading
+
+    init(instructionReader: RepositoryInstructionReading = RepositoryInstructionFileReader()) {
+        self.instructionReader = instructionReader
+    }
+
+    func buildPrompt(for record: ReviewWorkspaceRecord) -> CodexReviewPromptContract {
+        let instructions =
+            instructionReader.readInstructions(from: record.sourceClonePath)
+            ?? "No repository-specific AGENTS.md instructions were found."
+
+        let renderedPrompt = """
+            [gh-orbit-review-contract/v\(CodexReviewPromptContract.version)]
+            Objective: Review the prepared pull request worktree and print findings to this terminal only.
+
+            Pull request:
+            - Repository: \(record.repository.host)/\(record.repository.owner)/\(record.repository.name)
+            - PR number: \(record.pullRequestNumber)
+            - PR URL: \(record.pullRequestURL.absoluteString)
+            - Head repository: \(record.headRepository.host)/\(record.headRepository.owner)/\(record.headRepository.name)
+            - Head branch: \(record.headBranch)
+            - Head SHA: \(record.headSHA)
+            - Review worktree: \(record.worktreePath.path)
+
+            Repository instructions (AGENTS.md):
+            \(instructions)
+
+            Review-only rules:
+            - Stay within the prepared review worktree above.
+            - Do not push, merge, comment on GitHub, or submit review results automatically.
+            - Do not print or persist secrets, credentials, or tokens.
+            - Print findings and final status directly to this terminal session only.
+
+            Expected terminal output:
+            - A concise review summary.
+            - Findings with severity and file references when applicable.
+            - A final terminal-only completion note indicating whether issues were found.
+            """
+
+        return CodexReviewPromptContract(renderedPrompt: renderedPrompt)
+    }
+}
+
+@MainActor
+protocol ReviewWorkspaceCodexLaunching {
+    func launchSession(
+        for record: ReviewWorkspaceRecord,
+        environment: [String: String],
+        onTerminate: @escaping (Int32?) -> Void
+    ) throws -> TerminalProcessSession
+}
+
+@MainActor
+struct CodexReviewWorkspaceLauncher: ReviewWorkspaceCodexLaunching {
+    let executableResolver: any CodexExecutableResolving
+    let promptBuilder: any CodexReviewPromptBuilding
+    let terminalSessionFactory: any TerminalSessionCreating
+
+    init(
+        executableResolver: any CodexExecutableResolving = CodexExecutableResolver(),
+        promptBuilder: any CodexReviewPromptBuilding = CodexReviewPromptBuilder(),
+        terminalSessionFactory: any TerminalSessionCreating
+    ) {
+        self.executableResolver = executableResolver
+        self.promptBuilder = promptBuilder
+        self.terminalSessionFactory = terminalSessionFactory
+    }
+
+    func launchSession(
+        for record: ReviewWorkspaceRecord,
+        environment: [String: String],
+        onTerminate: @escaping (Int32?) -> Void
+    ) throws -> TerminalProcessSession {
+        let executable = try executableResolver.resolve()
+        let prompt = promptBuilder.buildPrompt(for: record)
+        let request = TerminalLaunchRequest(
+            executable: executable,
+            arguments: [],
+            environment: environment,
+            currentDirectoryURL: record.worktreePath
+        )
+        let session = terminalSessionFactory.makeSession(request: request, onTerminate: onTerminate)
+        session.send(string: prompt.renderedPrompt + "\n")
+        return session
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -24,10 +24,12 @@ struct OrbitCockpitApp: App {
             service: ReviewWorkspaceGitService(
                 git: URL(fileURLWithPath: "/usr/bin/git"),
                 paths: workspacePaths))
+        let codexLauncher = CodexReviewWorkspaceLauncher(terminalSessionFactory: terminalManager)
         _reviewWorkspaceManager = StateObject(
             wrappedValue: ReviewWorkspaceManager(
                 terminalManager: terminalManager,
-                lifecycleController: lifecycleController))
+                lifecycleController: lifecycleController,
+                codexLauncher: codexLauncher))
     }
 
     var body: some Scene {
@@ -103,6 +105,7 @@ struct ContentView: View {
 struct ReviewWorkspaceHostView: View {
     let workspace: ReviewWorkspace
     @EnvironmentObject var terminalManager: TerminalManager
+    @EnvironmentObject var reviewWorkspaceManager: ReviewWorkspaceManager
 
     var body: some View {
         switch workspace.state {
@@ -132,6 +135,9 @@ struct ReviewWorkspaceHostView: View {
                 description: Text(message))
         case .preparing:
             ProgressView("Preparing review workspace…")
+                .onAppear {
+                    reviewWorkspaceManager.launchCodexIfNeeded(for: workspace.id)
+                }
         case .terminating:
             ProgressView("Terminating review workspace…")
         case .failed(let message):
@@ -272,6 +278,7 @@ enum TerminalPaneState: Equatable {
 @MainActor
 protocol TerminalProcessSession: AnyObject {
     var engine: OrbitTerminalEngine { get }
+    func send(string: String)
     func terminateProcess()
 }
 
@@ -288,7 +295,32 @@ struct TerminalPaneSession {
 }
 
 @MainActor
-class TerminalManager: ObservableObject {
+protocol TerminalSessionLaunching {
+    func launchSession(
+        request: TerminalLaunchRequest,
+        isDark: Bool,
+        onLog: ((String, LogLevel) -> Void)?,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession
+}
+
+@MainActor
+struct SwiftTermSessionLauncher: TerminalSessionLaunching {
+    func launchSession(
+        request: TerminalLaunchRequest,
+        isDark: Bool,
+        onLog: ((String, LogLevel) -> Void)?,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession {
+        let adapter = SwiftTermAdapter(onLog: onLog, onTerminate: onTerminate)
+        adapter.isDarkMode(isDark)
+        adapter.startProcess(request: request)
+        return adapter
+    }
+}
+
+@MainActor
+class TerminalManager: ObservableObject, TerminalSessionCreating {
     static let workspacePanePrefix = "review-workspace:"
     @Published private var panes: [String: TerminalPaneSession] = [:]
     @Published var engineManager: NativeEngineManager?
@@ -297,10 +329,16 @@ class TerminalManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var onLog: ((String, LogLevel) -> Void)?
     private var launchTasks: [String: Task<Void, Never>] = [:]
+    private let sessionLauncher: any TerminalSessionLaunching
     let runtimeConfiguration: EngineRuntimeConfiguration
 
-    init(monitor: ActivityMonitor, runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration()) {
+    init(
+        monitor: ActivityMonitor,
+        runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration(),
+        sessionLauncher: any TerminalSessionLaunching = SwiftTermSessionLauncher()
+    ) {
         self.runtimeConfiguration = runtimeConfiguration
+        self.sessionLauncher = sessionLauncher
         let logFunc: (String, LogLevel) -> Void = { msg, level in
             monitor.log(component: "[App]", level: level, message: msg)
         }
@@ -337,11 +375,24 @@ class TerminalManager: ObservableObject {
     }
 
     var managedSocketPath: String? { engineManager?.managedSocketPath }
+    var isDarkModeEnabled: Bool { isDark }
 
     var managedLaunchEnvironment: [String: String] {
         var environment = runtimeConfiguration.environment
         environment["GH_ORBIT_REQUIRE_ENGINE"] = "1"
         return environment
+    }
+
+    func makeSession(
+        request: TerminalLaunchRequest,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession {
+        sessionLauncher.launchSession(
+            request: request,
+            isDark: isDark,
+            onLog: onLog,
+            onTerminate: onTerminate
+        )
     }
 
     func installSession(_ session: TerminalProcessSession, for name: String, state: TerminalPaneState = .running) {
@@ -387,13 +438,6 @@ class TerminalManager: ObservableObject {
 
         let task = Task { @MainActor in
             defer { launchTasks[name] = nil }
-            let adapter = SwiftTermAdapter(
-                onLog: onLog,
-                onTerminate: { [weak self] exitCode in
-                    self?.processTerminated(name: name, exitCode: exitCode)
-                })
-            adapter.isDarkMode(isDark)
-
             onLog?("Resolving gh-orbit binary...", .debug)
             // 1. Resolve binary
             guard let executableURL = PathResolver.resolveBinary(onLog: onLog) else {
@@ -429,9 +473,17 @@ class TerminalManager: ObservableObject {
             }
 
             onLog?("Launching TUI process with args: \(args)", .debug)
-            adapter.startProcess(
-                executable: executableURL, args: args, environment: env.map { "\($0.key)=\($0.value)" })
-            panes[name] = TerminalPaneSession(state: .running, session: adapter)
+            let session = makeSession(
+                request: TerminalLaunchRequest(
+                    executable: executableURL,
+                    arguments: args,
+                    environment: env,
+                    currentDirectoryURL: nil
+                ),
+                onTerminate: { [weak self] exitCode in
+                    self?.processTerminated(name: name, exitCode: exitCode)
+                })
+            panes[name] = TerminalPaneSession(state: .running, session: session)
         }
         launchTasks[name] = task
     }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -75,16 +75,19 @@ final class ReviewWorkspaceManager: ObservableObject {
     @Published private(set) var workspaces: [ReviewWorkspace] = []
     private let terminalManager: TerminalManager
     private let lifecycleController: ReviewWorkspaceLifecycleControlling?
+    private let codexLauncher: ReviewWorkspaceCodexLaunching?
     private let now: () -> Date
     private var didRestoreManagedWorkspaces = false
 
     init(
         terminalManager: TerminalManager,
         lifecycleController: ReviewWorkspaceLifecycleControlling? = nil,
+        codexLauncher: ReviewWorkspaceCodexLaunching? = nil,
         now: @escaping () -> Date = Date.init
     ) {
         self.terminalManager = terminalManager
         self.lifecycleController = lifecycleController
+        self.codexLauncher = codexLauncher
         self.now = now
     }
 
@@ -124,9 +127,37 @@ final class ReviewWorkspaceManager: ObservableObject {
         do {
             let record = try lifecycleController.createWorkspace(
                 for: pullRequest, workspaceID: workspaceID, now: now())
-            return attachManagedWorkspace(record, displayName: displayName, initialState: .preparing)
+            let workspace = attachManagedWorkspace(record, displayName: displayName, initialState: .preparing)
+            if let workspace {
+                launchCodexIfNeeded(for: workspace.id)
+            }
+            return workspace
         } catch {
             return nil
+        }
+    }
+
+    func launchCodexIfNeeded(for workspaceID: UUID) {
+        guard let codexLauncher,
+            let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
+            workspaces[index].state == .preparing,
+            let record = workspaces[index].record
+        else {
+            return
+        }
+
+        do {
+            let session = try codexLauncher.launchSession(
+                for: record,
+                environment: terminalManager.managedLaunchEnvironment,
+                onTerminate: { [weak self] exitCode in
+                    Task { @MainActor in
+                        self?.reportTerminalExit(for: workspaceID, exitCode: exitCode)
+                    }
+                })
+            install(session, for: workspaceID)
+        } catch {
+            reportSetupFailure(for: workspaceID, message: error.localizedDescription)
         }
     }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -5,6 +5,7 @@ import SwiftTerm
 @MainActor
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
+    private let processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)?
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
 
@@ -12,10 +13,16 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         return terminalView
     }
 
-    init(onLog: ((String, LogLevel) -> Void)? = nil, onTerminate: ((Int32?) -> Void)? = nil) {
+    init(
+        terminalView: LocalProcessTerminalView = LocalProcessTerminalView(frame: .zero),
+        processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)? = nil,
+        onLog: ((String, LogLevel) -> Void)? = nil,
+        onTerminate: ((Int32?) -> Void)? = nil
+    ) {
+        self.processStarter = processStarter
         self.onLog = onLog
         self.onTerminate = onTerminate
-        self.terminalView = LocalProcessTerminalView(frame: .zero)
+        self.terminalView = terminalView
         super.init()
         self.terminalView.processDelegate = self
         setupFont()
@@ -117,13 +124,17 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         // Implementation
     }
 
-    /// Launches the gh-orbit helper process.
-    func startProcess(executable: URL, args: [String], environment: [String]?) {
+    func startProcess(request: TerminalLaunchRequest) {
+        if let processStarter {
+            processStarter(terminalView, request)
+            return
+        }
         terminalView.startProcess(
-            executable: executable.path,
-            args: args,
-            environment: environment,
-            execName: nil
+            executable: request.executable.path,
+            args: request.arguments,
+            environment: request.environment.map { $0.map { "\($0.key)=\($0.value)" } },
+            execName: nil,
+            currentDirectory: request.currentDirectoryURL?.path
         )
     }
 

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/CodexReviewLauncherTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/CodexReviewLauncherTests.swift
@@ -4,11 +4,17 @@ import Testing
 
 @testable import OrbitCockpit
 
-private struct StubInstructionReader: RepositoryInstructionReading {
+private final class SpyInstructionReader: RepositoryInstructionReading {
     let contents: String?
+    private(set) var readRoots: [URL] = []
+
+    init(contents: String?) {
+        self.contents = contents
+    }
 
     func readInstructions(from repositoryRoot: URL) -> String? {
-        contents
+        readRoots.append(repositoryRoot)
+        return contents
     }
 }
 
@@ -62,8 +68,9 @@ struct CodexReviewLauncherTests {
     @Test
     func promptIncludesRequiredContextAndExcludesCloneSecrets() throws {
         let record = try sampleRecord()
+        let instructionReader = SpyInstructionReader(contents: "Follow AGENTS instructions.")
         let prompt = CodexReviewPromptBuilder(
-            instructionReader: StubInstructionReader(contents: "Follow AGENTS instructions.")
+            instructionReader: instructionReader
         ).buildPrompt(for: record)
 
         #expect(prompt.renderedPrompt.contains("[gh-orbit-review-contract/v1]"))
@@ -74,6 +81,8 @@ struct CodexReviewLauncherTests {
         #expect(prompt.renderedPrompt.contains("Follow AGENTS instructions."))
         #expect(!prompt.renderedPrompt.contains(record.sourceCloneRemoteURL))
         #expect(!prompt.renderedPrompt.contains(record.headCloneURL.absoluteString))
+        #expect(instructionReader.readRoots == [record.worktreePath])
+        #expect(instructionReader.readRoots != [record.sourceClonePath])
     }
 
     @Test @MainActor
@@ -85,7 +94,7 @@ struct CodexReviewLauncherTests {
             executableResolver: StubCodexExecutableResolver(
                 result: .success(URL(fileURLWithPath: "/usr/local/bin/codex"))),
             promptBuilder: CodexReviewPromptBuilder(
-                instructionReader: StubInstructionReader(contents: "Follow AGENTS instructions.")),
+                instructionReader: SpyInstructionReader(contents: "Follow AGENTS instructions.")),
             terminalSessionFactory: factory
         )
 

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/CodexReviewLauncherTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/CodexReviewLauncherTests.swift
@@ -1,0 +1,135 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import OrbitCockpit
+
+private struct StubInstructionReader: RepositoryInstructionReading {
+    let contents: String?
+
+    func readInstructions(from repositoryRoot: URL) -> String? {
+        contents
+    }
+}
+
+private struct StubCodexExecutableResolver: CodexExecutableResolving {
+    let result: Result<URL, Error>
+
+    func resolve() throws -> URL {
+        try result.get()
+    }
+}
+
+@MainActor
+private final class MockTerminalSessionFactory: TerminalSessionCreating {
+    private(set) var requests: [TerminalLaunchRequest] = []
+    private let session: MockTerminalSession
+
+    init(session: MockTerminalSession = MockTerminalSession()) {
+        self.session = session
+    }
+
+    func makeSession(
+        request: TerminalLaunchRequest,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession {
+        requests.append(request)
+        return session
+    }
+}
+
+@Suite("Codex review launcher")
+struct CodexReviewLauncherTests {
+    private func sampleRecord() throws -> ReviewWorkspaceRecord {
+        try .init(
+            id: #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")),
+            repository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 42,
+            pullRequestURL: #require(URL(string: "https://github.com/acme/orbit/pull/42")),
+            sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+            sourceCloneRemoteURL: "https://token@example.invalid/acme/orbit.git",
+            headRepository: .init(host: "github.com", owner: "contrib", name: "orbit"),
+            headCloneURL: #require(URL(string: "https://token@example.invalid/contrib/orbit.git")),
+            headBranch: "feature/review",
+            headSHA: "0123456789abcdef0123456789abcdef01234567",
+            worktreePath: URL(fileURLWithPath: "/tmp/worktrees/pr-42", isDirectory: true),
+            createdAt: .distantPast,
+            updatedAt: .distantPast,
+            state: .active
+        )
+    }
+
+    @Test
+    func promptIncludesRequiredContextAndExcludesCloneSecrets() throws {
+        let record = try sampleRecord()
+        let prompt = CodexReviewPromptBuilder(
+            instructionReader: StubInstructionReader(contents: "Follow AGENTS instructions.")
+        ).buildPrompt(for: record)
+
+        #expect(prompt.renderedPrompt.contains("[gh-orbit-review-contract/v1]"))
+        #expect(prompt.renderedPrompt.contains("PR number: 42"))
+        #expect(prompt.renderedPrompt.contains(record.pullRequestURL.absoluteString))
+        #expect(prompt.renderedPrompt.contains(record.headSHA))
+        #expect(prompt.renderedPrompt.contains(record.worktreePath.path))
+        #expect(prompt.renderedPrompt.contains("Follow AGENTS instructions."))
+        #expect(!prompt.renderedPrompt.contains(record.sourceCloneRemoteURL))
+        #expect(!prompt.renderedPrompt.contains(record.headCloneURL.absoluteString))
+    }
+
+    @Test @MainActor
+    func launcherUsesStructuredLaunchRequestAndTargetsPreparedWorktree() throws {
+        let record = try sampleRecord()
+        let session = MockTerminalSession()
+        let factory = MockTerminalSessionFactory(session: session)
+        let launcher = CodexReviewWorkspaceLauncher(
+            executableResolver: StubCodexExecutableResolver(
+                result: .success(URL(fileURLWithPath: "/usr/local/bin/codex"))),
+            promptBuilder: CodexReviewPromptBuilder(
+                instructionReader: StubInstructionReader(contents: "Follow AGENTS instructions.")),
+            terminalSessionFactory: factory
+        )
+
+        _ = try launcher.launchSession(
+            for: record,
+            environment: ["GH_ORBIT_REQUIRE_ENGINE": "1"],
+            onTerminate: { _ in }
+        )
+
+        let request = try #require(factory.requests.first)
+        #expect(request.executable.path == "/usr/local/bin/codex")
+        #expect(request.arguments.isEmpty)
+        #expect(request.environment == ["GH_ORBIT_REQUIRE_ENGINE": "1"])
+        #expect(request.currentDirectoryURL == record.worktreePath)
+        #expect(session.sendCalls.count == 1)
+        #expect(session.sendCalls[0].contains(record.headSHA))
+        #expect(session.sendCalls[0].hasSuffix("\n"))
+    }
+
+    @Test @MainActor
+    func swiftTermAdapterForwardsCurrentDirectoryAsFirstClassField() throws {
+        var launchedExecutable: String?
+        var launchedArgs: [String] = []
+        var launchedEnvironment: [String]?
+        var launchedCurrentDirectory: String?
+        let adapter = SwiftTermAdapter(
+            processStarter: { _, request in
+                launchedExecutable = request.executable.path
+                launchedArgs = request.arguments
+                launchedEnvironment = request.environment.map { $0.map { "\($0.key)=\($0.value)" } }
+                launchedCurrentDirectory = request.currentDirectoryURL?.path
+            })
+        let request = TerminalLaunchRequest(
+            executable: URL(fileURLWithPath: "/usr/local/bin/codex"),
+            arguments: ["exec"],
+            environment: ["FOO": "bar"],
+            currentDirectoryURL: URL(fileURLWithPath: "/tmp/worktree", isDirectory: true)
+        )
+
+        adapter.startProcess(request: request)
+
+        #expect(launchedExecutable == "/usr/local/bin/codex")
+        #expect(launchedArgs == ["exec"])
+        #expect(launchedEnvironment == ["FOO=bar"])
+        #expect(launchedCurrentDirectory == "/tmp/worktree")
+    }
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -29,9 +29,14 @@ final class MockTerminalEngine: OrbitTerminalEngine {
 final class MockTerminalSession: TerminalProcessSession {
     let engine: OrbitTerminalEngine
     var terminateCalls = 0
+    var sendCalls: [String] = []
 
     init(engine: OrbitTerminalEngine = MockTerminalEngine()) {
         self.engine = engine
+    }
+
+    func send(string: String) {
+        sendCalls.append(string)
     }
 
     func terminateProcess() {


### PR DESCRIPTION
## Summary

- launch Codex CLI automatically for managed native review workspaces using a structured terminal launch request with executable, args, environment, and working directory kept as separate fields
- build and document a versioned review-only prompt contract from immutable review metadata plus repository AGENTS instructions sourced from the exact prepared worktree
- surface missing Codex as an actionable workspace failure and add focused Swift tests for prompt sourcing, terminal launch cwd forwarding, and prompt dispatch

## Validation

- rtk make native/check
- rtk make check

## Issue

- Closes #431
