### PR TITLE
feat(native): start review workspaces from native requests (#430)

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct OrbitCockpitApp: App {
     @StateObject private var activityMonitor: ActivityMonitor
     @StateObject private var terminalManager: TerminalManager
+    @StateObject private var reviewRequestStore: ReviewRequestStore
     @StateObject private var reviewWorkspaceManager: ReviewWorkspaceManager
 
     init() {
@@ -16,6 +17,7 @@ struct OrbitCockpitApp: App {
         _activityMonitor = StateObject(wrappedValue: monitor)
         let terminalManager = TerminalManager(monitor: monitor)
         _terminalManager = StateObject(wrappedValue: terminalManager)
+        _reviewRequestStore = StateObject(wrappedValue: ReviewRequestStore())
         let runtimeConfiguration = terminalManager.runtimeConfiguration
         let workspacePaths = ReviewWorkspacePaths(
             root: URL(fileURLWithPath: runtimeConfiguration.reviewWorkspaceRoot, isDirectory: true))
@@ -37,6 +39,7 @@ struct OrbitCockpitApp: App {
             ContentView()
                 .environmentObject(activityMonitor)
                 .environmentObject(terminalManager)
+                .environmentObject(reviewRequestStore)
                 .environmentObject(reviewWorkspaceManager)
                 .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                     terminalManager.shutdown()
@@ -52,12 +55,14 @@ struct ContentView: View {
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var activityMonitor: ActivityMonitor
     @EnvironmentObject var terminalManager: TerminalManager
+    @EnvironmentObject var reviewRequestStore: ReviewRequestStore
     @EnvironmentObject var reviewWorkspaceManager: ReviewWorkspaceManager
 
     var body: some View {
         NavigationSplitView {
             Sidebar(selectedPane: $selectedPane)
                 .environmentObject(terminalManager)
+                .environmentObject(reviewRequestStore)
                 .environmentObject(reviewWorkspaceManager)
         } detail: {
             VStack(spacing: 0) {
@@ -65,6 +70,9 @@ struct ContentView: View {
                     if let workspace = reviewWorkspaceManager.workspace(forPaneName: selectedPane) {
                         ReviewWorkspaceHostView(workspace: workspace)
                             .environmentObject(terminalManager)
+                    } else if let request = reviewRequestStore.request(forPaneName: selectedPane) {
+                        ReviewRequestDetailView(request: request)
+                            .environmentObject(reviewWorkspaceManager)
                     } else {
                         TerminalHostView(paneName: selectedPane)
                             .environmentObject(terminalManager)
@@ -96,8 +104,52 @@ struct ContentView: View {
         }
         .onAppear {
             terminalManager.updateTheme(isDark: colorScheme == .dark)
+            reviewWorkspaceManager.onPaneFocusRequested = { paneName in
+                selectedPane = paneName
+            }
             reviewWorkspaceManager.restoreManagedWorkspacesIfNeeded()
         }
+        .onDisappear {
+            reviewWorkspaceManager.onPaneFocusRequested = nil
+        }
+    }
+}
+
+@MainActor
+struct ReviewRequestDetailView: View {
+    let request: NativeReviewRequest
+    @EnvironmentObject var reviewWorkspaceManager: ReviewWorkspaceManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(request.title)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Text(request.subtitle)
+                    .foregroundColor(.secondary)
+                Text("\(request.repository.host)/\(request.repository.owner)/\(request.repository.name)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Text("Pull request #\(request.pullRequestNumber)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Button("Start review workspace") {
+                _ = reviewWorkspaceManager.startReviewWorkspace(for: request)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Text("If the pull request head changes, starting again creates a new workspace for the new review target.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(24)
+        .navigationTitle(request.displayName)
     }
 }
 
@@ -160,6 +212,7 @@ struct ReviewWorkspaceHostView: View {
 struct Sidebar: View {
     @Binding var selectedPane: String?
     @EnvironmentObject var terminalManager: TerminalManager
+    @EnvironmentObject var reviewRequestStore: ReviewRequestStore
     @EnvironmentObject var reviewWorkspaceManager: ReviewWorkspaceManager
 
     var body: some View {
@@ -180,6 +233,18 @@ struct Sidebar: View {
                     .tag("Agent Alpha")
                 Label("Agent Beta", systemImage: "wand.and.stars")
                     .tag("Agent Beta")
+            }
+
+            Section("Review Requests") {
+                ForEach(reviewRequestStore.requests) { request in
+                    HStack {
+                        Label(request.title, systemImage: "person.crop.rectangle.badge.checkmark")
+                        Spacer()
+                        Text("PR #\(request.pullRequestNumber)")
+                            .foregroundColor(.secondary)
+                    }
+                    .tag(request.paneName)
+                }
             }
 
             Section("Review Workspaces") {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/PullRequestResolver.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/PullRequestResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RepositoryIdentity: Codable, Equatable {
+struct RepositoryIdentity: Codable, Equatable, Hashable {
     let host: String
     let owner: String
     let name: String
@@ -30,17 +30,40 @@ struct CommandInvocation: Equatable {
     let workingDirectory: URL?
 }
 
-protocol CommandRunning {
+protocol CommandRunning: Sendable {
     func run(_ invocation: CommandInvocation) throws -> String
 }
 
-enum PullRequestResolutionError: Error, Equatable {
+enum PullRequestResolutionError: Error, Equatable, LocalizedError {
     case missingExecutable(String)
     case noLocalClone, notGitRepository, unsupportedRemote, cloneIdentityMismatch
     case inaccessiblePullRequest, unavailableHead
+
+    var errorDescription: String? {
+        switch self {
+        case .missingExecutable(let name):
+            "Required tool `\(name)` was not found in PATH."
+        case .noLocalClone:
+            "No local clone matched the selected repository. Ensure the repository is available through `ghq`."
+        case .notGitRepository:
+            "The matched local clone is not a usable Git repository."
+        case .unsupportedRemote:
+            "The local clone uses an unsupported remote URL format."
+        case .cloneIdentityMismatch:
+            "The matched local clone does not point at the selected repository."
+        case .inaccessiblePullRequest:
+            "The selected pull request could not be resolved from the local clone."
+        case .unavailableHead:
+            "The selected pull request is missing immutable head metadata required for workspace launch."
+        }
+    }
 }
 
-struct PullRequestResolver {
+protocol PullRequestResolving: Sendable {
+    func resolve(repository: RepositoryIdentity, number: Int) throws -> ResolvedPullRequest
+}
+
+struct PullRequestResolver: PullRequestResolving, Sendable {
     let runner: CommandRunning
     let ghq: URL
     let git: URL

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewRequestStore.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewRequestStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@MainActor
+final class ReviewRequestStore: ObservableObject {
+    @Published var requests: [NativeReviewRequest]
+
+    init(requests: [NativeReviewRequest]? = nil) {
+        self.requests = requests ?? Self.defaultRequests()
+    }
+
+    func request(forPaneName paneName: String) -> NativeReviewRequest? {
+        requests.first { $0.paneName == paneName }
+    }
+
+    private static func defaultRequests() -> [NativeReviewRequest] {
+        let repository = RepositoryIdentity(host: "github.com", owner: "hirakiuc", name: "gh-orbit")
+        return [
+            NativeReviewRequest(
+                repository: repository,
+                pullRequestNumber: 442,
+                title: "Native review-workspace launcher",
+                subtitle: "Start the signed-off launcher flow from the native review-request surface."
+            ),
+            NativeReviewRequest(
+                repository: repository,
+                pullRequestNumber: 441,
+                title: "Native CI watchdog investigation",
+                subtitle: "Exercise duplicate prevention and failure routing against a prior native PR."
+            ),
+        ]
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -70,24 +70,63 @@ struct ReviewWorkspace: Identifiable, Equatable {
     var paneName: String { "review-workspace:\(id.uuidString.lowercased())" }
 }
 
+struct NativeReviewRequest: Identifiable, Equatable {
+    let repository: RepositoryIdentity
+    let pullRequestNumber: Int
+    let title: String
+    let subtitle: String
+
+    // swiftlint:disable:next identifier_name
+    var id: String { paneName }
+    var paneName: String {
+        "review-request:\(repository.host)/\(repository.owner)/\(repository.name)#\(pullRequestNumber)"
+    }
+    var displayName: String { "PR #\(pullRequestNumber)" }
+    var repositoryLabel: String { "\(repository.owner)/\(repository.name)" }
+}
+
+enum ReviewWorkspaceLaunchError: Error, Equatable, LocalizedError {
+    case unavailableResolver
+    case unavailableLifecycle
+    case duplicatePlaceholderConflict
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailableResolver:
+            "Pull request resolution is unavailable in this build."
+        case .unavailableLifecycle:
+            "Managed review-workspace lifecycle is unavailable in this build."
+        case .duplicatePlaceholderConflict:
+            "A review workspace placeholder already exists but could not be reused safely."
+        }
+    }
+}
+
 @MainActor
 final class ReviewWorkspaceManager: ObservableObject {
     @Published private(set) var workspaces: [ReviewWorkspace] = []
     private let terminalManager: TerminalManager
     private let lifecycleController: ReviewWorkspaceLifecycleControlling?
     private let codexLauncher: ReviewWorkspaceCodexLaunching?
+    private let pullRequestResolverFactory: () throws -> any PullRequestResolving
     private let now: () -> Date
     private var didRestoreManagedWorkspaces = false
+    private var phaseOneClaims: [LaunchClaimKey: UUID] = [:]
+    var onPaneFocusRequested: ((String) -> Void)?
 
     init(
         terminalManager: TerminalManager,
         lifecycleController: ReviewWorkspaceLifecycleControlling? = nil,
         codexLauncher: ReviewWorkspaceCodexLaunching? = nil,
+        pullRequestResolverFactory: @escaping () throws -> any PullRequestResolving = {
+            try PullRequestResolver.production()
+        },
         now: @escaping () -> Date = Date.init
     ) {
         self.terminalManager = terminalManager
         self.lifecycleController = lifecycleController
         self.codexLauncher = codexLauncher
+        self.pullRequestResolverFactory = pullRequestResolverFactory
         self.now = now
     }
 
@@ -101,6 +140,47 @@ final class ReviewWorkspaceManager: ObservableObject {
         guard terminalManager.reserveWorkspacePane(workspace.paneName) else { return nil }
         workspaces.append(workspace)
         return workspace
+    }
+
+    @discardableResult
+    func startReviewWorkspace(for request: NativeReviewRequest) -> UUID? {
+        let claimKey = LaunchClaimKey(repository: request.repository, pullRequestNumber: request.pullRequestNumber)
+        if let existingID = activeClaimedWorkspaceID(for: claimKey) {
+            requestFocus(for: existingID)
+            return existingID
+        }
+
+        let workspaceID = UUID()
+        guard createFixtureWorkspace(named: request.displayName, workspaceID: workspaceID) != nil else {
+            return nil
+        }
+        phaseOneClaims[claimKey] = workspaceID
+        requestFocus(for: workspaceID)
+
+        let resolver: any PullRequestResolving
+        do {
+            resolver = try pullRequestResolverFactory()
+        } catch {
+            phaseOneClaims.removeValue(forKey: claimKey)
+            reportSetupFailure(for: workspaceID, message: error.localizedDescription)
+            return workspaceID
+        }
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let result = Result {
+                try resolver.resolve(repository: request.repository, number: request.pullRequestNumber)
+            }
+            await MainActor.run {
+                self?.completeReviewWorkspaceStart(
+                    for: request,
+                    claimKey: claimKey,
+                    placeholderWorkspaceID: workspaceID,
+                    result: result
+                )
+            }
+        }
+
+        return workspaceID
     }
 
     @discardableResult
@@ -239,6 +319,121 @@ final class ReviewWorkspaceManager: ObservableObject {
         restoreManagedWorkspaces()
     }
 
+    private func completeReviewWorkspaceStart(
+        for request: NativeReviewRequest,
+        claimKey: LaunchClaimKey,
+        placeholderWorkspaceID: UUID,
+        result: Result<ResolvedPullRequest, Error>
+    ) {
+        phaseOneClaims.removeValue(forKey: claimKey)
+
+        switch result {
+        case .success(let pullRequest):
+            reconcileResolvedWorkspace(
+                for: request,
+                pullRequest: pullRequest,
+                placeholderWorkspaceID: placeholderWorkspaceID
+            )
+        case .failure(let error):
+            reportSetupFailure(for: placeholderWorkspaceID, message: error.localizedDescription)
+        }
+    }
+
+    private func reconcileResolvedWorkspace(
+        for request: NativeReviewRequest,
+        pullRequest: ResolvedPullRequest,
+        placeholderWorkspaceID: UUID
+    ) {
+        let resolvedKey = ResolvedLaunchKey(
+            repository: request.repository,
+            pullRequestNumber: request.pullRequestNumber,
+            headSHA: pullRequest.headSHA
+        )
+        if let existingID = activeResolvedWorkspaceID(for: resolvedKey), existingID != placeholderWorkspaceID {
+            discardPlaceholderWorkspace(for: placeholderWorkspaceID)
+            requestFocus(for: existingID)
+            return
+        }
+
+        do {
+            try materializeManagedWorkspace(
+                for: pullRequest,
+                displayName: request.displayName,
+                workspaceID: placeholderWorkspaceID
+            )
+            requestFocus(for: placeholderWorkspaceID)
+        } catch {
+            reportSetupFailure(for: placeholderWorkspaceID, message: error.localizedDescription)
+        }
+    }
+
+    private func materializeManagedWorkspace(
+        for pullRequest: ResolvedPullRequest,
+        displayName: String,
+        workspaceID: UUID
+    ) throws {
+        guard let lifecycleController else {
+            throw ReviewWorkspaceLaunchError.unavailableLifecycle
+        }
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
+            workspaces[index].record == nil,
+            workspaces[index].state == .preparing
+        else {
+            throw ReviewWorkspaceLaunchError.duplicatePlaceholderConflict
+        }
+
+        let record = try lifecycleController.createWorkspace(
+            for: pullRequest,
+            workspaceID: workspaceID,
+            now: now()
+        )
+        workspaces[index].displayName = displayName
+        workspaces[index].record = record
+        launchCodexIfNeeded(for: workspaceID)
+    }
+
+    private func discardPlaceholderWorkspace(for workspaceID: UUID) {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
+            workspaces[index].record == nil
+        else { return }
+        terminalManager.releaseWorkspacePane(workspaces[index].paneName)
+        workspaces.remove(at: index)
+    }
+
+    private func activeClaimedWorkspaceID(for key: LaunchClaimKey) -> UUID? {
+        guard let workspaceID = phaseOneClaims[key] else { return nil }
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }), isDuplicateActiveState(workspace.state)
+        else {
+            phaseOneClaims.removeValue(forKey: key)
+            return nil
+        }
+        return workspace.id
+    }
+
+    private func activeResolvedWorkspaceID(for key: ResolvedLaunchKey) -> UUID? {
+        workspaces.first {
+            guard let record = $0.record else { return false }
+            return $0.record?.repository == key.repository
+                && record.pullRequestNumber == key.pullRequestNumber
+                && record.headSHA.caseInsensitiveCompare(key.headSHA) == .orderedSame
+                && isDuplicateActiveState($0.state)
+        }?.id
+    }
+
+    private func isDuplicateActiveState(_ state: ReviewWorkspace.State) -> Bool {
+        switch state {
+        case .preparing, .running:
+            true
+        case .available, .terminating, .exited, .missing, .cleanupRequired, .failed:
+            false
+        }
+    }
+
+    private func requestFocus(for workspaceID: UUID) {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        onPaneFocusRequested?(workspace.paneName)
+    }
+
     private func restoreManagedWorkspaces() {
         guard let lifecycleController else { return }
         do {
@@ -270,4 +465,15 @@ final class ReviewWorkspaceManager: ObservableObject {
             .missing("Managed worktree missing at \(record.worktreePath.path).")
         }
     }
+}
+
+private struct LaunchClaimKey: Hashable {
+    let repository: RepositoryIdentity
+    let pullRequestNumber: Int
+}
+
+private struct ResolvedLaunchKey: Hashable {
+    let repository: RepositoryIdentity
+    let pullRequestNumber: Int
+    let headSHA: String
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspaceLifecycle.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspaceLifecycle.swift
@@ -39,12 +39,27 @@ enum ReviewWorkspaceCleanupResult: Equatable {
     case cleanupRequired(ReviewWorkspaceRecord)
 }
 
-enum ReviewWorkspaceLifecycleError: Error, Equatable {
+enum ReviewWorkspaceLifecycleError: Error, Equatable, LocalizedError {
     case invalidHeadSHA
     case worktreePathInsideSourceClone
     case worktreePathOutsideManagedRoot
     case fetchedRefMismatch(expected: String, actual: String)
     case checkedOutHeadMismatch(expected: String, actual: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidHeadSHA:
+            "The pull request head SHA is invalid and cannot be used to prepare a managed review workspace."
+        case .worktreePathInsideSourceClone:
+            "The managed review workspace path would overlap the source clone, so the worktree was not created."
+        case .worktreePathOutsideManagedRoot:
+            "The managed review workspace path escaped the configured review-workspace root."
+        case .fetchedRefMismatch(let expected, let actual):
+            "Fetched review ref mismatch: expected \(expected), got \(actual)."
+        case .checkedOutHeadMismatch(let expected, let actual):
+            "Checked-out review workspace mismatch: expected \(expected), got \(actual)."
+        }
+    }
 }
 
 struct ReviewWorkspacePaths {

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/PullRequestResolverTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/PullRequestResolverTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import OrbitCockpit
 
-private final class MockCommandRunner: CommandRunning {
+private final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     var invocations: [CommandInvocation] = []
     var results: [String]
     var failureAt: Int?

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -46,8 +46,80 @@ private final class MockReviewWorkspaceLifecycleController: ReviewWorkspaceLifec
     }
 }
 
+private final class MockPullRequestResolver: PullRequestResolving, @unchecked Sendable {
+    private let lock = NSLock()
+    var resolveCalls: [(RepositoryIdentity, Int)] = []
+    var result: Result<ResolvedPullRequest, Error>
+    var waitForResume = false
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    init(result: Result<ResolvedPullRequest, Error>) {
+        self.result = result
+    }
+
+    func resolve(repository: RepositoryIdentity, number: Int) throws -> ResolvedPullRequest {
+        lock.lock()
+        resolveCalls.append((repository, number))
+        let shouldWait = waitForResume
+        lock.unlock()
+
+        if shouldWait {
+            semaphore.wait()
+        }
+        return try result.get()
+    }
+
+    func resume() {
+        semaphore.signal()
+    }
+}
+
+@MainActor
+private final class MockReviewWorkspaceCodexLauncher: ReviewWorkspaceCodexLaunching {
+    private(set) var launchedRecords: [ReviewWorkspaceRecord] = []
+    private let session: MockTerminalSession
+
+    init(session: MockTerminalSession = MockTerminalSession()) {
+        self.session = session
+    }
+
+    func launchSession(
+        for record: ReviewWorkspaceRecord,
+        environment: [String: String],
+        onTerminate: @escaping (Int32?) -> Void
+    ) throws -> TerminalProcessSession {
+        launchedRecords.append(record)
+        return session
+    }
+}
+
 @Suite("Review workspace lifecycle")
 struct ReviewWorkspaceTests {
+    private func sampleRequest() -> NativeReviewRequest {
+        NativeReviewRequest(
+            repository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 42,
+            title: "Needs review",
+            subtitle: "Review request fixture"
+        )
+    }
+
+    private func sampleResolvedPullRequest(
+        headSHA: String = "0123456789abcdef0123456789abcdef01234567"
+    ) -> ResolvedPullRequest {
+        .init(
+            base: .init(host: "github.com", owner: "acme", name: "orbit"),
+            localClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+            localCloneRemoteURL: "git@github.com:acme/orbit.git",
+            number: 42,
+            url: URL(string: "https://github.com/acme/orbit/pull/42")!,
+            head: .init(host: "github.com", owner: "contrib", name: "orbit"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/origin.git", isDirectory: true),
+            headBranch: "feature/review",
+            headSHA: headSHA
+        )
+    }
+
     @Test @MainActor
     func workspacesUseIndependentReservedPanes() throws {
         let terminalManager = TerminalManager(monitor: ActivityMonitor())
@@ -189,5 +261,110 @@ struct ReviewWorkspaceTests {
         #expect(
             manager.workspace(forPaneName: workspace.paneName)?.state
                 == .cleanupRequired("Cleanup required for /tmp/worktree."))
+    }
+
+    @Test @MainActor
+    func duplicateStartsReusePreparingPlaceholderBeforeResolutionCompletes() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .success(sampleResolvedPullRequest()))
+        resolver.waitForResume = true
+        let codexLauncher = MockReviewWorkspaceCodexLauncher()
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            codexLauncher: codexLauncher,
+            pullRequestResolverFactory: { resolver }
+        )
+        var focusedPanes: [String] = []
+        manager.onPaneFocusRequested = { focusedPanes.append($0) }
+
+        let firstID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let secondID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+
+        #expect(firstID == secondID)
+        #expect(manager.workspaces.count == 1)
+        #expect(manager.workspaces[0].state == .preparing)
+        #expect(resolver.resolveCalls.count == 1)
+        #expect(focusedPanes.count == 2)
+        #expect(focusedPanes[0] == focusedPanes[1])
+
+        resolver.resume()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(manager.workspaces[0].state == .running)
+    }
+
+    @Test @MainActor
+    func identicalResolvedWorkspaceIsFocusedInsteadOfDuplicated() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .success(sampleResolvedPullRequest()))
+        let codexLauncher = MockReviewWorkspaceCodexLauncher()
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            codexLauncher: codexLauncher,
+            pullRequestResolverFactory: { resolver }
+        )
+        var focusedPanes: [String] = []
+        manager.onPaneFocusRequested = { focusedPanes.append($0) }
+
+        _ = manager.startReviewWorkspace(for: sampleRequest())
+        try await Task.sleep(nanoseconds: 100_000_000)
+        _ = manager.startReviewWorkspace(for: sampleRequest())
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(manager.workspaces.count == 1)
+        #expect(manager.workspaces[0].state == .running)
+        #expect(codexLauncher.launchedRecords.count == 1)
+        #expect(resolver.resolveCalls.count == 2)
+        #expect(focusedPanes.last == manager.workspaces[0].paneName)
+    }
+
+    @Test @MainActor
+    func changedHeadAllowsSecondWorkspaceLaunch() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .success(sampleResolvedPullRequest()))
+        let codexLauncher = MockReviewWorkspaceCodexLauncher()
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            codexLauncher: codexLauncher,
+            pullRequestResolverFactory: { resolver }
+        )
+
+        _ = manager.startReviewWorkspace(for: sampleRequest())
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        resolver.result = .success(sampleResolvedPullRequest(headSHA: "fedcba9876543210fedcba9876543210fedcba98"))
+        _ = manager.startReviewWorkspace(for: sampleRequest())
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(manager.workspaces.count == 2)
+        #expect(manager.workspaces.allSatisfy { $0.state == .running })
+    }
+
+    @Test @MainActor
+    func resolutionFailuresRemainVisibleAsFailedWorkspace() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .failure(PullRequestResolutionError.noLocalClone))
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            pullRequestResolverFactory: { resolver }
+        )
+
+        let workspaceID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let workspace = try #require(manager.workspaces.first(where: { $0.id == workspaceID }))
+        #expect(
+            workspace.state
+                == .failed(
+                    "No local clone matched the selected repository. Ensure the repository is available through `ghq`."
+                ))
     }
 }


### PR DESCRIPTION
## Summary

- add a native Review Requests sidebar surface and detail action that starts a review workspace from selected repository identity and pull request number only
- implement a two-phase workspace launch flow with immediate preparing placeholders, duplicate suppression during unresolved starts, resolved head-based reuse, and focus handoff into the workspace pane
- surface pull-request resolution and worktree setup failures as visible workspace errors and add focused native tests for duplicate handling, changed heads, focus behavior, and error presentation

## Validation

- rtk make native/check
- rtk make check

## Issue

- Closes #430
