### PR TITLE
feat(native): scope review workspace diagnostics to active workspace

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -128,6 +128,18 @@ struct ReviewWorkspaceHostView: View {
     @EnvironmentObject var reviewWorkspaceManager: ReviewWorkspaceManager
 
     var body: some View {
+        VStack(spacing: 0) {
+            workspaceContent
+
+            Divider()
+
+            WorkspaceDiagnosticsView(diagnostics: workspace.diagnostics)
+                .frame(minHeight: 180, idealHeight: 220, maxHeight: 260)
+        }
+    }
+
+    @ViewBuilder
+    private var workspaceContent: some View {
         switch workspace.state {
         case .available:
             if let path = workspace.record?.worktreePath.path {
@@ -173,6 +185,85 @@ struct ReviewWorkspaceHostView: View {
         } else {
             Text(unavailable).foregroundColor(.secondary)
         }
+    }
+}
+
+struct WorkspaceDiagnosticsView: View {
+    let diagnostics: [WorkspaceDiagnosticEntry]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Workspace Diagnostics", systemImage: "stethoscope")
+                    .font(.headline)
+                Spacer()
+                Text("\(diagnostics.count)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            if diagnostics.isEmpty {
+                ContentUnavailableView(
+                    "Waiting for workspace diagnostics",
+                    systemImage: "text.magnifyingglass",
+                    description: Text("Events for the selected review workspace will appear here."))
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(diagnostics) { diagnostic in
+                            WorkspaceDiagnosticRow(entry: diagnostic)
+                        }
+                    }
+                    .padding(12)
+                }
+                .background(Color(NSColor.textBackgroundColor))
+            }
+        }
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+struct WorkspaceDiagnosticRow: View {
+    let entry: WorkspaceDiagnosticEntry
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    private var levelColor: Color {
+        switch entry.level {
+        case .debug:
+            return .gray
+        case .info:
+            return .primary
+        case .warning:
+            return .yellow
+        case .error:
+            return .red
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(Self.timestampFormatter.string(from: entry.timestamp))
+                .foregroundColor(.secondary)
+                .frame(width: 56, alignment: .leading)
+
+            Text(entry.category.rawValue.uppercased())
+                .foregroundColor(levelColor)
+                .frame(width: 82, alignment: .leading)
+
+            Text(entry.message)
+                .foregroundColor(levelColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(.system(.caption, design: .monospaced))
     }
 }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -298,9 +298,17 @@ final class ReviewWorkspaceManager: ObservableObject {
     }
 
     func install(_ session: TerminalProcessSession, for workspaceID: UUID) {
-        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }), workspaces[index].state == .preparing,
-            terminalManager.installWorkspaceSession(session, for: workspaces[index].paneName)
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }), workspaces[index].state == .preparing
         else { return }
+        guard terminalManager.installWorkspaceSession(session, for: workspaces[index].paneName) else {
+            session.terminateProcess()
+            reportSetupFailure(
+                for: workspaceID,
+                category: .codex,
+                message: "Failed to attach the managed workspace to a terminal session."
+            )
+            return
+        }
         workspaces[index].state = .running
         appendDiagnostic(
             for: workspaceID,

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -66,8 +66,27 @@ struct ReviewWorkspace: Identifiable, Equatable {
     var displayName: String
     var state: State
     var record: ReviewWorkspaceRecord?
+    var diagnostics: [WorkspaceDiagnosticEntry] = []
 
     var paneName: String { "review-workspace:\(id.uuidString.lowercased())" }
+}
+
+struct WorkspaceDiagnosticEntry: Identifiable, Equatable {
+    enum Category: String, Equatable {
+        case launch = "Launch"
+        case resolution = "Resolution"
+        case workspace = "Workspace"
+        case codex = "Codex"
+        case cleanup = "Cleanup"
+        case restore = "Restore"
+    }
+
+    // swiftlint:disable:next identifier_name
+    let id = UUID()
+    let timestamp: Date
+    let category: Category
+    let level: LogLevel
+    let message: String
 }
 
 struct NativeReviewRequest: Identifiable, Equatable {
@@ -146,6 +165,12 @@ final class ReviewWorkspaceManager: ObservableObject {
     func startReviewWorkspace(for request: NativeReviewRequest) -> UUID? {
         let claimKey = LaunchClaimKey(repository: request.repository, pullRequestNumber: request.pullRequestNumber)
         if let existingID = activeClaimedWorkspaceID(for: claimKey) {
+            appendDiagnostic(
+                for: existingID,
+                category: .launch,
+                level: .info,
+                message: "Reused the existing in-progress workspace for PR #\(request.pullRequestNumber)."
+            )
             requestFocus(for: existingID)
             return existingID
         }
@@ -155,6 +180,18 @@ final class ReviewWorkspaceManager: ObservableObject {
             return nil
         }
         phaseOneClaims[claimKey] = workspaceID
+        appendDiagnostic(
+            for: workspaceID,
+            category: .launch,
+            level: .info,
+            message: "Accepted a start request for \(request.repositoryLabel) PR #\(request.pullRequestNumber)."
+        )
+        appendDiagnostic(
+            for: workspaceID,
+            category: .resolution,
+            level: .info,
+            message: "Resolving the selected pull request against the local clone."
+        )
         requestFocus(for: workspaceID)
 
         let resolver: any PullRequestResolving
@@ -162,7 +199,11 @@ final class ReviewWorkspaceManager: ObservableObject {
             resolver = try pullRequestResolverFactory()
         } catch {
             phaseOneClaims.removeValue(forKey: claimKey)
-            reportSetupFailure(for: workspaceID, message: error.localizedDescription)
+            reportSetupFailure(
+                for: workspaceID,
+                category: .resolution,
+                message: error.localizedDescription
+            )
             return workspaceID
         }
 
@@ -240,9 +281,19 @@ final class ReviewWorkspaceManager: ObservableObject {
                         self?.reportTerminalExit(for: workspaceID, exitCode: exitCode)
                     }
                 })
+            appendDiagnostic(
+                for: workspaceID,
+                category: .codex,
+                level: .info,
+                message: "Launching the Codex review session."
+            )
             install(session, for: workspaceID)
         } catch {
-            reportSetupFailure(for: workspaceID, message: error.localizedDescription)
+            reportSetupFailure(
+                for: workspaceID,
+                category: .codex,
+                message: error.localizedDescription
+            )
         }
     }
 
@@ -251,6 +302,12 @@ final class ReviewWorkspaceManager: ObservableObject {
             terminalManager.installWorkspaceSession(session, for: workspaces[index].paneName)
         else { return }
         workspaces[index].state = .running
+        appendDiagnostic(
+            for: workspaceID,
+            category: .codex,
+            level: .info,
+            message: "Attached the workspace to a running Codex session."
+        )
     }
 
     func requestTermination(for workspaceID: UUID) {
@@ -260,6 +317,12 @@ final class ReviewWorkspaceManager: ObservableObject {
             return
         }
         workspaces[index].state = .terminating
+        appendDiagnostic(
+            for: workspaceID,
+            category: .cleanup,
+            level: .info,
+            message: "Terminating the active workspace session."
+        )
         terminalManager.terminateWorkspacePane(workspaces[index].paneName)
     }
 
@@ -273,6 +336,12 @@ final class ReviewWorkspaceManager: ObservableObject {
         guard let record = workspaces[index].record, workspaces[index].state == .terminating, let lifecycleController
         else {
             workspaces[index].state = .exited(exitCode ?? -1)
+            appendDiagnostic(
+                for: workspaceID,
+                category: .cleanup,
+                level: .info,
+                message: "The workspace session exited with code \(exitCode ?? -1)."
+            )
             return
         }
         do {
@@ -281,21 +350,49 @@ final class ReviewWorkspaceManager: ObservableObject {
             case .removed:
                 workspaces[index].record = nil
                 workspaces[index].state = .exited(exitCode ?? -1)
+                appendDiagnostic(
+                    for: workspaceID,
+                    category: .cleanup,
+                    level: .info,
+                    message: "Cleaned up the managed workspace after exit."
+                )
             case .cleanupRequired(let updated):
                 workspaces[index].record = updated
                 workspaces[index].state = .cleanupRequired("Cleanup required for \(updated.worktreePath.path).")
+                appendDiagnostic(
+                    for: workspaceID,
+                    category: .cleanup,
+                    level: .warning,
+                    message: "Workspace cleanup requires manual action for \(updated.worktreePath.path)."
+                )
             }
         } catch {
             workspaces[index].state = .cleanupRequired("Cleanup required for \(record.worktreePath.path).")
+            appendDiagnostic(
+                for: workspaceID,
+                category: .cleanup,
+                level: .error,
+                message: "Workspace cleanup failed for \(record.worktreePath.path)."
+            )
         }
     }
 
-    func reportSetupFailure(for workspaceID: UUID, message: String) {
+    func reportSetupFailure(
+        for workspaceID: UUID,
+        category: WorkspaceDiagnosticEntry.Category = .workspace,
+        message: String
+    ) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         switch workspaces[index].state {
         case .preparing, .running: break
         case .available, .terminating, .exited, .missing, .cleanupRequired, .failed: return
         }
+        appendDiagnostic(
+            for: workspaceID,
+            category: category,
+            level: .error,
+            message: message
+        )
         workspaces[index].state = .failed(message)
     }
 
@@ -305,6 +402,12 @@ final class ReviewWorkspaceManager: ObservableObject {
         if let record {
             workspaces[index].record = record
         }
+        appendDiagnostic(
+            for: workspaceID,
+            category: .cleanup,
+            level: .warning,
+            message: message
+        )
         workspaces[index].state = .cleanupRequired(message)
     }
 
@@ -334,13 +437,23 @@ final class ReviewWorkspaceManager: ObservableObject {
 
         switch result {
         case .success(let pullRequest):
+            appendDiagnostic(
+                for: placeholderWorkspaceID,
+                category: .resolution,
+                level: .info,
+                message: "Resolved the pull request head at \(pullRequest.headSHA)."
+            )
             reconcileResolvedWorkspace(
                 for: request,
                 pullRequest: pullRequest,
                 placeholderWorkspaceID: placeholderWorkspaceID
             )
         case .failure(let error):
-            reportSetupFailure(for: placeholderWorkspaceID, message: error.localizedDescription)
+            reportSetupFailure(
+                for: placeholderWorkspaceID,
+                category: .resolution,
+                message: error.localizedDescription
+            )
         }
     }
 
@@ -355,6 +468,12 @@ final class ReviewWorkspaceManager: ObservableObject {
             headSHA: pullRequest.headSHA
         )
         if let existingID = activeResolvedWorkspaceID(for: resolvedKey), existingID != placeholderWorkspaceID {
+            appendDiagnostic(
+                for: existingID,
+                category: .workspace,
+                level: .info,
+                message: "Reused the existing workspace for the resolved head \(pullRequest.headSHA)."
+            )
             discardPlaceholderWorkspace(for: placeholderWorkspaceID)
             requestFocus(for: existingID)
             return
@@ -366,9 +485,19 @@ final class ReviewWorkspaceManager: ObservableObject {
                 displayName: request.displayName,
                 workspaceID: placeholderWorkspaceID
             )
+            appendDiagnostic(
+                for: placeholderWorkspaceID,
+                category: .workspace,
+                level: .info,
+                message: "Prepared the managed worktree for \(request.displayName)."
+            )
             requestFocus(for: placeholderWorkspaceID)
         } catch {
-            reportSetupFailure(for: placeholderWorkspaceID, message: error.localizedDescription)
+            reportSetupFailure(
+                for: placeholderWorkspaceID,
+                category: .workspace,
+                message: error.localizedDescription
+            )
         }
     }
 
@@ -439,13 +568,37 @@ final class ReviewWorkspaceManager: ObservableObject {
         onPaneFocusRequested?(workspace.paneName)
     }
 
+    private func appendDiagnostic(
+        for workspaceID: UUID,
+        category: WorkspaceDiagnosticEntry.Category,
+        level: LogLevel,
+        message: String
+    ) {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+        workspaces[index].diagnostics.append(
+            WorkspaceDiagnosticEntry(
+                timestamp: now(),
+                category: category,
+                level: level,
+                message: message
+            )
+        )
+    }
+
     private func restoreManagedWorkspaces() {
         guard let lifecycleController else { return }
         do {
             let result = try lifecycleController.restoreWorkspaces(now: now())
             for record in result.records {
                 let displayName = "PR #\(record.pullRequestNumber)"
-                _ = attachManagedWorkspace(record, displayName: displayName)
+                if let workspace = attachManagedWorkspace(record, displayName: displayName) {
+                    appendDiagnostic(
+                        for: workspace.id,
+                        category: .restore,
+                        level: .info,
+                        message: "Restored a managed workspace from persisted state."
+                    )
+                }
             }
             for orphaned in result.orphanedWorktrees {
                 let workspaceID = UUID()
@@ -453,7 +606,15 @@ final class ReviewWorkspaceManager: ObservableObject {
                     id: workspaceID,
                     displayName: orphaned.worktreePath.lastPathComponent,
                     state: .cleanupRequired("Orphaned managed worktree at \(orphaned.worktreePath.path)."),
-                    record: nil)
+                    record: nil,
+                    diagnostics: [
+                        WorkspaceDiagnosticEntry(
+                            timestamp: now(),
+                            category: .restore,
+                            level: .warning,
+                            message: "Detected an orphaned managed worktree at \(orphaned.worktreePath.path)."
+                        )
+                    ])
                 guard terminalManager.reserveWorkspacePane(workspace.paneName) else { continue }
                 workspaces.append(workspace)
             }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -366,5 +366,101 @@ struct ReviewWorkspaceTests {
                 == .failed(
                     "No local clone matched the selected repository. Ensure the repository is available through `ghq`."
                 ))
+        #expect(workspace.diagnostics.map(\.category) == [.launch, .resolution, .resolution])
+        #expect(workspace.diagnostics.last?.level == .error)
+    }
+
+    @Test @MainActor
+    func duplicateReuseAppendsDiagnosticOnlyToReusedWorkspace() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .success(sampleResolvedPullRequest()))
+        resolver.waitForResume = true
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            pullRequestResolverFactory: { resolver }
+        )
+
+        let workspaceID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        _ = manager.startReviewWorkspace(for: sampleRequest())
+
+        let workspace = try #require(manager.workspaces.first(where: { $0.id == workspaceID }))
+        #expect(workspace.diagnostics.count == 3)
+        #expect(
+            workspace.diagnostics.last?.message
+                == "Reused the existing in-progress workspace for PR #42."
+        )
+    }
+
+    @Test @MainActor
+    func diagnosticsRemainScopedToEachWorkspace() async throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let resolver = MockPullRequestResolver(result: .success(sampleResolvedPullRequest()))
+        let codexLauncher = MockReviewWorkspaceCodexLauncher()
+        let manager = ReviewWorkspaceManager(
+            terminalManager: terminalManager,
+            lifecycleController: lifecycle,
+            codexLauncher: codexLauncher,
+            pullRequestResolverFactory: { resolver }
+        )
+
+        let firstID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        resolver.result = .success(sampleResolvedPullRequest(headSHA: "fedcba9876543210fedcba9876543210fedcba98"))
+        let secondID = try #require(manager.startReviewWorkspace(for: sampleRequest()))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let first = try #require(manager.workspaces.first(where: { $0.id == firstID }))
+        let second = try #require(manager.workspaces.first(where: { $0.id == secondID }))
+
+        #expect(first.diagnostics.contains { $0.message.contains("0123456789abcdef0123456789abcdef01234567") })
+        #expect(!first.diagnostics.contains { $0.message.contains("fedcba9876543210fedcba9876543210fedcba98") })
+        #expect(second.diagnostics.contains { $0.message.contains("fedcba9876543210fedcba9876543210fedcba98") })
+        #expect(!second.diagnostics.contains { $0.message.contains("0123456789abcdef0123456789abcdef01234567") })
+    }
+
+    @Test @MainActor
+    func restoredManagedWorkspacesAndOrphansRecordRestoreDiagnostics() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let lifecycle = MockReviewWorkspaceLifecycleController()
+        let workspaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let pullRequestURL = try #require(URL(string: "https://github.com/acme/orbit/pull/12"))
+        let record = ReviewWorkspaceRecord(
+            id: workspaceID,
+            repository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            pullRequestNumber: 12,
+            pullRequestURL: pullRequestURL,
+            sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+            sourceCloneRemoteURL: "git@github.com:acme/orbit.git",
+            headRepository: .init(host: "github.com", owner: "acme", name: "orbit"),
+            headCloneURL: URL(fileURLWithPath: "/tmp/origin.git", isDirectory: true),
+            headBranch: "main",
+            headSHA: "0123456789abcdef0123456789abcdef01234567",
+            worktreePath: URL(fileURLWithPath: "/tmp/worktree", isDirectory: true),
+            createdAt: .distantPast,
+            updatedAt: .distantPast,
+            state: .active)
+        lifecycle.restoredResult = .init(
+            records: [record],
+            orphanedWorktrees: [
+                .init(
+                    sourceClonePath: URL(fileURLWithPath: "/tmp/source", isDirectory: true),
+                    worktreePath: URL(fileURLWithPath: "/tmp/orphan", isDirectory: true))
+            ])
+
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager, lifecycleController: lifecycle)
+        manager.restoreManagedWorkspacesIfNeeded()
+
+        let restored = try #require(manager.workspaces.first(where: { $0.record?.id == workspaceID }))
+        let orphan = try #require(manager.workspaces.first(where: { $0.record == nil }))
+
+        #expect(restored.diagnostics.map(\.category) == [.restore])
+        #expect(restored.diagnostics.first?.level == .info)
+        #expect(orphan.diagnostics.map(\.category) == [.restore])
+        #expect(orphan.diagnostics.first?.level == .warning)
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -264,6 +264,23 @@ struct ReviewWorkspaceTests {
     }
 
     @Test @MainActor
+    func attachFailureBecomesVisibleWorkspaceScopedCodexError() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager)
+        let workspace = try #require(manager.createFixtureWorkspace(named: "review"))
+        let session = MockTerminalSession()
+
+        terminalManager.releaseWorkspacePane(workspace.paneName)
+        manager.install(session, for: workspace.id)
+
+        let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
+        #expect(updatedWorkspace.state == .failed("Failed to attach the managed workspace to a terminal session."))
+        #expect(updatedWorkspace.diagnostics.map(\.category) == [.codex])
+        #expect(updatedWorkspace.diagnostics.last?.level == .error)
+        #expect(session.terminateCalls == 1)
+    }
+
+    @Test @MainActor
     func duplicateStartsReusePreparingPlaceholderBeforeResolutionCompletes() async throws {
         let terminalManager = TerminalManager(monitor: ActivityMonitor())
         let lifecycle = MockReviewWorkspaceLifecycleController()


### PR DESCRIPTION
## Summary
- add workspace-owned diagnostic history for native review workspaces
- render scoped diagnostics in the selected workspace detail view while keeping global debug logs separate
- surface terminal session attach failures as visible `.codex` workspace errors with regression coverage

## Testing
- `rtk make native/check`
- `rtk make check`

## Issue
- Closes #447
