### PR TITLE
feat(native): improve review workspace failed-state recovery UX

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -172,9 +172,8 @@ struct ReviewWorkspaceHostView: View {
                 }
         case .terminating:
             ProgressView("Terminating review workspace…")
-        case .failed(let message):
-            ContentUnavailableView(
-                "Review workspace failed", systemImage: "exclamationmark.triangle", description: Text(message))
+        case .failed(let failure):
+            ReviewWorkspaceFailureView(failure: failure)
         }
     }
 
@@ -184,6 +183,43 @@ struct ReviewWorkspaceHostView: View {
             TerminalContainer(engine: engine, isFocused: true)
         } else {
             Text(unavailable).foregroundColor(.secondary)
+        }
+    }
+}
+
+struct ReviewWorkspaceFailureView: View {
+    let failure: ReviewWorkspaceFailure
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                ContentUnavailableView(
+                    failure.title,
+                    systemImage: failure.systemImage,
+                    description: Text(failure.summary)
+                )
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("What you can do next")
+                        .font(.headline)
+
+                    ForEach(Array(failure.recoveryGuidance.enumerated()), id: \.offset) { _, step in
+                        Label(step, systemImage: "arrow.right.circle")
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Original error")
+                        .font(.headline)
+                    Text(failure.message)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }
@@ -316,7 +352,7 @@ struct Sidebar: View {
         case .exited(let code): "Exited (\(code))"
         case .missing: "Missing"
         case .cleanupRequired: "Cleanup required"
-        case .failed(let message): message
+        case .failed(let failure): failure.title
         }
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/ReviewWorkspace.swift
@@ -58,7 +58,7 @@ struct ReviewWorkspace: Identifiable, Equatable {
         case exited(Int32)
         case missing(String)
         case cleanupRequired(String)
-        case failed(String)
+        case failed(ReviewWorkspaceFailure)
     }
 
     // swiftlint:disable:next identifier_name
@@ -69,6 +69,125 @@ struct ReviewWorkspace: Identifiable, Equatable {
     var diagnostics: [WorkspaceDiagnosticEntry] = []
 
     var paneName: String { "review-workspace:\(id.uuidString.lowercased())" }
+}
+
+struct ReviewWorkspaceFailure: Equatable {
+    enum Kind: Equatable {
+        case missingTool(String?)
+        case noLocalClone
+        case cloneMismatch
+        case inaccessiblePullRequest
+        case worktreeSetup
+        case codexLaunch
+        case unknown
+    }
+
+    let kind: Kind
+    let message: String
+
+    var title: String {
+        switch kind {
+        case .missingTool:
+            "Required tool missing"
+        case .noLocalClone:
+            "Local clone not found"
+        case .cloneMismatch:
+            "Local clone mismatch"
+        case .inaccessiblePullRequest:
+            "Pull request could not be resolved"
+        case .worktreeSetup:
+            "Managed worktree setup failed"
+        case .codexLaunch:
+            "Codex session launch failed"
+        case .unknown:
+            "Review workspace failed"
+        }
+    }
+
+    var summary: String {
+        switch kind {
+        case .missingTool(let tool):
+            if let tool, !tool.isEmpty {
+                return "Orbit Cockpit could not find the required `\(tool)` executable for this review workspace."
+            }
+            return "Orbit Cockpit could not find a required executable for this review workspace."
+        case .noLocalClone:
+            return "Orbit Cockpit could not find a matching local clone for the selected repository."
+        case .cloneMismatch:
+            return "Orbit Cockpit found a local clone, but it does not match the selected repository setup."
+        case .inaccessiblePullRequest:
+            return "Orbit Cockpit could not read immutable pull request details from the selected repository."
+        case .worktreeSetup:
+            return "Orbit Cockpit could not prepare the managed review worktree for this pull request."
+        case .codexLaunch:
+            return "Orbit Cockpit prepared the workspace, but the Codex review session could not be started."
+        case .unknown:
+            return "Orbit Cockpit could not finish preparing this review workspace."
+        }
+    }
+
+    var recoveryGuidance: [String] {
+        switch kind {
+        case .missingTool(let tool):
+            if let tool, !tool.isEmpty {
+                return [
+                    "Install `\(tool)` locally or expose it through your PATH.",
+                    "If the executable is installed in a custom location, point the app to it with the expected environment override before relaunching the workspace.",
+                ]
+            }
+            return [
+                "Install the missing command-line tool locally and make sure it is available in PATH.",
+                "Restart the workspace after the executable becomes available.",
+            ]
+        case .noLocalClone:
+            return [
+                "Clone the repository locally with `ghq` before starting a review workspace.",
+                "Confirm the repository path matches the selected owner and repository name.",
+            ]
+        case .cloneMismatch:
+            return [
+                "Check the matched local clone's `origin` remote and make sure it points at the selected repository.",
+                "Use the correct local clone before starting the review workspace again.",
+            ]
+        case .inaccessiblePullRequest:
+            return [
+                "Confirm the pull request still exists and that the local clone can access its metadata.",
+                "Refresh local authentication or repository access, then retry the review workspace launch.",
+            ]
+        case .worktreeSetup:
+            return [
+                "Check whether the review workspace root is writable and whether a prior worktree needs manual cleanup.",
+                "Retry after fixing the local workspace environment.",
+            ]
+        case .codexLaunch:
+            return [
+                "Confirm the Codex CLI is installed and can be launched from the local environment.",
+                "If the review workspace was prepared successfully, retry after fixing the local Codex runtime or terminal session setup.",
+            ]
+        case .unknown:
+            return [
+                "Review the supporting error message and workspace diagnostics below for more detail.",
+                "Retry after fixing the local environment or repository state that blocked workspace launch.",
+            ]
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .missingTool:
+            "wrench.and.screwdriver"
+        case .noLocalClone, .cloneMismatch:
+            "externaldrive.badge.xmark"
+        case .inaccessiblePullRequest:
+            "arrow.trianglehead.branch"
+        case .worktreeSetup:
+            "externaldrive.badge.exclamationmark"
+        case .codexLaunch:
+            "terminal.badge.exclamationmark"
+        case .unknown:
+            "exclamationmark.triangle"
+        }
+    }
 }
 
 struct WorkspaceDiagnosticEntry: Identifiable, Equatable {
@@ -202,6 +321,7 @@ final class ReviewWorkspaceManager: ObservableObject {
             reportSetupFailure(
                 for: workspaceID,
                 category: .resolution,
+                error: error,
                 message: error.localizedDescription
             )
             return workspaceID
@@ -292,6 +412,7 @@ final class ReviewWorkspaceManager: ObservableObject {
             reportSetupFailure(
                 for: workspaceID,
                 category: .codex,
+                error: error,
                 message: error.localizedDescription
             )
         }
@@ -388,6 +509,7 @@ final class ReviewWorkspaceManager: ObservableObject {
     func reportSetupFailure(
         for workspaceID: UUID,
         category: WorkspaceDiagnosticEntry.Category = .workspace,
+        error: Error? = nil,
         message: String
     ) {
         guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
@@ -401,7 +523,7 @@ final class ReviewWorkspaceManager: ObservableObject {
             level: .error,
             message: message
         )
-        workspaces[index].state = .failed(message)
+        workspaces[index].state = .failed(classifyFailure(category: category, error: error, message: message))
     }
 
     func reportCleanupRequired(for workspaceID: UUID, message: String, record: ReviewWorkspaceRecord? = nil) {
@@ -460,6 +582,7 @@ final class ReviewWorkspaceManager: ObservableObject {
             reportSetupFailure(
                 for: placeholderWorkspaceID,
                 category: .resolution,
+                error: error,
                 message: error.localizedDescription
             )
         }
@@ -504,6 +627,7 @@ final class ReviewWorkspaceManager: ObservableObject {
             reportSetupFailure(
                 for: placeholderWorkspaceID,
                 category: .workspace,
+                error: error,
                 message: error.localizedDescription
             )
         }
@@ -574,6 +698,52 @@ final class ReviewWorkspaceManager: ObservableObject {
     private func requestFocus(for workspaceID: UUID) {
         guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
         onPaneFocusRequested?(workspace.paneName)
+    }
+
+    private func classifyFailure(
+        category: WorkspaceDiagnosticEntry.Category,
+        error: Error?,
+        message: String
+    ) -> ReviewWorkspaceFailure {
+        if let resolutionError = error as? PullRequestResolutionError {
+            switch resolutionError {
+            case .missingExecutable(let name):
+                return ReviewWorkspaceFailure(kind: .missingTool(name), message: message)
+            case .noLocalClone:
+                return ReviewWorkspaceFailure(kind: .noLocalClone, message: message)
+            case .notGitRepository, .unsupportedRemote, .cloneIdentityMismatch:
+                return ReviewWorkspaceFailure(kind: .cloneMismatch, message: message)
+            case .inaccessiblePullRequest, .unavailableHead:
+                return ReviewWorkspaceFailure(kind: .inaccessiblePullRequest, message: message)
+            }
+        }
+
+        if let codexError = error as? CodexExecutableResolutionError {
+            switch codexError {
+            case .missingExecutable:
+                return ReviewWorkspaceFailure(kind: .missingTool("codex"), message: message)
+            }
+        }
+
+        if let launchError = error as? ReviewWorkspaceLaunchError {
+            switch launchError {
+            case .unavailableResolver:
+                return ReviewWorkspaceFailure(kind: .unknown, message: message)
+            case .unavailableLifecycle, .duplicatePlaceholderConflict:
+                return ReviewWorkspaceFailure(kind: .worktreeSetup, message: message)
+            }
+        }
+
+        switch category {
+        case .resolution:
+            return ReviewWorkspaceFailure(kind: .inaccessiblePullRequest, message: message)
+        case .workspace:
+            return ReviewWorkspaceFailure(kind: .worktreeSetup, message: message)
+        case .codex:
+            return ReviewWorkspaceFailure(kind: .codexLaunch, message: message)
+        case .launch, .cleanup, .restore:
+            return ReviewWorkspaceFailure(kind: .unknown, message: message)
+        }
     }
 
     private func appendDiagnostic(

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/ReviewWorkspaceTests.swift
@@ -95,6 +95,13 @@ private final class MockReviewWorkspaceCodexLauncher: ReviewWorkspaceCodexLaunch
 
 @Suite("Review workspace lifecycle")
 struct ReviewWorkspaceTests {
+    private func failure(
+        _ kind: ReviewWorkspaceFailure.Kind,
+        message: String
+    ) -> ReviewWorkspaceFailure {
+        ReviewWorkspaceFailure(kind: kind, message: message)
+    }
+
     private func sampleRequest() -> NativeReviewRequest {
         NativeReviewRequest(
             repository: .init(host: "github.com", owner: "acme", name: "orbit"),
@@ -158,7 +165,9 @@ struct ReviewWorkspaceTests {
         manager.install(firstSession, for: first.id)
         manager.reportSetupFailure(for: second.id, message: "setup failed")
         manager.reportTerminalExit(for: second.id, exitCode: 0)
-        #expect(manager.workspace(forPaneName: second.paneName)?.state == .failed("setup failed"))
+        #expect(
+            manager.workspace(forPaneName: second.paneName)?.state
+                == .failed(failure(.worktreeSetup, message: "setup failed")))
         manager.requestTermination(for: first.id)
         #expect(manager.workspace(forPaneName: first.paneName)?.state == .terminating)
         manager.reportSetupFailure(for: first.id, message: "late failure")
@@ -166,7 +175,9 @@ struct ReviewWorkspaceTests {
         manager.reportTerminalExit(for: first.id, exitCode: 0)
         manager.dismiss(first.id)
         #expect(manager.workspace(forPaneName: first.paneName) == nil)
-        #expect(manager.workspace(forPaneName: second.paneName)?.state == .failed("setup failed"))
+        #expect(
+            manager.workspace(forPaneName: second.paneName)?.state
+                == .failed(failure(.worktreeSetup, message: "setup failed")))
     }
 
     @Test @MainActor
@@ -274,7 +285,13 @@ struct ReviewWorkspaceTests {
         manager.install(session, for: workspace.id)
 
         let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
-        #expect(updatedWorkspace.state == .failed("Failed to attach the managed workspace to a terminal session."))
+        #expect(
+            updatedWorkspace.state
+                == .failed(
+                    failure(
+                        .codexLaunch,
+                        message: "Failed to attach the managed workspace to a terminal session."
+                    )))
         #expect(updatedWorkspace.diagnostics.map(\.category) == [.codex])
         #expect(updatedWorkspace.diagnostics.last?.level == .error)
         #expect(session.terminateCalls == 1)
@@ -381,10 +398,146 @@ struct ReviewWorkspaceTests {
         #expect(
             workspace.state
                 == .failed(
-                    "No local clone matched the selected repository. Ensure the repository is available through `ghq`."
+                    failure(
+                        .noLocalClone,
+                        message:
+                            "No local clone matched the selected repository. Ensure the repository is available through `ghq`."
+                    )
                 ))
         #expect(workspace.diagnostics.map(\.category) == [.launch, .resolution, .resolution])
         #expect(workspace.diagnostics.last?.level == .error)
+    }
+
+    @Test @MainActor
+    func setupFailurePreservesStructuredFailureClassForMissingTool() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager)
+        let workspace = try #require(manager.createFixtureWorkspace(named: "review"))
+
+        manager.reportSetupFailure(
+            for: workspace.id,
+            category: .resolution,
+            error: PullRequestResolutionError.missingExecutable("ghq"),
+            message: "Required tool `ghq` was not found in PATH."
+        )
+
+        let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
+        #expect(
+            updatedWorkspace.state
+                == .failed(failure(.missingTool("ghq"), message: "Required tool `ghq` was not found in PATH."))
+        )
+    }
+
+    @Test @MainActor
+    func setupFailurePreservesStructuredFailureClassForCloneMismatch() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager)
+        let workspace = try #require(manager.createFixtureWorkspace(named: "review"))
+
+        manager.reportSetupFailure(
+            for: workspace.id,
+            category: .resolution,
+            error: PullRequestResolutionError.cloneIdentityMismatch,
+            message: "The matched local clone does not point at the selected repository."
+        )
+
+        let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
+        #expect(
+            updatedWorkspace.state
+                == .failed(
+                    failure(
+                        .cloneMismatch,
+                        message: "The matched local clone does not point at the selected repository."
+                    )))
+    }
+
+    @Test @MainActor
+    func setupFailurePreservesStructuredFailureClassForInaccessiblePullRequest() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager)
+        let workspace = try #require(manager.createFixtureWorkspace(named: "review"))
+
+        manager.reportSetupFailure(
+            for: workspace.id,
+            category: .resolution,
+            error: PullRequestResolutionError.inaccessiblePullRequest,
+            message: "The selected pull request could not be resolved from the local clone."
+        )
+
+        let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
+        #expect(
+            updatedWorkspace.state
+                == .failed(
+                    failure(
+                        .inaccessiblePullRequest,
+                        message: "The selected pull request could not be resolved from the local clone."
+                    )))
+    }
+
+    @Test @MainActor
+    func setupFailurePreservesStructuredFailureClassForCodexMissingTool() throws {
+        let terminalManager = TerminalManager(monitor: ActivityMonitor())
+        let manager = ReviewWorkspaceManager(terminalManager: terminalManager)
+        let workspace = try #require(manager.createFixtureWorkspace(named: "review"))
+
+        manager.reportSetupFailure(
+            for: workspace.id,
+            category: .codex,
+            error: CodexExecutableResolutionError.missingExecutable(
+                "Codex CLI not found. Install `codex` or set CODEX_BIN to the executable path."
+            ),
+            message: "Codex CLI not found. Install `codex` or set CODEX_BIN to the executable path."
+        )
+
+        let updatedWorkspace = try #require(manager.workspace(forPaneName: workspace.paneName))
+        #expect(
+            updatedWorkspace.state
+                == .failed(
+                    failure(
+                        .missingTool("codex"),
+                        message: "Codex CLI not found. Install `codex` or set CODEX_BIN to the executable path."
+                    )))
+    }
+
+    @Test
+    func failureGuidanceProvidesPlainLanguageRecoveryHints() {
+        let missingTool = ReviewWorkspaceFailure(
+            kind: .missingTool("ghq"),
+            message: "Required tool `ghq` was not found in PATH."
+        )
+        let cloneMismatch = ReviewWorkspaceFailure(
+            kind: .cloneMismatch,
+            message: "The matched local clone does not point at the selected repository."
+        )
+        let inaccessiblePullRequest = ReviewWorkspaceFailure(
+            kind: .inaccessiblePullRequest,
+            message: "The selected pull request could not be resolved from the local clone."
+        )
+        let worktreeSetup = ReviewWorkspaceFailure(
+            kind: .worktreeSetup,
+            message: "Managed review-workspace lifecycle is unavailable in this build."
+        )
+        let codexLaunch = ReviewWorkspaceFailure(
+            kind: .codexLaunch,
+            message: "Failed to attach the managed workspace to a terminal session."
+        )
+        let unknown = ReviewWorkspaceFailure(
+            kind: .unknown,
+            message: "Unclassified failure."
+        )
+
+        #expect(missingTool.title == "Required tool missing")
+        #expect(missingTool.recoveryGuidance[0].contains("Install `ghq`"))
+        #expect(cloneMismatch.title == "Local clone mismatch")
+        #expect(cloneMismatch.recoveryGuidance[0].contains("origin"))
+        #expect(inaccessiblePullRequest.title == "Pull request could not be resolved")
+        #expect(inaccessiblePullRequest.recoveryGuidance[0].contains("pull request still exists"))
+        #expect(worktreeSetup.title == "Managed worktree setup failed")
+        #expect(worktreeSetup.recoveryGuidance[0].contains("review workspace root"))
+        #expect(codexLaunch.title == "Codex session launch failed")
+        #expect(codexLaunch.recoveryGuidance[0].contains("Codex CLI"))
+        #expect(unknown.title == "Review workspace failed")
+        #expect(unknown.recoveryGuidance[0].contains("workspace diagnostics"))
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- store structured review workspace failure descriptors at the native failure origin instead of collapsing everything to raw strings
- render failed-state titles, summaries, recovery guidance, and original error context directly from the stored failure model
- add focused Swift coverage for failure classification and user-facing recovery guidance

## Testing
- `rtk make native/check`
- `rtk make check`

## Issue
- Closes #448
