### PR TITLE
feat(native): add Orbit Cockpit settings foundation (#455)

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -6,6 +6,7 @@ import SwiftUI
 @MainActor
 struct OrbitCockpitApp: App {
     @StateObject private var activityMonitor: ActivityMonitor
+    @StateObject private var settingsStore: OrbitCockpitSettingsStore
     @StateObject private var terminalManager: TerminalManager
     @StateObject private var reviewWorkspaceManager: ReviewWorkspaceManager
     private let reviewWorkspaceRequestInbox: ReviewWorkspaceRequestInbox
@@ -15,7 +16,9 @@ struct OrbitCockpitApp: App {
         let monitor = ActivityMonitor()
         monitor.log(component: "[App]", level: .info, message: "Launched Orbit Cockpit")
         _activityMonitor = StateObject(wrappedValue: monitor)
-        let terminalManager = TerminalManager(monitor: monitor)
+        let settingsStore = OrbitCockpitSettingsStore()
+        _settingsStore = StateObject(wrappedValue: settingsStore)
+        let terminalManager = TerminalManager(monitor: monitor, settingsStore: settingsStore)
         _terminalManager = StateObject(wrappedValue: terminalManager)
         let runtimeConfiguration = terminalManager.runtimeConfiguration
         let workspacePaths = ReviewWorkspacePaths(
@@ -49,12 +52,18 @@ struct OrbitCockpitApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(activityMonitor)
+                .environmentObject(settingsStore)
                 .environmentObject(terminalManager)
                 .environmentObject(reviewWorkspaceManager)
                 .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                     reviewWorkspaceRequestInbox.stop()
                     terminalManager.shutdown()
                 }
+        }
+
+        Settings {
+            OrbitCockpitSettingsView()
+                .environmentObject(settingsStore)
         }
     }
 }
@@ -445,6 +454,7 @@ struct TerminalPaneSession {
 protocol TerminalSessionLaunching {
     func launchSession(
         request: TerminalLaunchRequest,
+        settings: TerminalSessionSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
@@ -455,11 +465,12 @@ protocol TerminalSessionLaunching {
 struct SwiftTermSessionLauncher: TerminalSessionLaunching {
     func launchSession(
         request: TerminalLaunchRequest,
+        settings: TerminalSessionSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
     ) -> TerminalProcessSession {
-        let adapter = SwiftTermAdapter(onLog: onLog, onTerminate: onTerminate)
+        let adapter = SwiftTermAdapter(settings: settings, onLog: onLog, onTerminate: onTerminate)
         adapter.isDarkMode(isDark)
         adapter.startProcess(request: request)
         return adapter
@@ -477,13 +488,16 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     private var onLog: ((String, LogLevel) -> Void)?
     private var launchTasks: [String: Task<Void, Never>] = [:]
     private let sessionLauncher: any TerminalSessionLaunching
+    private let settingsStore: OrbitCockpitSettingsStore
     let runtimeConfiguration: EngineRuntimeConfiguration
 
     init(
         monitor: ActivityMonitor,
+        settingsStore: OrbitCockpitSettingsStore = OrbitCockpitSettingsStore(),
         runtimeConfiguration: EngineRuntimeConfiguration = EngineRuntimeConfiguration(),
         sessionLauncher: any TerminalSessionLaunching = SwiftTermSessionLauncher()
     ) {
+        self.settingsStore = settingsStore
         self.runtimeConfiguration = runtimeConfiguration
         self.sessionLauncher = sessionLauncher
         let logFunc: (String, LogLevel) -> Void = { msg, level in
@@ -537,6 +551,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     ) -> TerminalProcessSession {
         sessionLauncher.launchSession(
             request: request,
+            settings: settingsStore.terminalSessionSettings,
             isDark: isDark,
             onLog: onLog,
             onTerminate: onTerminate

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SwiftUI
+
+enum TerminalColorSchemePreference: String, CaseIterable, Codable, Sendable {
+    case system
+    case light
+    case dark
+
+    var label: String {
+        switch self {
+        case .system:
+            "Follow System"
+        case .light:
+            "Light"
+        case .dark:
+            "Dark"
+        }
+    }
+}
+
+struct OrbitCockpitSettings: Equatable, Codable, Sendable {
+    struct Terminal: Equatable, Codable, Sendable {
+        var fontSize: Double = 12
+        var usesNerdFont: Bool = true
+    }
+
+    struct Appearance: Equatable, Codable, Sendable {
+        var terminalColorSchemePreference: TerminalColorSchemePreference = .system
+        var showDebugLogsByDefault: Bool = false
+    }
+
+    struct LinksAndInput: Equatable, Codable, Sendable {
+        var openLinksDirectly: Bool = true
+        var optionKeySendsMeta: Bool = true
+    }
+
+    struct Advanced: Equatable, Codable, Sendable {
+        var preferGPURenderer: Bool = true
+        var scrollbackLineLimit: Int = 10_000
+    }
+
+    var terminal: Terminal = .init()
+    var appearance: Appearance = .init()
+    var linksAndInput: LinksAndInput = .init()
+    var advanced: Advanced = .init()
+
+    static let defaults = OrbitCockpitSettings()
+}
+
+struct TerminalSessionSettings: Equatable, Sendable {
+    var fontSize: Double
+    var usesNerdFont: Bool
+    var colorSchemePreference: TerminalColorSchemePreference
+
+    static let defaults = TerminalSessionSettings(
+        fontSize: OrbitCockpitSettings.defaults.terminal.fontSize,
+        usesNerdFont: OrbitCockpitSettings.defaults.terminal.usesNerdFont,
+        colorSchemePreference: OrbitCockpitSettings.defaults.appearance.terminalColorSchemePreference)
+}
+
+extension OrbitCockpitSettings {
+    var terminalSessionSettings: TerminalSessionSettings {
+        TerminalSessionSettings(
+            fontSize: terminal.fontSize,
+            usesNerdFont: terminal.usesNerdFont,
+            colorSchemePreference: appearance.terminalColorSchemePreference)
+    }
+}
+
+@MainActor
+final class OrbitCockpitSettingsStore: ObservableObject {
+    static let defaultStorageKey = "orbit-cockpit.settings"
+
+    @Published private(set) var settings: OrbitCockpitSettings
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = defaultStorageKey
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.settings = Self.loadSettings(from: defaults, storageKey: storageKey)
+    }
+
+    var terminalSessionSettings: TerminalSessionSettings {
+        settings.terminalSessionSettings
+    }
+
+    func binding<Value>(_ keyPath: WritableKeyPath<OrbitCockpitSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { self.settings[keyPath: keyPath] },
+            set: { newValue in
+                var updated = self.settings
+                updated[keyPath: keyPath] = newValue
+                self.apply(updated)
+            })
+    }
+
+    func resetToDefaults() {
+        apply(.defaults)
+    }
+
+    private func apply(_ updated: OrbitCockpitSettings) {
+        settings = updated
+        persist(updated)
+    }
+
+    private func persist(_ settings: OrbitCockpitSettings) {
+        guard let data = try? encoder.encode(settings) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+
+    private static func loadSettings(from defaults: UserDefaults, storageKey: String) -> OrbitCockpitSettings {
+        guard
+            let data = defaults.data(forKey: storageKey),
+            let settings = try? JSONDecoder().decode(OrbitCockpitSettings.self, from: data)
+        else {
+            return .defaults
+        }
+        return settings
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -7,7 +7,7 @@ struct OrbitCockpitSettingsView: View {
     var body: some View {
         TabView {
             Form {
-                Section("Terminal Defaults") {
+                Section {
                     Stepper(value: settingsStore.binding(\.terminal.fontSize), in: 10...24, step: 1) {
                         HStack {
                             Text("Font Size")
@@ -18,6 +18,8 @@ struct OrbitCockpitSettingsView: View {
                     }
 
                     Toggle("Prefer Nerd Font", isOn: settingsStore.binding(\.terminal.usesNerdFont))
+                } header: {
+                    Text("Terminal Defaults")
                 } footer: {
                     Text("These defaults are consumed when Orbit Cockpit launches new terminal sessions.")
                 }
@@ -29,7 +31,7 @@ struct OrbitCockpitSettingsView: View {
             }
 
             Form {
-                Section("Appearance") {
+                Section {
                     Picker(
                         "Terminal Theme",
                         selection: settingsStore.binding(\.appearance.terminalColorSchemePreference)
@@ -41,6 +43,8 @@ struct OrbitCockpitSettingsView: View {
 
                     Toggle(
                         "Show debug logs on launch", isOn: settingsStore.binding(\.appearance.showDebugLogsByDefault))
+                } header: {
+                    Text("Appearance")
                 } footer: {
                     Text(
                         "Appearance defaults are stored now so later tasks can wire immediate runtime application cleanly."
@@ -54,10 +58,12 @@ struct OrbitCockpitSettingsView: View {
             }
 
             Form {
-                Section("Links & Input") {
+                Section {
                     Toggle(
                         "Open detected links directly", isOn: settingsStore.binding(\.linksAndInput.openLinksDirectly))
                     Toggle("Treat Option as Meta", isOn: settingsStore.binding(\.linksAndInput.optionKeySendsMeta))
+                } header: {
+                    Text("Links & Input")
                 } footer: {
                     Text("This section establishes typed native ownership for later SwiftTerm input behavior.")
                 }
@@ -69,7 +75,7 @@ struct OrbitCockpitSettingsView: View {
             }
 
             Form {
-                Section("Advanced") {
+                Section {
                     Toggle(
                         "Prefer GPU rendering when available", isOn: settingsStore.binding(\.advanced.preferGPURenderer)
                     )
@@ -84,6 +90,8 @@ struct OrbitCockpitSettingsView: View {
                                 .foregroundColor(.secondary)
                         }
                     }
+                } header: {
+                    Text("Advanced")
                 } footer: {
                     Text(
                         "Advanced values are persisted behind the native settings model so future engine-specific work stays decoupled from raw storage."

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+@MainActor
+struct OrbitCockpitSettingsView: View {
+    @EnvironmentObject private var settingsStore: OrbitCockpitSettingsStore
+
+    var body: some View {
+        TabView {
+            Form {
+                Section("Terminal Defaults") {
+                    Stepper(value: settingsStore.binding(\.terminal.fontSize), in: 10...24, step: 1) {
+                        HStack {
+                            Text("Font Size")
+                            Spacer()
+                            Text("\(Int(settingsStore.settings.terminal.fontSize)) pt")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Toggle("Prefer Nerd Font", isOn: settingsStore.binding(\.terminal.usesNerdFont))
+                } footer: {
+                    Text("These defaults are consumed when Orbit Cockpit launches new terminal sessions.")
+                }
+            }
+            .formStyle(.grouped)
+            .padding(20)
+            .tabItem {
+                Label("Terminal", systemImage: "terminal")
+            }
+
+            Form {
+                Section("Appearance") {
+                    Picker(
+                        "Terminal Theme",
+                        selection: settingsStore.binding(\.appearance.terminalColorSchemePreference)
+                    ) {
+                        ForEach(TerminalColorSchemePreference.allCases, id: \.self) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+
+                    Toggle(
+                        "Show debug logs on launch", isOn: settingsStore.binding(\.appearance.showDebugLogsByDefault))
+                } footer: {
+                    Text(
+                        "Appearance defaults are stored now so later tasks can wire immediate runtime application cleanly."
+                    )
+                }
+            }
+            .formStyle(.grouped)
+            .padding(20)
+            .tabItem {
+                Label("Appearance", systemImage: "paintpalette")
+            }
+
+            Form {
+                Section("Links & Input") {
+                    Toggle(
+                        "Open detected links directly", isOn: settingsStore.binding(\.linksAndInput.openLinksDirectly))
+                    Toggle("Treat Option as Meta", isOn: settingsStore.binding(\.linksAndInput.optionKeySendsMeta))
+                } footer: {
+                    Text("This section establishes typed native ownership for later SwiftTerm input behavior.")
+                }
+            }
+            .formStyle(.grouped)
+            .padding(20)
+            .tabItem {
+                Label("Links & Input", systemImage: "link")
+            }
+
+            Form {
+                Section("Advanced") {
+                    Toggle(
+                        "Prefer GPU rendering when available", isOn: settingsStore.binding(\.advanced.preferGPURenderer)
+                    )
+
+                    Stepper(
+                        value: settingsStore.binding(\.advanced.scrollbackLineLimit), in: 1_000...50_000, step: 1_000
+                    ) {
+                        HStack {
+                            Text("Scrollback Line Limit")
+                            Spacer()
+                            Text("\(settingsStore.settings.advanced.scrollbackLineLimit)")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                } footer: {
+                    Text(
+                        "Advanced values are persisted behind the native settings model so future engine-specific work stays decoupled from raw storage."
+                    )
+                }
+            }
+            .formStyle(.grouped)
+            .padding(20)
+            .tabItem {
+                Label("Advanced", systemImage: "gearshape.2")
+            }
+        }
+        .frame(minWidth: 560, minHeight: 360)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Reset to Defaults") {
+                    settingsStore.resetToDefaults()
+                }
+            }
+        }
+    }
+}

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -5,6 +5,7 @@ import SwiftTerm
 @MainActor
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
+    private let settings: TerminalSessionSettings
     private let processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)?
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
@@ -14,11 +15,13 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     init(
+        settings: TerminalSessionSettings = .defaults,
         terminalView: LocalProcessTerminalView = LocalProcessTerminalView(frame: .zero),
         processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)? = nil,
         onLog: ((String, LogLevel) -> Void)? = nil,
         onTerminate: ((Int32?) -> Void)? = nil
     ) {
+        self.settings = settings
         self.processStarter = processStarter
         self.onLog = onLog
         self.onTerminate = onTerminate
@@ -29,6 +32,12 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     private func setupFont() {
+        let fontSize = settings.fontSize
+        guard settings.usesNerdFont else {
+            terminalView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+            return
+        }
+
         // Preferred "Mono" Nerd Fonts for fixed-width icon rendering.
         let preferredFonts = [
             "MonaspiceNe Nerd Font Mono",
@@ -44,7 +53,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
 
         var selectedFont: NSFont?
         for name in preferredFonts {
-            if let font = NSFont(name: name, size: 12) {
+            if let font = NSFont(name: name, size: fontSize) {
                 selectedFont = font
                 onLog?("Found Nerd Font: \(name)", .debug)
                 break
@@ -54,7 +63,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         if let font = selectedFont {
             terminalView.font = font
         } else {
-            terminalView.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+            terminalView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
             onLog?("No Nerd Font found, falling back to system monospaced font.", .warning)
             print("[SwiftTermAdapter] No Nerd Font found, falling back to system monospaced font.")
         }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import OrbitCockpit
+
+@Suite("OrbitCockpit Settings Store Tests")
+@MainActor
+struct OrbitCockpitSettingsStoreTests {
+    @Test("Defaults load when nothing is persisted")
+    func testDefaultsLoad() throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.Settings.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+
+        #expect(store.settings == .defaults)
+    }
+
+    @Test("Persisted values survive store recreation")
+    func testPersistedValuesReload() throws {
+        let suiteName = "OrbitCockpitTests.Settings.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+
+        store.binding(\.terminal.fontSize).wrappedValue = 14
+        store.binding(\.appearance.showDebugLogsByDefault).wrappedValue = true
+        store.binding(\.advanced.scrollbackLineLimit).wrappedValue = 20_000
+
+        let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
+
+        #expect(reloaded.settings.terminal.fontSize == 14)
+        #expect(reloaded.settings.appearance.showDebugLogsByDefault)
+        #expect(reloaded.settings.advanced.scrollbackLineLimit == 20_000)
+    }
+
+    @Test("Reset to defaults restores canonical values")
+    func testResetToDefaults() throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.Settings.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+
+        store.binding(\.terminal.fontSize).wrappedValue = 18
+        store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
+        store.binding(\.advanced.preferGPURenderer).wrappedValue = false
+
+        store.resetToDefaults()
+
+        #expect(store.settings == .defaults)
+
+        let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
+        #expect(reloaded.settings == .defaults)
+    }
+}

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -23,4 +23,18 @@ struct SwiftTermAdapterTests {
         // Verify font size is 12
         #expect(terminalView.font.pointSize == 12)
     }
+
+    @Test("Configured font size is applied to terminal view")
+    @MainActor
+    func testConfiguredFontSizeIsApplied() async throws {
+        let settings = TerminalSessionSettings(fontSize: 16, usesNerdFont: false, colorSchemePreference: .system)
+        let adapter = SwiftTermAdapter(settings: settings, onLog: nil)
+
+        guard let terminalView = adapter.view as? LocalProcessTerminalView else {
+            Issue.record("adapter.view is not a LocalProcessTerminalView")
+            return
+        }
+
+        #expect(terminalView.font.pointSize == 16)
+    }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -44,6 +44,31 @@ final class MockTerminalSession: TerminalProcessSession {
     }
 }
 
+@MainActor
+final class RecordingSessionLauncher: TerminalSessionLaunching {
+    var lastRequest: TerminalLaunchRequest?
+    var lastSettings: TerminalSessionSettings?
+    var lastIsDark: Bool?
+    let session: TerminalProcessSession
+
+    init(session: TerminalProcessSession = MockTerminalSession()) {
+        self.session = session
+    }
+
+    func launchSession(
+        request: TerminalLaunchRequest,
+        settings: TerminalSessionSettings,
+        isDark: Bool,
+        onLog: ((String, LogLevel) -> Void)?,
+        onTerminate: @escaping (Int32?) -> Void
+    ) -> TerminalProcessSession {
+        lastRequest = request
+        lastSettings = settings
+        lastIsDark = isDark
+        return session
+    }
+}
+
 @Suite("Terminal Manager Tests")
 struct TerminalManagerTests {
 
@@ -138,5 +163,39 @@ struct TerminalManagerTests {
         manager.shutdown()
 
         #expect(manager.engineManager?.isEngineReady == false)
+    }
+
+    @Test("Launch path consumes typed terminal settings from the native store")
+    @MainActor
+    func testMakeSessionUsesSettingsStoreSnapshot() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.TerminalManager.\(UUID().uuidString)"))
+        let settingsStore = OrbitCockpitSettingsStore(defaults: defaults)
+        var configured = OrbitCockpitSettings.defaults
+        configured.terminal.fontSize = 15
+        configured.terminal.usesNerdFont = false
+        configured.appearance.terminalColorSchemePreference = .dark
+        defaults.set(try JSONEncoder().encode(configured), forKey: OrbitCockpitSettingsStore.defaultStorageKey)
+        let reloadedStore = OrbitCockpitSettingsStore(defaults: defaults)
+
+        let launcher = RecordingSessionLauncher()
+        let manager = TerminalManager(
+            monitor: ActivityMonitor(),
+            settingsStore: reloadedStore,
+            sessionLauncher: launcher)
+        let request = TerminalLaunchRequest(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["true"],
+            environment: nil,
+            currentDirectoryURL: nil)
+
+        _ = manager.makeSession(request: request, onTerminate: { _ in })
+
+        #expect(launcher.lastRequest == request)
+        #expect(
+            launcher.lastSettings
+                == TerminalSessionSettings(
+                    fontSize: 15,
+                    usesNerdFont: false,
+                    colorSchemePreference: .dark))
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -169,7 +169,6 @@ struct TerminalManagerTests {
     @MainActor
     func testMakeSessionUsesSettingsStoreSnapshot() async throws {
         let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.TerminalManager.\(UUID().uuidString)"))
-        let settingsStore = OrbitCockpitSettingsStore(defaults: defaults)
         var configured = OrbitCockpitSettings.defaults
         configured.terminal.fontSize = 15
         configured.terminal.usesNerdFont = false


### PR DESCRIPTION
## Summary

- add a native Orbit Cockpit settings model/store backed by UserDefaults
- add a macOS Settings scene with Terminal, Appearance, Links & Input, and Advanced sections
- wire typed settings through the app root and terminal launch path, with reset-to-defaults support
- add focused native tests for persistence, reset behavior, and launch-path settings consumption

## Validation

- export GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home
- rtk make native/check
- rtk make check

Refs #455