### PR TITLE
feat(native): add live-applied SwiftTerm settings (#456)

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -518,8 +518,8 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
             .store(in: &cancellables)
 
         settingsStore.$settings
-            .sink { [weak self] _ in
-                self?.applySettingsToRunningSessions()
+            .sink { [weak self] settings in
+                self?.applySettingsToRunningSessions(settings.terminalSessionSettings)
             }
             .store(in: &cancellables)
 
@@ -528,7 +528,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
 
     func updateTheme(isDark: Bool) {
         self.isDark = isDark
-        applySettingsToRunningSessions()
+        applySettingsToRunningSessions(settingsStore.terminalSessionSettings)
     }
 
     func state(for name: String) -> TerminalPaneState? {
@@ -581,8 +581,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
         return true
     }
 
-    private func applySettingsToRunningSessions() {
-        let settings = settingsStore.terminalSessionSettings
+    private func applySettingsToRunningSessions(_ settings: TerminalSessionSettings) {
         for pane in panes.values {
             pane.session?.engine.applyTerminalSettings(settings, isDark: isDark)
         }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -517,14 +517,18 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
             }
             .store(in: &cancellables)
 
+        settingsStore.$settings
+            .sink { [weak self] _ in
+                self?.applySettingsToRunningSessions()
+            }
+            .store(in: &cancellables)
+
         self.engineManager = newManager
     }
 
     func updateTheme(isDark: Bool) {
         self.isDark = isDark
-        for pane in panes.values {
-            pane.session?.engine.isDarkMode(isDark)
-        }
+        applySettingsToRunningSessions()
     }
 
     func state(for name: String) -> TerminalPaneState? {
@@ -561,6 +565,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     func installSession(_ session: TerminalProcessSession, for name: String, state: TerminalPaneState = .running) {
         guard !name.hasPrefix(Self.workspacePanePrefix) else { return }
         panes[name] = TerminalPaneSession(state: state, session: session)
+        session.engine.applyTerminalSettings(settingsStore.terminalSessionSettings, isDark: isDark)
     }
 
     func reserveWorkspacePane(_ name: String) -> Bool {
@@ -572,7 +577,15 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     func installWorkspaceSession(_ session: TerminalProcessSession, for name: String) -> Bool {
         guard name.hasPrefix(Self.workspacePanePrefix), panes[name] != nil else { return false }
         panes[name] = TerminalPaneSession(state: .running, session: session)
+        session.engine.applyTerminalSettings(settingsStore.terminalSessionSettings, isDark: isDark)
         return true
+    }
+
+    private func applySettingsToRunningSessions() {
+        let settings = settingsStore.terminalSessionSettings
+        for pane in panes.values {
+            pane.session?.engine.applyTerminalSettings(settings, isDark: isDark)
+        }
     }
 
     func terminateWorkspacePane(_ name: String) { panes[name]?.session?.terminateProcess() }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
@@ -22,6 +22,9 @@ struct OrbitCockpitSettings: Equatable, Codable, Sendable {
     struct Terminal: Equatable, Codable, Sendable {
         var fontSize: Double = 12
         var usesNerdFont: Bool = true
+        var useBrightColorsForBoldText: Bool = true
+        var useCustomBlockGlyphs: Bool = true
+        var antiAliasCustomBlockGlyphs: Bool = false
     }
 
     struct Appearance: Equatable, Codable, Sendable {
@@ -32,6 +35,8 @@ struct OrbitCockpitSettings: Equatable, Codable, Sendable {
     struct LinksAndInput: Equatable, Codable, Sendable {
         var openLinksDirectly: Bool = true
         var optionKeySendsMeta: Bool = true
+        var mouseReportingEnabled: Bool = true
+        var backspaceSendsControlH: Bool = false
     }
 
     struct Advanced: Equatable, Codable, Sendable {
@@ -50,20 +55,40 @@ struct OrbitCockpitSettings: Equatable, Codable, Sendable {
 struct TerminalSessionSettings: Equatable, Sendable {
     var fontSize: Double
     var usesNerdFont: Bool
+    var useBrightColorsForBoldText: Bool
+    var useCustomBlockGlyphs: Bool
+    var antiAliasCustomBlockGlyphs: Bool
     var colorSchemePreference: TerminalColorSchemePreference
+    var optionKeySendsMeta: Bool
+    var mouseReportingEnabled: Bool
+    var backspaceSendsControlH: Bool
 
     static let defaults = TerminalSessionSettings(
         fontSize: OrbitCockpitSettings.defaults.terminal.fontSize,
         usesNerdFont: OrbitCockpitSettings.defaults.terminal.usesNerdFont,
-        colorSchemePreference: OrbitCockpitSettings.defaults.appearance.terminalColorSchemePreference)
+        useBrightColorsForBoldText: OrbitCockpitSettings.defaults.terminal.useBrightColorsForBoldText,
+        useCustomBlockGlyphs: OrbitCockpitSettings.defaults.terminal.useCustomBlockGlyphs,
+        antiAliasCustomBlockGlyphs: OrbitCockpitSettings.defaults.terminal.antiAliasCustomBlockGlyphs,
+        colorSchemePreference: OrbitCockpitSettings.defaults.appearance.terminalColorSchemePreference,
+        optionKeySendsMeta: OrbitCockpitSettings.defaults.linksAndInput.optionKeySendsMeta,
+        mouseReportingEnabled: OrbitCockpitSettings.defaults.linksAndInput.mouseReportingEnabled,
+        backspaceSendsControlH: OrbitCockpitSettings.defaults.linksAndInput.backspaceSendsControlH)
 }
 
 extension OrbitCockpitSettings {
+    /// The explicit subset of terminal settings that Orbit Cockpit supports
+    /// both for new sessions and live application to running SwiftTerm views.
     var terminalSessionSettings: TerminalSessionSettings {
         TerminalSessionSettings(
             fontSize: terminal.fontSize,
             usesNerdFont: terminal.usesNerdFont,
-            colorSchemePreference: appearance.terminalColorSchemePreference)
+            useBrightColorsForBoldText: terminal.useBrightColorsForBoldText,
+            useCustomBlockGlyphs: terminal.useCustomBlockGlyphs,
+            antiAliasCustomBlockGlyphs: terminal.antiAliasCustomBlockGlyphs,
+            colorSchemePreference: appearance.terminalColorSchemePreference,
+            optionKeySendsMeta: linksAndInput.optionKeySendsMeta,
+            mouseReportingEnabled: linksAndInput.mouseReportingEnabled,
+            backspaceSendsControlH: linksAndInput.backspaceSendsControlH)
     }
 }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -18,10 +18,19 @@ struct OrbitCockpitSettingsView: View {
                     }
 
                     Toggle("Prefer Nerd Font", isOn: settingsStore.binding(\.terminal.usesNerdFont))
+                    Toggle(
+                        "Bright colors for bold text",
+                        isOn: settingsStore.binding(\.terminal.useBrightColorsForBoldText))
+                    Toggle("Custom block glyphs", isOn: settingsStore.binding(\.terminal.useCustomBlockGlyphs))
+                    Toggle(
+                        "Anti-aliased custom block glyphs",
+                        isOn: settingsStore.binding(\.terminal.antiAliasCustomBlockGlyphs))
                 } header: {
                     Text("Terminal Defaults")
                 } footer: {
-                    Text("These defaults are consumed when Orbit Cockpit launches new terminal sessions.")
+                    Text(
+                        "These settings apply to running SwiftTerm panes immediately and are also used for new terminal sessions."
+                    )
                 }
             }
             .formStyle(.grouped)
@@ -62,10 +71,16 @@ struct OrbitCockpitSettingsView: View {
                     Toggle(
                         "Open detected links directly", isOn: settingsStore.binding(\.linksAndInput.openLinksDirectly))
                     Toggle("Treat Option as Meta", isOn: settingsStore.binding(\.linksAndInput.optionKeySendsMeta))
+                    Toggle("Enable mouse reporting", isOn: settingsStore.binding(\.linksAndInput.mouseReportingEnabled))
+                    Toggle(
+                        "Backspace sends Control-H", isOn: settingsStore.binding(\.linksAndInput.backspaceSendsControlH)
+                    )
                 } header: {
                     Text("Links & Input")
                 } footer: {
-                    Text("This section establishes typed native ownership for later SwiftTerm input behavior.")
+                    Text(
+                        "Only the controls SwiftTerm can update safely on existing panes are exposed here as live-applied settings."
+                    )
                 }
             }
             .formStyle(.grouped)

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
@@ -20,6 +20,9 @@ protocol OrbitTerminalEngine: AnyObject {
     /// Extracts the current plain-text content of the terminal buffer.
     func getBuffer() -> String
 
+    /// Applies the live-supported terminal settings to an existing terminal view.
+    func applyTerminalSettings(_ settings: TerminalSessionSettings, isDark: Bool)
+
     /// Sets the terminal theme (e.g., Light or Dark).
     func isDarkMode(_ isDark: Bool)
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -5,7 +5,7 @@ import SwiftTerm
 @MainActor
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
-    private let settings: TerminalSessionSettings
+    private var settings: TerminalSessionSettings
     private let processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)?
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
@@ -28,7 +28,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         self.terminalView = terminalView
         super.init()
         self.terminalView.processDelegate = self
-        setupFont()
+        applyTerminalSettings(settings, isDark: false)
     }
 
     private func setupFont() {
@@ -69,6 +69,24 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         }
     }
 
+    private func applyTheme(isDark: Bool) {
+        switch settings.colorSchemePreference {
+        case .system:
+            isDarkMode(isDark)
+        case .light:
+            terminalView.nativeBackgroundColor = .white
+            terminalView.nativeForegroundColor = .black
+        case .dark:
+            terminalView.nativeBackgroundColor = .black
+            terminalView.nativeForegroundColor = .white
+        }
+    }
+
+    private func refreshDisplay() {
+        terminalView.terminal.updateFullScreen()
+        terminalView.setNeedsDisplay(terminalView.bounds)
+    }
+
     func feed(data: Data) {
         let bytes = [UInt8](data)
         terminalView.feed(byteArray: bytes[...])
@@ -99,14 +117,21 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         return fullText
     }
 
+    func applyTerminalSettings(_ settings: TerminalSessionSettings, isDark: Bool) {
+        self.settings = settings
+        setupFont()
+        terminalView.optionAsMetaKey = settings.optionKeySendsMeta
+        terminalView.allowMouseReporting = settings.mouseReportingEnabled
+        terminalView.backspaceSendsControlH = settings.backspaceSendsControlH
+        terminalView.useBrightColors = settings.useBrightColorsForBoldText
+        terminalView.customBlockGlyphs = settings.useCustomBlockGlyphs
+        terminalView.antiAliasCustomBlockGlyphs = settings.antiAliasCustomBlockGlyphs
+        applyTheme(isDark: isDark)
+        refreshDisplay()
+    }
+
     func isDarkMode(_ isDark: Bool) {
-        if isDark {
-            terminalView.nativeBackgroundColor = .black
-            terminalView.nativeForegroundColor = .white
-        } else {
-            terminalView.nativeBackgroundColor = .white
-            terminalView.nativeForegroundColor = .black
-        }
+        applyTheme(isDark: isDark)
     }
 
     // MARK: - LocalProcessTerminalViewDelegate

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -72,7 +72,13 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     private func applyTheme(isDark: Bool) {
         switch settings.colorSchemePreference {
         case .system:
-            isDarkMode(isDark)
+            if isDark {
+                terminalView.nativeBackgroundColor = .black
+                terminalView.nativeForegroundColor = .white
+            } else {
+                terminalView.nativeBackgroundColor = .white
+                terminalView.nativeForegroundColor = .black
+            }
         case .light:
             terminalView.nativeBackgroundColor = .white
             terminalView.nativeForegroundColor = .black

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
@@ -22,12 +22,14 @@ struct OrbitCockpitSettingsStoreTests {
 
         store.binding(\.terminal.fontSize).wrappedValue = 14
         store.binding(\.appearance.showDebugLogsByDefault).wrappedValue = true
+        store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
         store.binding(\.advanced.scrollbackLineLimit).wrappedValue = 20_000
 
         let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
 
         #expect(reloaded.settings.terminal.fontSize == 14)
         #expect(reloaded.settings.appearance.showDebugLogsByDefault)
+        #expect(!reloaded.settings.linksAndInput.optionKeySendsMeta)
         #expect(reloaded.settings.advanced.scrollbackLineLimit == 20_000)
     }
 
@@ -38,6 +40,7 @@ struct OrbitCockpitSettingsStoreTests {
 
         store.binding(\.terminal.fontSize).wrappedValue = 18
         store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
+        store.binding(\.linksAndInput.mouseReportingEnabled).wrappedValue = false
         store.binding(\.advanced.preferGPURenderer).wrappedValue = false
 
         store.resetToDefaults()

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -27,7 +27,16 @@ struct SwiftTermAdapterTests {
     @Test("Configured font size is applied to terminal view")
     @MainActor
     func testConfiguredFontSizeIsApplied() async throws {
-        let settings = TerminalSessionSettings(fontSize: 16, usesNerdFont: false, colorSchemePreference: .system)
+        let settings = TerminalSessionSettings(
+            fontSize: 16,
+            usesNerdFont: false,
+            useBrightColorsForBoldText: true,
+            useCustomBlockGlyphs: true,
+            antiAliasCustomBlockGlyphs: false,
+            colorSchemePreference: .system,
+            optionKeySendsMeta: true,
+            mouseReportingEnabled: true,
+            backspaceSendsControlH: false)
         let adapter = SwiftTermAdapter(settings: settings, onLog: nil)
 
         guard let terminalView = adapter.view as? LocalProcessTerminalView else {
@@ -36,5 +45,39 @@ struct SwiftTermAdapterTests {
         }
 
         #expect(terminalView.font.pointSize == 16)
+    }
+
+    @Test("Live-applied SwiftTerm settings update an existing terminal view")
+    @MainActor
+    func testApplyTerminalSettingsUpdatesExistingView() async throws {
+        let adapter = SwiftTermAdapter(onLog: nil)
+
+        guard let terminalView = adapter.view as? LocalProcessTerminalView else {
+            Issue.record("adapter.view is not a LocalProcessTerminalView")
+            return
+        }
+
+        adapter.applyTerminalSettings(
+            TerminalSessionSettings(
+                fontSize: 15,
+                usesNerdFont: false,
+                useBrightColorsForBoldText: false,
+                useCustomBlockGlyphs: false,
+                antiAliasCustomBlockGlyphs: true,
+                colorSchemePreference: .light,
+                optionKeySendsMeta: false,
+                mouseReportingEnabled: false,
+                backspaceSendsControlH: true),
+            isDark: true)
+
+        #expect(terminalView.font.pointSize == 15)
+        #expect(!terminalView.optionAsMetaKey)
+        #expect(!terminalView.allowMouseReporting)
+        #expect(terminalView.backspaceSendsControlH)
+        #expect(!terminalView.useBrightColors)
+        #expect(!terminalView.customBlockGlyphs)
+        #expect(terminalView.antiAliasCustomBlockGlyphs)
+        #expect(terminalView.nativeBackgroundColor == .white)
+        #expect(terminalView.nativeForegroundColor == .black)
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -9,6 +9,7 @@ import Testing
 final class MockTerminalEngine: OrbitTerminalEngine {
     let view = NSView()
     var isDarkModeCalls: [Bool] = []
+    var appliedSettings: [(TerminalSessionSettings, Bool)] = []
 
     func feed(data: Data) {}
 
@@ -18,6 +19,10 @@ final class MockTerminalEngine: OrbitTerminalEngine {
 
     func getBuffer() -> String {
         ""
+    }
+
+    func applyTerminalSettings(_ settings: TerminalSessionSettings, isDark: Bool) {
+        appliedSettings.append((settings, isDark))
     }
 
     func isDarkMode(_ isDark: Bool) {
@@ -172,7 +177,13 @@ struct TerminalManagerTests {
         var configured = OrbitCockpitSettings.defaults
         configured.terminal.fontSize = 15
         configured.terminal.usesNerdFont = false
+        configured.terminal.useBrightColorsForBoldText = false
+        configured.terminal.useCustomBlockGlyphs = false
+        configured.terminal.antiAliasCustomBlockGlyphs = true
         configured.appearance.terminalColorSchemePreference = .dark
+        configured.linksAndInput.optionKeySendsMeta = false
+        configured.linksAndInput.mouseReportingEnabled = false
+        configured.linksAndInput.backspaceSendsControlH = true
         defaults.set(try JSONEncoder().encode(configured), forKey: OrbitCockpitSettingsStore.defaultStorageKey)
         let reloadedStore = OrbitCockpitSettingsStore(defaults: defaults)
 
@@ -195,6 +206,61 @@ struct TerminalManagerTests {
                 == TerminalSessionSettings(
                     fontSize: 15,
                     usesNerdFont: false,
-                    colorSchemePreference: .dark))
+                    useBrightColorsForBoldText: false,
+                    useCustomBlockGlyphs: false,
+                    antiAliasCustomBlockGlyphs: true,
+                    colorSchemePreference: .dark,
+                    optionKeySendsMeta: false,
+                    mouseReportingEnabled: false,
+                    backspaceSendsControlH: true))
+    }
+
+    @Test("Running sessions receive live-applied terminal settings updates")
+    @MainActor
+    func testSettingsStoreUpdatesRunningSessions() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.LiveApply.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+        let manager = TerminalManager(monitor: ActivityMonitor(), settingsStore: store)
+        let engine = MockTerminalEngine()
+        let session = MockTerminalSession(engine: engine)
+
+        manager.installSession(session, for: "TUI")
+        #expect(engine.appliedSettings.count == 1)
+
+        store.binding(\.terminal.fontSize).wrappedValue = 18
+        store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
+        store.binding(\.linksAndInput.backspaceSendsControlH).wrappedValue = true
+
+        let latest = try #require(engine.appliedSettings.last)
+        #expect(latest.0.fontSize == 18)
+        #expect(!latest.0.optionKeySendsMeta)
+        #expect(latest.0.backspaceSendsControlH)
+    }
+
+    @Test("New sessions inherit updated settings snapshots")
+    @MainActor
+    func testNewSessionsInheritUpdatedSettings() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.NewSessions.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+        let launcher = RecordingSessionLauncher()
+        let manager = TerminalManager(
+            monitor: ActivityMonitor(),
+            settingsStore: store,
+            sessionLauncher: launcher)
+
+        store.binding(\.terminal.fontSize).wrappedValue = 17
+        store.binding(\.linksAndInput.mouseReportingEnabled).wrappedValue = false
+
+        _ = manager.makeSession(
+            request: TerminalLaunchRequest(
+                executable: URL(fileURLWithPath: "/usr/bin/env"),
+                arguments: ["true"],
+                environment: nil,
+                currentDirectoryURL: nil),
+            onTerminate: { _ in })
+
+        let launchedSettings = try #require(launcher.lastSettings)
+        #expect(launchedSettings.fontSize == 17)
+        #expect(!launchedSettings.mouseReportingEnabled)
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -231,6 +231,17 @@ struct TerminalManagerTests {
         store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
         store.binding(\.linksAndInput.backspaceSendsControlH).wrappedValue = true
 
+        for _ in 0..<20 {
+            if let latest = engine.appliedSettings.last,
+                latest.0.fontSize == 18,
+                latest.0.optionKeySendsMeta == false,
+                latest.0.backspaceSendsControlH
+            {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
         let latest = try #require(engine.appliedSettings.last)
         #expect(latest.0.fontSize == 18)
         #expect(!latest.0.optionKeySendsMeta)


### PR DESCRIPTION
## Summary

- expand the typed terminal settings snapshot with the explicit SwiftTerm subset that is safe to apply to running macOS terminal views
- apply that subset to existing panes through `OrbitTerminalEngine.applyTerminalSettings`, while preserving inheritance for newly launched sessions
- extend the native settings UI and tests to distinguish live-applied behavior from launch-time session defaults

## Validation

- `export GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache TMPDIR=$(pwd)/tmp HOME=$(pwd)/tmp/swift-home`
- `rtk make native/check`
- `HOME=$(pwd)/tmp/test-home XDG_CONFIG_HOME=$(pwd)/tmp/test-home/.config XDG_DATA_HOME=$(pwd)/tmp/test-home/.local/share XDG_STATE_HOME=$(pwd)/tmp/test-home/.local/state TMPDIR=$(pwd)/tmp GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache rtk make go/build`
- `HOME=$(pwd)/tmp/test-home XDG_CONFIG_HOME=$(pwd)/tmp/test-home/.config XDG_DATA_HOME=$(pwd)/tmp/test-home/.local/share XDG_STATE_HOME=$(pwd)/tmp/test-home/.local/state TMPDIR=$(pwd)/tmp GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache rtk make go/test`
- `HOME=$(pwd)/tmp/test-home XDG_CONFIG_HOME=$(pwd)/tmp/test-home/.config XDG_DATA_HOME=$(pwd)/tmp/test-home/.local/share XDG_STATE_HOME=$(pwd)/tmp/test-home/.local/state TMPDIR=$(pwd)/tmp GOCACHE=$(pwd)/tmp/go-cache GOLANGCI_LINT_CACHE=$(pwd)/tmp/lint-cache rtk make check`

Refs #456