### PR TITLE
[03] Add session-bound SwiftTerm terminal options (#457)

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -455,6 +455,7 @@ protocol TerminalSessionLaunching {
     func launchSession(
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
+        startupSettings: TerminalStartupSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
@@ -466,11 +467,16 @@ struct SwiftTermSessionLauncher: TerminalSessionLaunching {
     func launchSession(
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
+        startupSettings: TerminalStartupSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
     ) -> TerminalProcessSession {
-        let adapter = SwiftTermAdapter(settings: settings, onLog: onLog, onTerminate: onTerminate)
+        let adapter = SwiftTermAdapter(
+            settings: settings,
+            startupSettings: startupSettings,
+            onLog: onLog,
+            onTerminate: onTerminate)
         adapter.isDarkMode(isDark)
         adapter.startProcess(request: request)
         return adapter
@@ -518,8 +524,10 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
             .store(in: &cancellables)
 
         settingsStore.$settings
+            .map(\.terminalSessionSettings)
+            .removeDuplicates()
             .sink { [weak self] settings in
-                self?.applySettingsToRunningSessions(settings.terminalSessionSettings)
+                self?.applySettingsToRunningSessions(settings)
             }
             .store(in: &cancellables)
 
@@ -556,6 +564,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
         sessionLauncher.launchSession(
             request: request,
             settings: settingsStore.terminalSessionSettings,
+            startupSettings: settingsStore.terminalStartupSettings,
             isDark: isDark,
             onLog: onLog,
             onTerminate: onTerminate

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
@@ -18,6 +18,46 @@ enum TerminalColorSchemePreference: String, CaseIterable, Codable, Sendable {
     }
 }
 
+enum TerminalCursorStylePreference: String, CaseIterable, Codable, Sendable {
+    case blinkBlock
+    case steadyBlock
+    case blinkUnderline
+    case steadyUnderline
+    case blinkBar
+    case steadyBar
+
+    var label: String {
+        switch self {
+        case .blinkBlock:
+            "Blinking Block"
+        case .steadyBlock:
+            "Steady Block"
+        case .blinkUnderline:
+            "Blinking Underline"
+        case .steadyUnderline:
+            "Steady Underline"
+        case .blinkBar:
+            "Blinking Bar"
+        case .steadyBar:
+            "Steady Bar"
+        }
+    }
+}
+
+enum TerminalAnsi256PaletteStrategyPreference: String, CaseIterable, Codable, Sendable {
+    case xterm
+    case base16Lab
+
+    var label: String {
+        switch self {
+        case .xterm:
+            "xterm"
+        case .base16Lab:
+            "Base16 LAB"
+        }
+    }
+}
+
 struct OrbitCockpitSettings: Equatable, Codable, Sendable {
     struct Terminal: Equatable, Codable, Sendable {
         var fontSize: Double = 12
@@ -42,6 +82,12 @@ struct OrbitCockpitSettings: Equatable, Codable, Sendable {
     struct Advanced: Equatable, Codable, Sendable {
         var preferGPURenderer: Bool = true
         var scrollbackLineLimit: Int = 10_000
+        var cursorStyle: TerminalCursorStylePreference = .blinkBlock
+        var termName: String = "xterm-256color"
+        var tabWidth: Int = 8
+        var screenReaderMode: Bool = false
+        var sixelSupportEnabled: Bool = true
+        var ansi256PaletteStrategy: TerminalAnsi256PaletteStrategyPreference = .base16Lab
     }
 
     var terminal: Terminal = .init()
@@ -75,6 +121,25 @@ struct TerminalSessionSettings: Equatable, Sendable {
         backspaceSendsControlH: OrbitCockpitSettings.defaults.linksAndInput.backspaceSendsControlH)
 }
 
+struct TerminalStartupSettings: Equatable, Sendable {
+    var scrollbackLineLimit: Int
+    var cursorStyle: TerminalCursorStylePreference
+    var termName: String
+    var tabWidth: Int
+    var screenReaderMode: Bool
+    var sixelSupportEnabled: Bool
+    var ansi256PaletteStrategy: TerminalAnsi256PaletteStrategyPreference
+
+    static let defaults = TerminalStartupSettings(
+        scrollbackLineLimit: OrbitCockpitSettings.defaults.advanced.scrollbackLineLimit,
+        cursorStyle: OrbitCockpitSettings.defaults.advanced.cursorStyle,
+        termName: OrbitCockpitSettings.defaults.advanced.termName,
+        tabWidth: OrbitCockpitSettings.defaults.advanced.tabWidth,
+        screenReaderMode: OrbitCockpitSettings.defaults.advanced.screenReaderMode,
+        sixelSupportEnabled: OrbitCockpitSettings.defaults.advanced.sixelSupportEnabled,
+        ansi256PaletteStrategy: OrbitCockpitSettings.defaults.advanced.ansi256PaletteStrategy)
+}
+
 extension OrbitCockpitSettings {
     /// The explicit subset of terminal settings that Orbit Cockpit supports
     /// both for new sessions and live application to running SwiftTerm views.
@@ -89,6 +154,18 @@ extension OrbitCockpitSettings {
             optionKeySendsMeta: linksAndInput.optionKeySendsMeta,
             mouseReportingEnabled: linksAndInput.mouseReportingEnabled,
             backspaceSendsControlH: linksAndInput.backspaceSendsControlH)
+    }
+
+    /// Startup-only SwiftTerm configuration that applies when creating a new session.
+    var terminalStartupSettings: TerminalStartupSettings {
+        TerminalStartupSettings(
+            scrollbackLineLimit: advanced.scrollbackLineLimit,
+            cursorStyle: advanced.cursorStyle,
+            termName: advanced.termName,
+            tabWidth: advanced.tabWidth,
+            screenReaderMode: advanced.screenReaderMode,
+            sixelSupportEnabled: advanced.sixelSupportEnabled,
+            ansi256PaletteStrategy: advanced.ansi256PaletteStrategy)
     }
 }
 
@@ -114,6 +191,10 @@ final class OrbitCockpitSettingsStore: ObservableObject {
 
     var terminalSessionSettings: TerminalSessionSettings {
         settings.terminalSessionSettings
+    }
+
+    var terminalStartupSettings: TerminalStartupSettings {
+        settings.terminalStartupSettings
     }
 
     func binding<Value>(_ keyPath: WritableKeyPath<OrbitCockpitSettings, Value>) -> Binding<Value> {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -94,6 +94,11 @@ struct OrbitCockpitSettingsView: View {
                     Toggle(
                         "Prefer GPU rendering when available", isOn: settingsStore.binding(\.advanced.preferGPURenderer)
                     )
+                } header: {
+                    Text("Rendering")
+                }
+
+                Section {
 
                     Stepper(
                         value: settingsStore.binding(\.advanced.scrollbackLineLimit), in: 1_000...50_000, step: 1_000
@@ -105,11 +110,46 @@ struct OrbitCockpitSettingsView: View {
                                 .foregroundColor(.secondary)
                         }
                     }
+
+                    Picker("Cursor Style", selection: settingsStore.binding(\.advanced.cursorStyle)) {
+                        ForEach(TerminalCursorStylePreference.allCases, id: \.self) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+
+                    HStack {
+                        Text("TERM Value")
+                        TextField("xterm-256color", text: settingsStore.binding(\.advanced.termName))
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Stepper(value: settingsStore.binding(\.advanced.tabWidth), in: 2...16, step: 1) {
+                        HStack {
+                            Text("Tab Width")
+                            Spacer()
+                            Text("\(settingsStore.settings.advanced.tabWidth)")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Toggle(
+                        "Enable screen reader mode", isOn: settingsStore.binding(\.advanced.screenReaderMode))
+                    Toggle(
+                        "Advertise Sixel support", isOn: settingsStore.binding(\.advanced.sixelSupportEnabled))
+
+                    Picker(
+                        "ANSI 256 Palette",
+                        selection: settingsStore.binding(\.advanced.ansi256PaletteStrategy)
+                    ) {
+                        ForEach(TerminalAnsi256PaletteStrategyPreference.allCases, id: \.self) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
                 } header: {
-                    Text("Advanced")
+                    Text("New Session Startup")
                 } footer: {
                     Text(
-                        "Advanced values are persisted behind the native settings model so future engine-specific work stays decoupled from raw storage."
+                        "These settings apply to new terminal sessions only. Existing panes keep their current startup configuration."
                     )
                 }
             }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -6,6 +6,7 @@ import SwiftTerm
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
     private var settings: TerminalSessionSettings
+    private let startupSettings: TerminalStartupSettings
     private let processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)?
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
@@ -16,19 +17,36 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
 
     init(
         settings: TerminalSessionSettings = .defaults,
+        startupSettings: TerminalStartupSettings = .defaults,
         terminalView: LocalProcessTerminalView = LocalProcessTerminalView(frame: .zero),
         processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)? = nil,
         onLog: ((String, LogLevel) -> Void)? = nil,
         onTerminate: ((Int32?) -> Void)? = nil
     ) {
         self.settings = settings
+        self.startupSettings = startupSettings
         self.processStarter = processStarter
         self.onLog = onLog
         self.onTerminate = onTerminate
         self.terminalView = terminalView
         super.init()
         self.terminalView.processDelegate = self
+        applyStartupTerminalOptions()
         applyTerminalSettings(settings, isDark: false)
+    }
+
+    private func applyStartupTerminalOptions() {
+        let terminal = terminalView.getTerminal()
+        var options = terminal.options
+        options.scrollback = startupSettings.scrollbackLineLimit
+        options.termName = startupSettings.termName
+        options.cursorStyle = startupSettings.cursorStyle.swiftTermCursorStyle
+        options.screenReaderMode = startupSettings.screenReaderMode
+        options.tabStopWidth = startupSettings.tabWidth
+        options.enableSixelReported = startupSettings.sixelSupportEnabled
+        options.ansi256PaletteStrategy = startupSettings.ansi256PaletteStrategy.swiftTermStrategy
+        terminal.options = options
+        terminal.setup(isReset: true)
     }
 
     private func setupFont() {
@@ -180,5 +198,35 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
 
     func terminateProcess() {
         terminalView.terminate()
+    }
+}
+
+extension TerminalCursorStylePreference {
+    fileprivate var swiftTermCursorStyle: CursorStyle {
+        switch self {
+        case .blinkBlock:
+            .blinkBlock
+        case .steadyBlock:
+            .steadyBlock
+        case .blinkUnderline:
+            .blinkUnderline
+        case .steadyUnderline:
+            .steadyUnderline
+        case .blinkBar:
+            .blinkBar
+        case .steadyBar:
+            .steadyBar
+        }
+    }
+}
+
+extension TerminalAnsi256PaletteStrategyPreference {
+    fileprivate var swiftTermStrategy: Ansi256PaletteStrategy {
+        switch self {
+        case .xterm:
+            .xterm
+        case .base16Lab:
+            .base16Lab
+        }
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
@@ -24,6 +24,12 @@ struct OrbitCockpitSettingsStoreTests {
         store.binding(\.appearance.showDebugLogsByDefault).wrappedValue = true
         store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
         store.binding(\.advanced.scrollbackLineLimit).wrappedValue = 20_000
+        store.binding(\.advanced.cursorStyle).wrappedValue = .steadyBar
+        store.binding(\.advanced.termName).wrappedValue = "xterm-gh-orbit"
+        store.binding(\.advanced.tabWidth).wrappedValue = 4
+        store.binding(\.advanced.screenReaderMode).wrappedValue = true
+        store.binding(\.advanced.sixelSupportEnabled).wrappedValue = false
+        store.binding(\.advanced.ansi256PaletteStrategy).wrappedValue = .xterm
 
         let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
 
@@ -31,6 +37,12 @@ struct OrbitCockpitSettingsStoreTests {
         #expect(reloaded.settings.appearance.showDebugLogsByDefault)
         #expect(!reloaded.settings.linksAndInput.optionKeySendsMeta)
         #expect(reloaded.settings.advanced.scrollbackLineLimit == 20_000)
+        #expect(reloaded.settings.advanced.cursorStyle == .steadyBar)
+        #expect(reloaded.settings.advanced.termName == "xterm-gh-orbit")
+        #expect(reloaded.settings.advanced.tabWidth == 4)
+        #expect(reloaded.settings.advanced.screenReaderMode)
+        #expect(!reloaded.settings.advanced.sixelSupportEnabled)
+        #expect(reloaded.settings.advanced.ansi256PaletteStrategy == .xterm)
     }
 
     @Test("Reset to defaults restores canonical values")

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -8,6 +8,20 @@ import Testing
 @Suite("SwiftTermAdapter Tests")
 struct SwiftTermAdapterTests {
 
+    private static func isSteadyBar(_ style: CursorStyle) -> Bool {
+        if case .steadyBar = style {
+            return true
+        }
+        return false
+    }
+
+    private static func isXtermPalette(_ strategy: Ansi256PaletteStrategy) -> Bool {
+        if case .xterm = strategy {
+            return true
+        }
+        return false
+    }
+
     @Test("Font initialization")
     @MainActor
     func testFontInitialization() async throws {
@@ -45,6 +59,34 @@ struct SwiftTermAdapterTests {
         }
 
         #expect(terminalView.font.pointSize == 16)
+    }
+
+    @Test("Startup-only SwiftTerm settings are configured on the terminal")
+    @MainActor
+    func testStartupSettingsAreAppliedOnInitialization() async throws {
+        let startupSettings = TerminalStartupSettings(
+            scrollbackLineLimit: 20_000,
+            cursorStyle: .steadyBar,
+            termName: "xterm-gh-orbit",
+            tabWidth: 4,
+            screenReaderMode: true,
+            sixelSupportEnabled: false,
+            ansi256PaletteStrategy: .xterm)
+        let adapter = SwiftTermAdapter(startupSettings: startupSettings, onLog: nil)
+
+        guard let terminalView = adapter.view as? LocalProcessTerminalView else {
+            Issue.record("adapter.view is not a LocalProcessTerminalView")
+            return
+        }
+
+        let options = terminalView.getTerminal().options
+        #expect(options.scrollback == 20_000)
+        #expect(Self.isSteadyBar(options.cursorStyle))
+        #expect(options.termName == "xterm-gh-orbit")
+        #expect(options.tabStopWidth == 4)
+        #expect(options.screenReaderMode)
+        #expect(!options.enableSixelReported)
+        #expect(Self.isXtermPalette(options.ansi256PaletteStrategy))
     }
 
     @Test("Live-applied SwiftTerm settings update an existing terminal view")

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -53,6 +53,7 @@ final class MockTerminalSession: TerminalProcessSession {
 final class RecordingSessionLauncher: TerminalSessionLaunching {
     var lastRequest: TerminalLaunchRequest?
     var lastSettings: TerminalSessionSettings?
+    var lastStartupSettings: TerminalStartupSettings?
     var lastIsDark: Bool?
     let session: TerminalProcessSession
 
@@ -63,12 +64,14 @@ final class RecordingSessionLauncher: TerminalSessionLaunching {
     func launchSession(
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
+        startupSettings: TerminalStartupSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
     ) -> TerminalProcessSession {
         lastRequest = request
         lastSettings = settings
+        lastStartupSettings = startupSettings
         lastIsDark = isDark
         return session
     }
@@ -184,6 +187,13 @@ struct TerminalManagerTests {
         configured.linksAndInput.optionKeySendsMeta = false
         configured.linksAndInput.mouseReportingEnabled = false
         configured.linksAndInput.backspaceSendsControlH = true
+        configured.advanced.scrollbackLineLimit = 20_000
+        configured.advanced.cursorStyle = .steadyBar
+        configured.advanced.termName = "xterm-gh-orbit"
+        configured.advanced.tabWidth = 4
+        configured.advanced.screenReaderMode = true
+        configured.advanced.sixelSupportEnabled = false
+        configured.advanced.ansi256PaletteStrategy = .xterm
         defaults.set(try JSONEncoder().encode(configured), forKey: OrbitCockpitSettingsStore.defaultStorageKey)
         let reloadedStore = OrbitCockpitSettingsStore(defaults: defaults)
 
@@ -213,6 +223,16 @@ struct TerminalManagerTests {
                     optionKeySendsMeta: false,
                     mouseReportingEnabled: false,
                     backspaceSendsControlH: true))
+        #expect(
+            launcher.lastStartupSettings
+                == TerminalStartupSettings(
+                    scrollbackLineLimit: 20_000,
+                    cursorStyle: .steadyBar,
+                    termName: "xterm-gh-orbit",
+                    tabWidth: 4,
+                    screenReaderMode: true,
+                    sixelSupportEnabled: false,
+                    ansi256PaletteStrategy: .xterm))
     }
 
     @Test("Running sessions receive live-applied terminal settings updates")
@@ -248,6 +268,27 @@ struct TerminalManagerTests {
         #expect(latest.0.backspaceSendsControlH)
     }
 
+    @Test("Startup-only settings do not live-apply to running sessions")
+    @MainActor
+    func testStartupSettingsDoNotUpdateRunningSessions() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.StartupOnly.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+        let manager = TerminalManager(monitor: ActivityMonitor(), settingsStore: store)
+        let engine = MockTerminalEngine()
+        let session = MockTerminalSession(engine: engine)
+
+        manager.installSession(session, for: "TUI")
+        #expect(engine.appliedSettings.count == 1)
+
+        store.binding(\.advanced.cursorStyle).wrappedValue = .steadyBar
+        store.binding(\.advanced.scrollbackLineLimit).wrappedValue = 20_000
+        store.binding(\.advanced.termName).wrappedValue = "xterm-gh-orbit"
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        #expect(engine.appliedSettings.count == 1)
+    }
+
     @Test("New sessions inherit updated settings snapshots")
     @MainActor
     func testNewSessionsInheritUpdatedSettings() async throws {
@@ -261,6 +302,9 @@ struct TerminalManagerTests {
 
         store.binding(\.terminal.fontSize).wrappedValue = 17
         store.binding(\.linksAndInput.mouseReportingEnabled).wrappedValue = false
+        store.binding(\.advanced.cursorStyle).wrappedValue = .steadyUnderline
+        store.binding(\.advanced.tabWidth).wrappedValue = 4
+        store.binding(\.advanced.sixelSupportEnabled).wrappedValue = false
 
         _ = manager.makeSession(
             request: TerminalLaunchRequest(
@@ -273,5 +317,9 @@ struct TerminalManagerTests {
         let launchedSettings = try #require(launcher.lastSettings)
         #expect(launchedSettings.fontSize == 17)
         #expect(!launchedSettings.mouseReportingEnabled)
+        let launchedStartupSettings = try #require(launcher.lastStartupSettings)
+        #expect(launchedStartupSettings.cursorStyle == .steadyUnderline)
+        #expect(launchedStartupSettings.tabWidth == 4)
+        #expect(!launchedStartupSettings.sixelSupportEnabled)
     }
 }


### PR DESCRIPTION
## Summary
- add launch-only SwiftTerm startup settings for new sessions
- keep live-applied pane settings separate from startup-only TerminalOptions
- add native tests for persistence, launch propagation, and non-live startup behavior

## Testing
- rtk make native/test
- rtk make check

Closes #457
