### PR TITLE
[04] Add SwiftTerm GPU/rendering settings with safe fallback behavior (#458)

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitApp.swift
@@ -456,6 +456,7 @@ protocol TerminalSessionLaunching {
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
         startupSettings: TerminalStartupSettings,
+        rendererSettings: TerminalRendererSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
@@ -468,6 +469,7 @@ struct SwiftTermSessionLauncher: TerminalSessionLaunching {
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
         startupSettings: TerminalStartupSettings,
+        rendererSettings: TerminalRendererSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
@@ -475,6 +477,7 @@ struct SwiftTermSessionLauncher: TerminalSessionLaunching {
         let adapter = SwiftTermAdapter(
             settings: settings,
             startupSettings: startupSettings,
+            rendererSettings: rendererSettings,
             onLog: onLog,
             onTerminate: onTerminate)
         adapter.isDarkMode(isDark)
@@ -531,6 +534,14 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
             }
             .store(in: &cancellables)
 
+        settingsStore.$settings
+            .map(\.terminalRendererSettings)
+            .removeDuplicates()
+            .sink { [weak self] settings in
+                self?.applyRendererSettingsToRunningSessions(settings)
+            }
+            .store(in: &cancellables)
+
         self.engineManager = newManager
     }
 
@@ -565,6 +576,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
             request: request,
             settings: settingsStore.terminalSessionSettings,
             startupSettings: settingsStore.terminalStartupSettings,
+            rendererSettings: settingsStore.terminalRendererSettings,
             isDark: isDark,
             onLog: onLog,
             onTerminate: onTerminate
@@ -574,6 +586,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     func installSession(_ session: TerminalProcessSession, for name: String, state: TerminalPaneState = .running) {
         guard !name.hasPrefix(Self.workspacePanePrefix) else { return }
         panes[name] = TerminalPaneSession(state: state, session: session)
+        session.engine.applyRendererSettings(settingsStore.terminalRendererSettings)
         session.engine.applyTerminalSettings(settingsStore.terminalSessionSettings, isDark: isDark)
     }
 
@@ -586,6 +599,7 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     func installWorkspaceSession(_ session: TerminalProcessSession, for name: String) -> Bool {
         guard name.hasPrefix(Self.workspacePanePrefix), panes[name] != nil else { return false }
         panes[name] = TerminalPaneSession(state: .running, session: session)
+        session.engine.applyRendererSettings(settingsStore.terminalRendererSettings)
         session.engine.applyTerminalSettings(settingsStore.terminalSessionSettings, isDark: isDark)
         return true
     }
@@ -593,6 +607,12 @@ class TerminalManager: ObservableObject, TerminalSessionCreating {
     private func applySettingsToRunningSessions(_ settings: TerminalSessionSettings) {
         for pane in panes.values {
             pane.session?.engine.applyTerminalSettings(settings, isDark: isDark)
+        }
+    }
+
+    private func applyRendererSettingsToRunningSessions(_ settings: TerminalRendererSettings) {
+        for pane in panes.values {
+            pane.session?.engine.applyRendererSettings(settings)
         }
     }
 

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettings.swift
@@ -58,6 +58,20 @@ enum TerminalAnsi256PaletteStrategyPreference: String, CaseIterable, Codable, Se
     }
 }
 
+enum TerminalMetalBufferingModePreference: String, CaseIterable, Codable, Sendable {
+    case perRowPersistent
+    case perFrameAggregated
+
+    var label: String {
+        switch self {
+        case .perRowPersistent:
+            "Per Row Persistent"
+        case .perFrameAggregated:
+            "Per Frame Aggregated"
+        }
+    }
+}
+
 struct OrbitCockpitSettings: Equatable, Codable, Sendable {
     struct Terminal: Equatable, Codable, Sendable {
         var fontSize: Double = 12
@@ -81,6 +95,7 @@ struct OrbitCockpitSettings: Equatable, Codable, Sendable {
 
     struct Advanced: Equatable, Codable, Sendable {
         var preferGPURenderer: Bool = true
+        var metalBufferingMode: TerminalMetalBufferingModePreference = .perRowPersistent
         var scrollbackLineLimit: Int = 10_000
         var cursorStyle: TerminalCursorStylePreference = .blinkBlock
         var termName: String = "xterm-256color"
@@ -140,6 +155,26 @@ struct TerminalStartupSettings: Equatable, Sendable {
         ansi256PaletteStrategy: OrbitCockpitSettings.defaults.advanced.ansi256PaletteStrategy)
 }
 
+struct TerminalRendererSettings: Equatable, Sendable {
+    var useMetalRenderer: Bool
+    var metalBufferingMode: TerminalMetalBufferingModePreference
+
+    static let defaults = TerminalRendererSettings(
+        useMetalRenderer: OrbitCockpitSettings.defaults.advanced.preferGPURenderer,
+        metalBufferingMode: OrbitCockpitSettings.defaults.advanced.metalBufferingMode)
+}
+
+struct TerminalRendererStatus: Equatable, Sendable {
+    var preferredMetalRenderer: Bool
+    var isUsingMetalRenderer: Bool
+    var lastRendererError: String?
+
+    static let defaults = TerminalRendererStatus(
+        preferredMetalRenderer: TerminalRendererSettings.defaults.useMetalRenderer,
+        isUsingMetalRenderer: false,
+        lastRendererError: nil)
+}
+
 extension OrbitCockpitSettings {
     /// The explicit subset of terminal settings that Orbit Cockpit supports
     /// both for new sessions and live application to running SwiftTerm views.
@@ -166,6 +201,13 @@ extension OrbitCockpitSettings {
             screenReaderMode: advanced.screenReaderMode,
             sixelSupportEnabled: advanced.sixelSupportEnabled,
             ansi256PaletteStrategy: advanced.ansi256PaletteStrategy)
+    }
+
+    /// Runtime-safe renderer settings that can be applied to existing SwiftTerm views.
+    var terminalRendererSettings: TerminalRendererSettings {
+        TerminalRendererSettings(
+            useMetalRenderer: advanced.preferGPURenderer,
+            metalBufferingMode: advanced.metalBufferingMode)
     }
 }
 
@@ -195,6 +237,10 @@ final class OrbitCockpitSettingsStore: ObservableObject {
 
     var terminalStartupSettings: TerminalStartupSettings {
         settings.terminalStartupSettings
+    }
+
+    var terminalRendererSettings: TerminalRendererSettings {
+        settings.terminalRendererSettings
     }
 
     func binding<Value>(_ keyPath: WritableKeyPath<OrbitCockpitSettings, Value>) -> Binding<Value> {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -92,10 +92,24 @@ struct OrbitCockpitSettingsView: View {
             Form {
                 Section {
                     Toggle(
-                        "Prefer GPU rendering when available", isOn: settingsStore.binding(\.advanced.preferGPURenderer)
+                        "Use Metal renderer when available",
+                        isOn: settingsStore.binding(\.advanced.preferGPURenderer)
                     )
+
+                    Picker(
+                        "Metal Buffering Mode",
+                        selection: settingsStore.binding(\.advanced.metalBufferingMode)
+                    ) {
+                        ForEach(TerminalMetalBufferingModePreference.allCases, id: \.self) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
                 } header: {
                     Text("Rendering")
+                } footer: {
+                    Text(
+                        "Renderer settings apply to running panes immediately when SwiftTerm can switch safely. If Metal activation fails, the pane stays usable on the CoreGraphics fallback path."
+                    )
                 }
 
                 Section {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
@@ -23,6 +23,12 @@ protocol OrbitTerminalEngine: AnyObject {
     /// Applies the live-supported terminal settings to an existing terminal view.
     func applyTerminalSettings(_ settings: TerminalSessionSettings, isDark: Bool)
 
+    /// Applies runtime-safe renderer settings to an existing terminal view.
+    func applyRendererSettings(_ settings: TerminalRendererSettings)
+
+    /// Reports the observed renderer status for this terminal view.
+    var rendererStatus: TerminalRendererStatus { get }
+
     /// Sets the terminal theme (e.g., Light or Dark).
     func isDarkMode(_ isDark: Bool)
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitTerminalEngine.swift
@@ -29,6 +29,9 @@ protocol OrbitTerminalEngine: AnyObject {
     /// Reports the observed renderer status for this terminal view.
     var rendererStatus: TerminalRendererStatus { get }
 
+    /// Notifies the engine that its view has attached to a window.
+    func didAttachToWindow()
+
     /// Sets the terminal theme (e.g., Light or Dark).
     func isDarkMode(_ isDark: Bool)
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -3,28 +3,46 @@ import Foundation
 import SwiftTerm
 
 @MainActor
+protocol TerminalRendererControlling: AnyObject {
+    var metalBufferingMode: MetalBufferingMode { get set }
+    var isUsingMetalRenderer: Bool { get }
+    func setUseMetal(_ enabled: Bool) throws
+}
+
+extension LocalProcessTerminalView: TerminalRendererControlling {}
+
+@MainActor
 class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProcessTerminalViewDelegate {
     private let terminalView: LocalProcessTerminalView
     private var settings: TerminalSessionSettings
     private let startupSettings: TerminalStartupSettings
+    private let rendererController: any TerminalRendererControlling
     private let processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)?
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
+    private var currentRendererStatus = TerminalRendererStatus.defaults
 
     var view: NSView {
         return terminalView
     }
 
+    var rendererStatus: TerminalRendererStatus {
+        currentRendererStatus
+    }
+
     init(
         settings: TerminalSessionSettings = .defaults,
         startupSettings: TerminalStartupSettings = .defaults,
+        rendererSettings: TerminalRendererSettings = .defaults,
         terminalView: LocalProcessTerminalView = LocalProcessTerminalView(frame: .zero),
+        rendererController: (any TerminalRendererControlling)? = nil,
         processStarter: ((LocalProcessTerminalView, TerminalLaunchRequest) -> Void)? = nil,
         onLog: ((String, LogLevel) -> Void)? = nil,
         onTerminate: ((Int32?) -> Void)? = nil
     ) {
         self.settings = settings
         self.startupSettings = startupSettings
+        self.rendererController = rendererController ?? terminalView
         self.processStarter = processStarter
         self.onLog = onLog
         self.onTerminate = onTerminate
@@ -32,6 +50,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         super.init()
         self.terminalView.processDelegate = self
         applyStartupTerminalOptions()
+        applyRendererSettings(rendererSettings)
         applyTerminalSettings(settings, isDark: false)
     }
 
@@ -154,6 +173,32 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         refreshDisplay()
     }
 
+    func applyRendererSettings(_ settings: TerminalRendererSettings) {
+        rendererController.metalBufferingMode = settings.metalBufferingMode.swiftTermMode
+        do {
+            try rendererController.setUseMetal(settings.useMetalRenderer)
+            currentRendererStatus = TerminalRendererStatus(
+                preferredMetalRenderer: settings.useMetalRenderer,
+                isUsingMetalRenderer: rendererController.isUsingMetalRenderer,
+                lastRendererError: nil)
+        } catch let error as MetalError {
+            try? rendererController.setUseMetal(false)
+            currentRendererStatus = TerminalRendererStatus(
+                preferredMetalRenderer: settings.useMetalRenderer,
+                isUsingMetalRenderer: rendererController.isUsingMetalRenderer,
+                lastRendererError: error.description)
+            onLog?("Metal renderer fallback engaged: \(error.description)", .warning)
+        } catch {
+            try? rendererController.setUseMetal(false)
+            currentRendererStatus = TerminalRendererStatus(
+                preferredMetalRenderer: settings.useMetalRenderer,
+                isUsingMetalRenderer: rendererController.isUsingMetalRenderer,
+                lastRendererError: error.localizedDescription)
+            onLog?("Metal renderer fallback engaged: \(error.localizedDescription)", .warning)
+        }
+        refreshDisplay()
+    }
+
     func isDarkMode(_ isDark: Bool) {
         applyTheme(isDark: isDark)
     }
@@ -216,6 +261,17 @@ extension TerminalCursorStylePreference {
             .blinkBar
         case .steadyBar:
             .steadyBar
+        }
+    }
+}
+
+extension TerminalMetalBufferingModePreference {
+    fileprivate var swiftTermMode: MetalBufferingMode {
+        switch self {
+        case .perRowPersistent:
+            .perRowPersistent
+        case .perFrameAggregated:
+            .perFrameAggregated
         }
     }
 }

--- a/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/SwiftTermAdapter.swift
@@ -21,6 +21,8 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     private let onLog: ((String, LogLevel) -> Void)?
     private let onTerminate: ((Int32?) -> Void)?
     private var currentRendererStatus = TerminalRendererStatus.defaults
+    private var rendererSettings: TerminalRendererSettings
+    private var isAttachedToWindow = false
 
     var view: NSView {
         return terminalView
@@ -42,6 +44,7 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     ) {
         self.settings = settings
         self.startupSettings = startupSettings
+        self.rendererSettings = rendererSettings
         self.rendererController = rendererController ?? terminalView
         self.processStarter = processStarter
         self.onLog = onLog
@@ -50,7 +53,6 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
         super.init()
         self.terminalView.processDelegate = self
         applyStartupTerminalOptions()
-        applyRendererSettings(rendererSettings)
         applyTerminalSettings(settings, isDark: false)
     }
 
@@ -174,7 +176,15 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
     }
 
     func applyRendererSettings(_ settings: TerminalRendererSettings) {
+        rendererSettings = settings
         rendererController.metalBufferingMode = settings.metalBufferingMode.swiftTermMode
+        guard isAttachedToWindow || !settings.useMetalRenderer else {
+            currentRendererStatus = TerminalRendererStatus(
+                preferredMetalRenderer: settings.useMetalRenderer,
+                isUsingMetalRenderer: rendererController.isUsingMetalRenderer,
+                lastRendererError: nil)
+            return
+        }
         do {
             try rendererController.setUseMetal(settings.useMetalRenderer)
             currentRendererStatus = TerminalRendererStatus(
@@ -197,6 +207,12 @@ class SwiftTermAdapter: NSObject, OrbitTerminalEngine, @preconcurrency LocalProc
             onLog?("Metal renderer fallback engaged: \(error.localizedDescription)", .warning)
         }
         refreshDisplay()
+    }
+
+    func didAttachToWindow() {
+        guard !isAttachedToWindow else { return }
+        isAttachedToWindow = true
+        applyRendererSettings(rendererSettings)
     }
 
     func isDarkMode(_ isDark: Bool) {

--- a/native/OrbitCockpit/Sources/OrbitCockpit/TerminalContainer.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/TerminalContainer.swift
@@ -76,6 +76,7 @@ class ThrottledContainerView: NSView {
     }
 
     private func resumeRendering() {
+        engine.didAttachToWindow()
         engine.view.isHidden = false
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
@@ -30,6 +30,8 @@ struct OrbitCockpitSettingsStoreTests {
         store.binding(\.advanced.screenReaderMode).wrappedValue = true
         store.binding(\.advanced.sixelSupportEnabled).wrappedValue = false
         store.binding(\.advanced.ansi256PaletteStrategy).wrappedValue = .xterm
+        store.binding(\.advanced.preferGPURenderer).wrappedValue = false
+        store.binding(\.advanced.metalBufferingMode).wrappedValue = .perFrameAggregated
 
         let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
 
@@ -43,6 +45,8 @@ struct OrbitCockpitSettingsStoreTests {
         #expect(reloaded.settings.advanced.screenReaderMode)
         #expect(!reloaded.settings.advanced.sixelSupportEnabled)
         #expect(reloaded.settings.advanced.ansi256PaletteStrategy == .xterm)
+        #expect(!reloaded.settings.advanced.preferGPURenderer)
+        #expect(reloaded.settings.advanced.metalBufferingMode == .perFrameAggregated)
     }
 
     @Test("Reset to defaults restores canonical values")

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -162,13 +162,20 @@ struct SwiftTermAdapterTests {
                 metalBufferingMode: .perFrameAggregated))
 
         #expect(Self.isPerFrameAggregated(rendererController.metalBufferingMode))
-        #expect(rendererController.setUseMetalCalls == [false, true])
+        #expect(rendererController.setUseMetalCalls.isEmpty)
+        #expect(adapter.rendererStatus.preferredMetalRenderer)
+        #expect(!adapter.rendererStatus.isUsingMetalRenderer)
+        #expect(adapter.rendererStatus.lastRendererError == nil)
+
+        adapter.didAttachToWindow()
+
+        #expect(rendererController.setUseMetalCalls == [true])
         #expect(adapter.rendererStatus.preferredMetalRenderer)
         #expect(adapter.rendererStatus.isUsingMetalRenderer)
         #expect(adapter.rendererStatus.lastRendererError == nil)
     }
 
-    @Test("Renderer settings preserve fallback when Metal activation fails")
+    @Test("Renderer settings preserve fallback when Metal activation fails after attachment")
     @MainActor
     func testApplyRendererSettingsFallbackOnMetalError() async throws {
         let rendererController = StubRendererController()
@@ -186,7 +193,14 @@ struct SwiftTermAdapterTests {
                 metalBufferingMode: .perFrameAggregated))
 
         #expect(Self.isPerFrameAggregated(rendererController.metalBufferingMode))
-        #expect(rendererController.setUseMetalCalls == [false, true, false])
+        #expect(rendererController.setUseMetalCalls.isEmpty)
+        #expect(adapter.rendererStatus.preferredMetalRenderer)
+        #expect(!adapter.rendererStatus.isUsingMetalRenderer)
+        #expect(adapter.rendererStatus.lastRendererError == nil)
+
+        adapter.didAttachToWindow()
+
+        #expect(rendererController.setUseMetalCalls == [true, false])
         #expect(adapter.rendererStatus.preferredMetalRenderer)
         #expect(!adapter.rendererStatus.isUsingMetalRenderer)
         #expect(adapter.rendererStatus.lastRendererError == MetalError.deviceUnavailable.description)

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/SwiftTermAdapterTests.swift
@@ -5,6 +5,21 @@ import Testing
 
 @testable import OrbitCockpit
 
+private final class StubRendererController: TerminalRendererControlling {
+    var metalBufferingMode: MetalBufferingMode = .perRowPersistent
+    var isUsingMetalRenderer = false
+    var setUseMetalCalls: [Bool] = []
+    var errorToThrow: Error?
+
+    func setUseMetal(_ enabled: Bool) throws {
+        setUseMetalCalls.append(enabled)
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        isUsingMetalRenderer = enabled
+    }
+}
+
 @Suite("SwiftTermAdapter Tests")
 struct SwiftTermAdapterTests {
 
@@ -17,6 +32,13 @@ struct SwiftTermAdapterTests {
 
     private static func isXtermPalette(_ strategy: Ansi256PaletteStrategy) -> Bool {
         if case .xterm = strategy {
+            return true
+        }
+        return false
+    }
+
+    private static func isPerFrameAggregated(_ mode: MetalBufferingMode) -> Bool {
+        if case .perFrameAggregated = mode {
             return true
         }
         return false
@@ -121,5 +143,52 @@ struct SwiftTermAdapterTests {
         #expect(terminalView.antiAliasCustomBlockGlyphs)
         #expect(terminalView.nativeBackgroundColor == .white)
         #expect(terminalView.nativeForegroundColor == .black)
+    }
+
+    @Test("Renderer settings apply successfully and report active Metal state")
+    @MainActor
+    func testApplyRendererSettingsSuccess() async throws {
+        let rendererController = StubRendererController()
+        let adapter = SwiftTermAdapter(
+            rendererSettings: TerminalRendererSettings(
+                useMetalRenderer: false,
+                metalBufferingMode: .perRowPersistent),
+            rendererController: rendererController,
+            onLog: nil)
+
+        adapter.applyRendererSettings(
+            TerminalRendererSettings(
+                useMetalRenderer: true,
+                metalBufferingMode: .perFrameAggregated))
+
+        #expect(Self.isPerFrameAggregated(rendererController.metalBufferingMode))
+        #expect(rendererController.setUseMetalCalls == [false, true])
+        #expect(adapter.rendererStatus.preferredMetalRenderer)
+        #expect(adapter.rendererStatus.isUsingMetalRenderer)
+        #expect(adapter.rendererStatus.lastRendererError == nil)
+    }
+
+    @Test("Renderer settings preserve fallback when Metal activation fails")
+    @MainActor
+    func testApplyRendererSettingsFallbackOnMetalError() async throws {
+        let rendererController = StubRendererController()
+        let adapter = SwiftTermAdapter(
+            rendererSettings: TerminalRendererSettings(
+                useMetalRenderer: false,
+                metalBufferingMode: .perRowPersistent),
+            rendererController: rendererController,
+            onLog: nil)
+        rendererController.errorToThrow = MetalError.deviceUnavailable
+
+        adapter.applyRendererSettings(
+            TerminalRendererSettings(
+                useMetalRenderer: true,
+                metalBufferingMode: .perFrameAggregated))
+
+        #expect(Self.isPerFrameAggregated(rendererController.metalBufferingMode))
+        #expect(rendererController.setUseMetalCalls == [false, true, false])
+        #expect(adapter.rendererStatus.preferredMetalRenderer)
+        #expect(!adapter.rendererStatus.isUsingMetalRenderer)
+        #expect(adapter.rendererStatus.lastRendererError == MetalError.deviceUnavailable.description)
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -35,6 +35,8 @@ final class MockTerminalEngine: OrbitTerminalEngine {
             lastRendererError: nil)
     }
 
+    func didAttachToWindow() {}
+
     func isDarkMode(_ isDark: Bool) {
         isDarkModeCalls.append(isDark)
     }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/TerminalManagerTests.swift
@@ -10,6 +10,8 @@ final class MockTerminalEngine: OrbitTerminalEngine {
     let view = NSView()
     var isDarkModeCalls: [Bool] = []
     var appliedSettings: [(TerminalSessionSettings, Bool)] = []
+    var appliedRendererSettings: [TerminalRendererSettings] = []
+    var rendererStatus = TerminalRendererStatus.defaults
 
     func feed(data: Data) {}
 
@@ -23,6 +25,14 @@ final class MockTerminalEngine: OrbitTerminalEngine {
 
     func applyTerminalSettings(_ settings: TerminalSessionSettings, isDark: Bool) {
         appliedSettings.append((settings, isDark))
+    }
+
+    func applyRendererSettings(_ settings: TerminalRendererSettings) {
+        appliedRendererSettings.append(settings)
+        rendererStatus = TerminalRendererStatus(
+            preferredMetalRenderer: settings.useMetalRenderer,
+            isUsingMetalRenderer: settings.useMetalRenderer,
+            lastRendererError: nil)
     }
 
     func isDarkMode(_ isDark: Bool) {
@@ -54,6 +64,7 @@ final class RecordingSessionLauncher: TerminalSessionLaunching {
     var lastRequest: TerminalLaunchRequest?
     var lastSettings: TerminalSessionSettings?
     var lastStartupSettings: TerminalStartupSettings?
+    var lastRendererSettings: TerminalRendererSettings?
     var lastIsDark: Bool?
     let session: TerminalProcessSession
 
@@ -65,6 +76,7 @@ final class RecordingSessionLauncher: TerminalSessionLaunching {
         request: TerminalLaunchRequest,
         settings: TerminalSessionSettings,
         startupSettings: TerminalStartupSettings,
+        rendererSettings: TerminalRendererSettings,
         isDark: Bool,
         onLog: ((String, LogLevel) -> Void)?,
         onTerminate: @escaping (Int32?) -> Void
@@ -72,6 +84,7 @@ final class RecordingSessionLauncher: TerminalSessionLaunching {
         lastRequest = request
         lastSettings = settings
         lastStartupSettings = startupSettings
+        lastRendererSettings = rendererSettings
         lastIsDark = isDark
         return session
     }
@@ -194,6 +207,8 @@ struct TerminalManagerTests {
         configured.advanced.screenReaderMode = true
         configured.advanced.sixelSupportEnabled = false
         configured.advanced.ansi256PaletteStrategy = .xterm
+        configured.advanced.preferGPURenderer = false
+        configured.advanced.metalBufferingMode = .perFrameAggregated
         defaults.set(try JSONEncoder().encode(configured), forKey: OrbitCockpitSettingsStore.defaultStorageKey)
         let reloadedStore = OrbitCockpitSettingsStore(defaults: defaults)
 
@@ -233,6 +248,11 @@ struct TerminalManagerTests {
                     screenReaderMode: true,
                     sixelSupportEnabled: false,
                     ansi256PaletteStrategy: .xterm))
+        #expect(
+            launcher.lastRendererSettings
+                == TerminalRendererSettings(
+                    useMetalRenderer: false,
+                    metalBufferingMode: .perFrameAggregated))
     }
 
     @Test("Running sessions receive live-applied terminal settings updates")
@@ -246,6 +266,7 @@ struct TerminalManagerTests {
 
         manager.installSession(session, for: "TUI")
         #expect(engine.appliedSettings.count == 1)
+        #expect(engine.appliedRendererSettings.count == 1)
 
         store.binding(\.terminal.fontSize).wrappedValue = 18
         store.binding(\.linksAndInput.optionKeySendsMeta).wrappedValue = false
@@ -266,6 +287,28 @@ struct TerminalManagerTests {
         #expect(latest.0.fontSize == 18)
         #expect(!latest.0.optionKeySendsMeta)
         #expect(latest.0.backspaceSendsControlH)
+    }
+
+    @Test("Running sessions receive live-applied renderer settings updates")
+    @MainActor
+    func testRendererSettingsUpdateRunningSessions() async throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.RendererLiveApply.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+        let manager = TerminalManager(monitor: ActivityMonitor(), settingsStore: store)
+        let engine = MockTerminalEngine()
+        let session = MockTerminalSession(engine: engine)
+
+        manager.installSession(session, for: "TUI")
+        #expect(engine.appliedRendererSettings.count == 1)
+
+        store.binding(\.advanced.preferGPURenderer).wrappedValue = false
+        store.binding(\.advanced.metalBufferingMode).wrappedValue = .perFrameAggregated
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        let latest = try #require(engine.appliedRendererSettings.last)
+        #expect(!latest.useMetalRenderer)
+        #expect(latest.metalBufferingMode == .perFrameAggregated)
     }
 
     @Test("Startup-only settings do not live-apply to running sessions")
@@ -305,6 +348,8 @@ struct TerminalManagerTests {
         store.binding(\.advanced.cursorStyle).wrappedValue = .steadyUnderline
         store.binding(\.advanced.tabWidth).wrappedValue = 4
         store.binding(\.advanced.sixelSupportEnabled).wrappedValue = false
+        store.binding(\.advanced.preferGPURenderer).wrappedValue = false
+        store.binding(\.advanced.metalBufferingMode).wrappedValue = .perFrameAggregated
 
         _ = manager.makeSession(
             request: TerminalLaunchRequest(
@@ -321,5 +366,8 @@ struct TerminalManagerTests {
         #expect(launchedStartupSettings.cursorStyle == .steadyUnderline)
         #expect(launchedStartupSettings.tabWidth == 4)
         #expect(!launchedStartupSettings.sixelSupportEnabled)
+        let launchedRendererSettings = try #require(launcher.lastRendererSettings)
+        #expect(!launchedRendererSettings.useMetalRenderer)
+        #expect(launchedRendererSettings.metalBufferingMode == .perFrameAggregated)
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated SwiftTerm renderer settings for Metal enablement and buffering mode
- defer Metal activation until the terminal view is attached to a window and preserve CoreGraphics fallback on failure
- add native tests for persistence, live renderer updates, and attachment-aware success/fallback behavior

## Testing
- rtk zsh -lc 'cd native/OrbitCockpit && HOME=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-home TMPDIR=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp swift test --disable-sandbox --build-path /Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-build --disable-xctest --enable-swift-testing'
- rtk make check

Closes #458
