### PR TITLE
[05] Add tests and documentation for native settings behavior

### DIFF
--- a/native/OrbitCockpit/Docs/SettingsBehavior.md
+++ b/native/OrbitCockpit/Docs/SettingsBehavior.md
@@ -1,0 +1,67 @@
+# Native Settings Behavior
+
+Orbit Cockpit’s native settings are organized by how they apply, not just by where they appear in the UI.
+
+## Live-Applied Settings
+
+These settings update already-running SwiftTerm panes without restarting the session.
+
+- Font size
+- Nerd Font preference
+- Bright colors for bold text
+- Custom block glyph settings
+- Terminal theme
+- Option-as-Meta behavior
+- Mouse reporting
+- Backspace sends Control-H
+
+User-facing rule:
+
+- Changes take effect immediately for running panes.
+- New terminal sessions also start with the updated values.
+
+## New-Session-Only Settings
+
+These settings are applied when a terminal session is created.
+
+- Scrollback line limit
+- Cursor style
+- `TERM` value
+- Tab width
+- Screen reader mode
+- Sixel support advertisement
+- ANSI 256-color palette strategy
+
+User-facing rule:
+
+- Changes apply to new terminal sessions.
+- Existing panes keep the startup configuration they were launched with.
+
+Orbit Cockpit intentionally does not pretend these settings update already-running panes, because SwiftTerm treats them as startup-oriented terminal options.
+
+## Renderer / GPU Settings
+
+These settings control how SwiftTerm renders the terminal view.
+
+- Metal renderer enable/disable
+- Metal buffering mode
+
+User-facing rule:
+
+- Orbit Cockpit applies these settings to running panes when SwiftTerm can switch safely.
+- Metal activation is deferred until the terminal view is attached to a window.
+- If Metal activation fails or Metal is unavailable, the pane stays usable on the CoreGraphics fallback path.
+
+This means the saved preference and the active renderer can differ temporarily or permanently on unsupported systems. The app treats that as a supported fallback case, not as a successful Metal activation.
+
+## Persistence Model
+
+All native settings are persisted in the native settings store and survive relaunch.
+
+The current implementation keeps three behavior-oriented paths separate:
+
+- `TerminalSessionSettings`: runtime-safe live updates
+- `TerminalStartupSettings`: new-session-only startup configuration
+- `TerminalRendererSettings`: renderer preferences and fallback-sensitive behavior
+
+That separation is intentional. It prevents Orbit Cockpit from claiming a setting applies immediately when the underlying terminal only supports it during session creation or through a guarded renderer transition.

--- a/native/OrbitCockpit/README.md
+++ b/native/OrbitCockpit/README.md
@@ -12,6 +12,16 @@ The Cockpit is designed to be a "host" for terminal-based workflows. It uses a p
 - **SwiftUI Wrapper**: The native navigation, notifications, and windowing logic.
 - **SwiftTerm**: The initial high-fidelity terminal emulator engine.
 
+## Settings Semantics
+
+Orbit Cockpit’s native settings are documented by application behavior rather than by raw SwiftTerm option names.
+
+- Live-applied settings update already-running panes immediately.
+- Startup settings apply to new terminal sessions only.
+- Renderer settings apply to running panes when SwiftTerm can switch safely, with CoreGraphics fallback preserved if Metal activation fails.
+
+See [Docs/SettingsBehavior.md](Docs/SettingsBehavior.md) for the current supported settings surface and its application semantics.
+
 ## Development
 
 ### Prerequisites

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsStoreTests.swift
@@ -66,4 +66,18 @@ struct OrbitCockpitSettingsStoreTests {
         let reloaded = OrbitCockpitSettingsStore(defaults: defaults)
         #expect(reloaded.settings == .defaults)
     }
+
+    @Test("Behavior-oriented settings projections stay distinct")
+    func testSettingsProjectionsReflectBehaviorBoundaries() throws {
+        let defaults = try #require(UserDefaults(suiteName: "OrbitCockpitTests.Settings.\(UUID().uuidString)"))
+        let store = OrbitCockpitSettingsStore(defaults: defaults)
+
+        store.binding(\.terminal.fontSize).wrappedValue = 16
+        store.binding(\.advanced.cursorStyle).wrappedValue = .steadyUnderline
+        store.binding(\.advanced.preferGPURenderer).wrappedValue = false
+
+        #expect(store.terminalSessionSettings.fontSize == 16)
+        #expect(store.terminalStartupSettings.cursorStyle == .steadyUnderline)
+        #expect(!store.terminalRendererSettings.useMetalRenderer)
+    }
 }


### PR DESCRIPTION
## Summary
- document Orbit Cockpit native settings behavior by application semantics
- add a focused settings-store test covering live, startup, and renderer projections
- link the new behavior guide from the native README for easier maintenance

## Testing
- `rtk zsh -lc 'cd native/OrbitCockpit && HOME=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-home TMPDIR=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp swift test --disable-sandbox --build-path /Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-build --disable-xctest --enable-swift-testing'`
- `rtk make check`

Closes #459
