### PR TITLE
fix(native): restore settings tab switching

### DIFF
--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -1,16 +1,23 @@
 import SwiftUI
 
+enum OrbitCockpitSettingsSection: Hashable, CaseIterable {
+    case terminal
+    case appearance
+    case linksAndInput
+    case advanced
+}
+
 @MainActor
 struct OrbitCockpitSettingsView: View {
-    private enum SettingsSection: Hashable {
-        case terminal
-        case appearance
-        case linksAndInput
-        case advanced
-    }
+    static let minimumWindowWidth: CGFloat = 700
+    static let minimumWindowHeight: CGFloat = 420
 
     @EnvironmentObject private var settingsStore: OrbitCockpitSettingsStore
-    @State private var selectedSection: SettingsSection = .terminal
+    @State var selectedSection: OrbitCockpitSettingsSection
+
+    init(initialSection: OrbitCockpitSettingsSection = .terminal) {
+        _selectedSection = State(initialValue: initialSection)
+    }
 
     var body: some View {
         TabView(selection: $selectedSection) {
@@ -46,7 +53,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Terminal", systemImage: "terminal")
             }
-            .tag(SettingsSection.terminal)
+            .tag(OrbitCockpitSettingsSection.terminal)
 
             Form {
                 Section {
@@ -74,7 +81,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Appearance", systemImage: "paintpalette")
             }
-            .tag(SettingsSection.appearance)
+            .tag(OrbitCockpitSettingsSection.appearance)
 
             Form {
                 Section {
@@ -98,7 +105,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Links & Input", systemImage: "link")
             }
-            .tag(SettingsSection.linksAndInput)
+            .tag(OrbitCockpitSettingsSection.linksAndInput)
 
             Form {
                 Section {
@@ -183,9 +190,9 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Advanced", systemImage: "gearshape.2")
             }
-            .tag(SettingsSection.advanced)
+            .tag(OrbitCockpitSettingsSection.advanced)
         }
-        .frame(minWidth: 700, minHeight: 420)
+        .frame(minWidth: Self.minimumWindowWidth, minHeight: Self.minimumWindowHeight)
         .safeAreaInset(edge: .bottom) {
             HStack {
                 Spacer()

--- a/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
+++ b/native/OrbitCockpit/Sources/OrbitCockpit/OrbitCockpitSettingsView.swift
@@ -2,10 +2,18 @@ import SwiftUI
 
 @MainActor
 struct OrbitCockpitSettingsView: View {
+    private enum SettingsSection: Hashable {
+        case terminal
+        case appearance
+        case linksAndInput
+        case advanced
+    }
+
     @EnvironmentObject private var settingsStore: OrbitCockpitSettingsStore
+    @State private var selectedSection: SettingsSection = .terminal
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedSection) {
             Form {
                 Section {
                     Stepper(value: settingsStore.binding(\.terminal.fontSize), in: 10...24, step: 1) {
@@ -38,6 +46,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Terminal", systemImage: "terminal")
             }
+            .tag(SettingsSection.terminal)
 
             Form {
                 Section {
@@ -65,6 +74,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Appearance", systemImage: "paintpalette")
             }
+            .tag(SettingsSection.appearance)
 
             Form {
                 Section {
@@ -88,6 +98,7 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Links & Input", systemImage: "link")
             }
+            .tag(SettingsSection.linksAndInput)
 
             Form {
                 Section {
@@ -172,14 +183,19 @@ struct OrbitCockpitSettingsView: View {
             .tabItem {
                 Label("Advanced", systemImage: "gearshape.2")
             }
+            .tag(SettingsSection.advanced)
         }
-        .frame(minWidth: 560, minHeight: 360)
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+        .frame(minWidth: 700, minHeight: 420)
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Spacer()
                 Button("Reset to Defaults") {
                     settingsStore.resetToDefaults()
                 }
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .background(.bar)
         }
     }
 }

--- a/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsViewTests.swift
+++ b/native/OrbitCockpit/Tests/OrbitCockpitTests/OrbitCockpitSettingsViewTests.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import Testing
+
+@testable import OrbitCockpit
+
+@Suite("OrbitCockpit Settings View Tests")
+@MainActor
+struct OrbitCockpitSettingsViewTests {
+    @Test("Settings view supports explicit section selection state")
+    func testInitialSectionSelectionCanTargetAnySettingsTab() {
+        for section in OrbitCockpitSettingsSection.allCases {
+            let view = OrbitCockpitSettingsView(initialSection: section)
+            #expect(view.selectedSection == section)
+        }
+    }
+
+    @Test("Settings view keeps the wider minimum frame for tab labels")
+    func testMinimumSettingsWindowFrame() {
+        #expect(OrbitCockpitSettingsView.minimumWindowWidth == 700)
+        #expect(OrbitCockpitSettingsView.minimumWindowHeight == 420)
+    }
+}


### PR DESCRIPTION
## Summary
- restore macOS Settings tab switching by using explicit tab selection state
- move the reset action out of the Settings toolbar so it no longer competes with the tab strip
- widen the settings window so the four section labels fit more comfortably

## Testing
- `rtk zsh -lc 'cd native/OrbitCockpit && HOME=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-home TMPDIR=/Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp swift test --disable-sandbox --build-path /Users/hirakiuc/repos/src/github.com/hirakiuc/gh-orbit/tmp/swift-build --disable-xctest --enable-swift-testing'`
