### PR TITLE
fix(tui): toggle local handled state independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ gh orbit
 | :--- | :--- |
 | `r` | Sync notifications (Manual) |
 | `m` | Toggle Read/Unread state |
+| `x` | Toggle local Handled/Unhandled state |
 | `enter` | View notification details (Description/Body) |
 | `o` | Open in default browser |
 | `c` | Checkout PR locally (`gh pr checkout`) |
@@ -56,6 +57,14 @@ gh orbit
 | `tab` | Cycle through tabs (Inbox, Unread, Triaged, All) |
 | `?` | Toggle detailed help menu |
 | `q` / `esc` | Back to list / Quit |
+
+Read state and local handled (triaged) state are independent. The `m` binding
+changes GitHub/local read state, while `x` changes only Inbox triage state.
+`keys.toggle_handled` is configurable; existing bindings take precedence over
+the inherited `x` default, and `[]` disables the action. If you explicitly add
+`toggle_handled` to your config and later downgrade to a version from before
+Issue #473, remove that one line first because older versions strictly reject
+unknown configuration keys.
 
 ---
 

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -359,11 +359,12 @@ func runTUI() error {
 
 			if err == nil {
 				env.logger.Info("connected to headless engine", "server", initResp.ServerInfo.Name)
-				if err := requireIndependentMutationTools(connectCtx, mcpClient); err != nil {
-					_ = mcpClient.Close()
-					return fmt.Errorf("connected engine is incompatible; restart or upgrade the engine: %w", err)
+				var adapter *engine.MCPAdapter
+				if err := prepareConnectedMutationClient(connectCtx, mcpClient, mcpClient.Close, func() {
+					adapter = engine.NewMCPAdapter(mcpClient)
+				}); err != nil {
+					return err
 				}
-				adapter := engine.NewMCPAdapter(mcpClient)
 
 				user, err := adapter.ResolveUserID(connectCtx)
 				if err != nil {
@@ -407,6 +408,20 @@ func runTUI() error {
 
 type toolCapabilityClient interface {
 	ListTools(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error)
+}
+
+func prepareConnectedMutationClient(
+	ctx context.Context,
+	capabilityClient toolCapabilityClient,
+	closeClient func() error,
+	onCompatible func(),
+) error {
+	if err := requireIndependentMutationTools(ctx, capabilityClient); err != nil {
+		_ = closeClient()
+		return fmt.Errorf("connected engine is incompatible; restart or upgrade the engine: %w", err)
+	}
+	onCompatible()
+	return nil
 }
 
 func requireIndependentMutationTools(ctx context.Context, capabilityClient toolCapabilityClient) error {

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -357,15 +359,16 @@ func runTUI() error {
 
 			if err == nil {
 				env.logger.Info("connected to headless engine", "server", initResp.ServerInfo.Name)
+				if err := requireIndependentMutationTools(connectCtx, mcpClient); err != nil {
+					_ = mcpClient.Close()
+					return fmt.Errorf("connected engine is incompatible; restart or upgrade the engine: %w", err)
+				}
 				adapter := engine.NewMCPAdapter(mcpClient)
 
 				user, err := adapter.ResolveUserID(connectCtx)
 				if err != nil {
-					if requireEngine {
-						return fmt.Errorf("cockpit-managed launch requires connected engine user identity: %w", err)
-					}
-					env.logger.Warn("failed to resolve connected engine user identity, falling back to standalone", "error", err)
-					goto standalone
+					_ = mcpClient.Close()
+					return fmt.Errorf("connected engine user identity is unavailable; restart or upgrade the engine: %w", err)
 				}
 				return launchTUIMCP(ctx, env, cfg, adapter, user)
 			}
@@ -383,7 +386,6 @@ func runTUI() error {
 		return fmt.Errorf("cockpit-managed launch requires a running MCP engine at %s", socketPath)
 	}
 
-standalone:
 	// 2. Standalone Mode (Library access)
 	eng, err := engine.NewCoreEngine(ctx, cfg, env.logger, executor)
 	if err != nil {
@@ -401,6 +403,36 @@ standalone:
 	}
 
 	return launchTUIStandalone(ctx, env, eng, user.Login)
+}
+
+type toolCapabilityClient interface {
+	ListTools(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error)
+}
+
+func requireIndependentMutationTools(ctx context.Context, capabilityClient toolCapabilityClient) error {
+	result, err := capabilityClient.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return fmt.Errorf("listing engine tools: %w", err)
+	}
+	if result == nil {
+		return errors.New("listing engine tools returned an empty response")
+	}
+	required := map[string]bool{"set_read": false, "set_handled": false}
+	for _, tool := range result.Tools {
+		if _, ok := required[tool.Name]; ok {
+			required[tool.Name] = true
+		}
+	}
+	var missing []string
+	for _, name := range []string{"set_read", "set_handled"} {
+		if !required[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("engine is missing required tool(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, adapter *engine.MCPAdapter, userID string) error {

--- a/cmd/gh-orbit/main_test.go
+++ b/cmd/gh-orbit/main_test.go
@@ -49,6 +49,42 @@ func TestRequireIndependentMutationTools(t *testing.T) {
 	}
 }
 
+func TestPrepareConnectedMutationClient_FailuresCloseWithoutConstructing(t *testing.T) {
+	tools := func(names ...string) *mcp.ListToolsResult {
+		result := &mcp.ListToolsResult{}
+		for _, name := range names {
+			result.Tools = append(result.Tools, mcp.Tool{Name: name})
+		}
+		return result
+	}
+
+	for _, tc := range []struct {
+		name   string
+		client capabilityClientStub
+	}{
+		{name: "rpc error", client: capabilityClientStub{err: errors.New("timeout")}},
+		{name: "nil malformed response", client: capabilityClientStub{}},
+		{name: "missing read", client: capabilityClientStub{result: tools("set_handled")}},
+		{name: "missing handled", client: capabilityClientStub{result: tools("set_read")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			closed, adapterConstructed, standaloneConstructed := 0, 0, 0
+			err := prepareConnectedMutationClient(context.Background(), tc.client, func() error {
+				closed++
+				return nil
+			}, func() { adapterConstructed++ })
+			if err == nil {
+				standaloneConstructed++
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "restart or upgrade")
+			assert.Equal(t, 1, closed)
+			assert.Zero(t, adapterConstructed)
+			assert.Zero(t, standaloneConstructed)
+		})
+	}
+}
+
 func TestResolveLogLevel(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/cmd/gh-orbit/main_test.go
+++ b/cmd/gh-orbit/main_test.go
@@ -1,11 +1,53 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type capabilityClientStub struct {
+	result *mcp.ListToolsResult
+	err    error
+}
+
+func (s capabilityClientStub) ListTools(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	return s.result, s.err
+}
+
+func TestRequireIndependentMutationTools(t *testing.T) {
+	tools := func(names ...string) *mcp.ListToolsResult {
+		result := &mcp.ListToolsResult{}
+		for _, name := range names {
+			result.Tools = append(result.Tools, mcp.Tool{Name: name})
+		}
+		return result
+	}
+
+	require.NoError(t, requireIndependentMutationTools(context.Background(), capabilityClientStub{result: tools("set_read", "set_handled")}))
+
+	for _, tc := range []struct {
+		name   string
+		client capabilityClientStub
+		want   string
+	}{
+		{name: "list error", client: capabilityClientStub{err: errors.New("timeout")}, want: "listing engine tools"},
+		{name: "nil response", client: capabilityClientStub{}, want: "empty response"},
+		{name: "missing read", client: capabilityClientStub{result: tools("set_handled")}, want: "set_read"},
+		{name: "missing handled", client: capabilityClientStub{result: tools("set_read")}, want: "set_handled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireIndependentMutationTools(context.Background(), tc.client)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
 
 func TestResolveLogLevel(t *testing.T) {
 	tests := []struct {

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -60,16 +60,21 @@ keys:
   back: ["esc", "backspace"]
   copy_url: ["y"]
   toggle_read: ["m"]
+  # Local triage state is independent from GitHub read/unread state.
+  # Existing bindings win collisions; use [] to disable this action.
+  # Remove this line before downgrading to a version that predates Issue #473.
+  toggle_handled: ["x"]
   toggle_detail: [" ", "space"]
   open_browser: ["enter"]
   checkout_pr: ["c"]
+  start_review_workspace: ["w"]
   view_contextual: ["v"]
 
   # Tab Navigation
   inbox: ["1"]
-  unread: ["2"]
-  triaged: ["3"]
-  all: ["4"]
+  unread: []
+  triaged: ["2"]
+  all: ["3"]
   next_tab: ["]", "tab"]
   prev_tab: ["[", "shift+tab"]
 

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -108,23 +108,43 @@ func (b *AppBackend) Sync(ctx context.Context, force bool) (models.RateLimitInfo
 	return b.Syncer.Sync(ctx, userID, force)
 }
 
-func (b *AppBackend) MarkRead(ctx context.Context, id string, read bool) (types.MarkReadResult, error) {
+func (b *AppBackend) SetRead(ctx context.Context, id string, read bool) (types.ReadUpdateResult, error) {
+	return b.updateRead(ctx, id, read, b.Store.SetReadLocally, withReadState)
+}
+
+// MarkReadLegacy preserves the coupled read/handled behavior required by old MCP clients.
+func (b *AppBackend) MarkReadLegacy(ctx context.Context, id string, read bool) (types.ReadUpdateResult, error) {
+	return b.updateRead(ctx, id, read, b.Store.MarkReadLocally, withLegacyReadState)
+}
+
+// MarkRead is retained for source compatibility outside the TUI-facing interface.
+func (b *AppBackend) MarkRead(ctx context.Context, id string, read bool) (types.ReadUpdateResult, error) {
+	return b.MarkReadLegacy(ctx, id, read)
+}
+
+func (b *AppBackend) updateRead(
+	ctx context.Context,
+	id string,
+	read bool,
+	persist func(context.Context, string, bool) error,
+	applyFallback func([]triage.NotificationWithState, string, bool) []triage.NotificationWithState,
+) (types.ReadUpdateResult, error) {
 	before, _ := b.Store.ListNotifications(ctx)
 
-	if err := b.Store.MarkReadLocally(ctx, id, read); err != nil {
+	if err := persist(ctx, id, read); err != nil {
 		notifications, reloadErr := b.Store.ListNotifications(ctx)
 		if reloadErr != nil {
 			if before != nil {
-				return types.MarkReadResult{
+				return types.ReadUpdateResult{
 					Status:        types.MarkReadLocalFailure,
 					Notifications: before,
 					Toast:         "Failed to update read state",
 					Err:           err,
 				}, nil
 			}
-			return types.MarkReadResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, err)
+			return types.ReadUpdateResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, err)
 		}
-		return types.MarkReadResult{
+		return types.ReadUpdateResult{
 			Status:        types.MarkReadLocalFailure,
 			Notifications: notifications,
 			Toast:         "Failed to update read state",
@@ -138,9 +158,9 @@ func (b *AppBackend) MarkRead(ctx context.Context, id string, read bool) (types.
 		if err := b.Client.MarkThreadAsRead(ctx, id); err != nil {
 			notifications, reloadErr := b.Store.ListNotifications(ctx)
 			if reloadErr != nil {
-				notifications = withReadState(before, id, read)
+				notifications = applyFallback(before, id, read)
 			}
-			return types.MarkReadResult{
+			return types.ReadUpdateResult{
 				Status:        types.MarkReadRemoteFailure,
 				Notifications: notifications,
 				Toast:         "Marked read locally; GitHub sync failed",
@@ -152,14 +172,52 @@ func (b *AppBackend) MarkRead(ctx context.Context, id string, read bool) (types.
 	notifications, err := b.Store.ListNotifications(ctx)
 	if err != nil {
 		if before != nil {
-			notifications = withReadState(before, id, read)
+			notifications = applyFallback(before, id, read)
 		} else {
-			return types.MarkReadResult{}, err
+			return types.ReadUpdateResult{}, err
 		}
 	}
 
-	return types.MarkReadResult{
+	return types.ReadUpdateResult{
 		Status:        types.MarkReadSuccess,
+		Notifications: notifications,
+	}, nil
+}
+
+func (b *AppBackend) SetHandled(ctx context.Context, id string, handled bool) (types.HandledUpdateResult, error) {
+	before, _ := b.Store.ListNotifications(ctx)
+
+	if err := b.Store.SetHandledLocally(ctx, id, handled); err != nil {
+		notifications, reloadErr := b.Store.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before != nil {
+				return types.HandledUpdateResult{
+					Status:        types.HandledUpdateFailure,
+					Notifications: before,
+					Toast:         "Failed to update handled state",
+					Err:           err,
+				}, nil
+			}
+			return types.HandledUpdateResult{}, fmt.Errorf("reload notifications after local handled failure: %w (original error: %v)", reloadErr, err)
+		}
+		return types.HandledUpdateResult{
+			Status:        types.HandledUpdateFailure,
+			Notifications: notifications,
+			Toast:         "Failed to update handled state",
+			Err:           err,
+		}, nil
+	}
+
+	b.publishNotificationsChanged()
+	notifications, err := b.Store.ListNotifications(ctx)
+	if err != nil {
+		if before == nil {
+			return types.HandledUpdateResult{}, err
+		}
+		notifications = withHandledState(before, id, handled)
+	}
+	return types.HandledUpdateResult{
+		Status:        types.HandledUpdateSuccess,
 		Notifications: notifications,
 	}, nil
 }
@@ -278,11 +336,26 @@ func withReadState(notifications []triage.NotificationWithState, id string, read
 	for idx := range cloned {
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsReadLocally = read
-			cloned[idx].IsHandledLocally = read
 			break
 		}
 	}
 	return cloned
+}
+
+func withHandledState(notifications []triage.NotificationWithState, id string, handled bool) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].IsHandledLocally = handled
+			break
+		}
+	}
+	return cloned
+}
+
+func withLegacyReadState(notifications []triage.NotificationWithState, id string, read bool) []triage.NotificationWithState {
+	cloned := withReadState(notifications, id, read)
+	return withHandledState(cloned, id, read)
 }
 
 func withPriority(notifications []triage.NotificationWithState, id string, priority int) []triage.NotificationWithState {

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -65,6 +65,40 @@ func TestAppBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	assert.Equal(t, snapshot, result.Notifications)
 }
 
+func TestAppBackend_IndependentReadAndHandledMutations(t *testing.T) {
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+	mockClient := mocks.NewMockClient(t)
+	before := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif"}, State: triage.State{IsHandledLocally: true}}}
+	afterRead := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}}}
+	afterHandled := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "notif"}, State: triage.State{IsReadLocally: true}}}
+
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(before, nil).Once()
+	mockRepo.EXPECT().SetReadLocally(mock.Anything, "notif", true).Return(nil).Once()
+	mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif").Return(nil).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(afterRead, nil).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(afterRead, nil).Once()
+	mockRepo.EXPECT().SetHandledLocally(mock.Anything, "notif", false).Return(nil).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(afterHandled, nil).Once()
+
+	published := 0
+	backend, err := NewAppBackend(AppBackendParams{
+		UserID: "user", Store: mockRepo, Client: mockClient, Syncer: mockSyncer, Enricher: mockEnricher,
+		PublishNotificationsChanged: func() { published++ },
+	})
+	require.NoError(t, err)
+
+	readResult, err := backend.SetRead(context.Background(), "notif", true)
+	require.NoError(t, err)
+	assert.True(t, readResult.Notifications[0].IsHandledLocally)
+	handledResult, err := backend.SetHandled(context.Background(), "notif", false)
+	require.NoError(t, err)
+	assert.True(t, handledResult.Notifications[0].IsReadLocally)
+	assert.False(t, handledResult.Notifications[0].IsHandledLocally)
+	assert.Equal(t, 2, published)
+}
+
 func TestAppBackend_SetPriorityPublishesNotificationsChanged(t *testing.T) {
 	mockRepo := mocks.NewMockRepository(t)
 	mockSyncer := mocks.NewMockSyncer(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type KeyMapConfig struct {
 	All                  []string `yaml:"all"`
 	CopyURL              []string `yaml:"copy_url"`
 	ToggleRead           []string `yaml:"toggle_read"`
+	ToggleHandled        []string `yaml:"toggle_handled"`
 	NextTab              []string `yaml:"next_tab"`
 	PrevTab              []string `yaml:"prev_tab"`
 	CheckoutPR           []string `yaml:"checkout_pr"`
@@ -47,6 +48,8 @@ type KeyMapConfig struct {
 	FilterIssue          []string `yaml:"filter_issue"`
 	FilterDiscussion     []string `yaml:"filter_discussion"`
 	Help                 []string `yaml:"help"`
+
+	toggleHandledExplicit bool
 }
 
 // TUIConfig represents settings for the Terminal UI.
@@ -106,6 +109,7 @@ func DefaultConfig() *Config {
 			All:                  []string{"3"},
 			CopyURL:              []string{"y"},
 			ToggleRead:           []string{"m"},
+			ToggleHandled:        []string{"x"},
 			NextTab:              []string{"]", "tab"},
 			PrevTab:              []string{"[", "shift+tab"},
 			CheckoutPR:           []string{"c"},
@@ -204,6 +208,11 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
+	toggleHandledExplicit, err := yamlMappingHasKey(data, "keys", "toggle_handled")
+	if err != nil {
+		return nil, fmt.Errorf("invalid config.yml: %w", err)
+	}
+
 	// Strict Schema Enforcement:
 	// 1. Initialize with defaults to handle missing fields
 	cfg := DefaultConfig()
@@ -215,6 +224,7 @@ func Load() (*Config, error) {
 	if err := dec.Decode(cfg); err != nil {
 		return nil, fmt.Errorf("invalid config.yml (check for typos): %w", err)
 	}
+	cfg.Keys.toggleHandledExplicit = toggleHandledExplicit
 
 	normalizeKeyMap(&cfg.Keys)
 
@@ -232,6 +242,51 @@ func normalizeKeyMap(keys *KeyMapConfig) {
 		keys.Triaged = []string{"2"}
 		keys.All = []string{"3"}
 	}
+
+	used := make(map[string]struct{})
+	existing := [][]string{
+		keys.Sync, keys.PriorityUp, keys.PriorityDown, keys.PriorityNone,
+		keys.Inbox, keys.Unread, keys.Triaged, keys.All, keys.CopyURL,
+		keys.ToggleRead, keys.NextTab, keys.PrevTab, keys.CheckoutPR,
+		keys.StartReviewWorkspace, keys.ViewContextual, keys.OpenBrowser,
+		keys.ToggleDetail, keys.Back, keys.Quit, keys.FilterPR,
+		keys.FilterIssue, keys.FilterDiscussion, keys.Help,
+	}
+	for _, bindings := range existing {
+		for _, binding := range bindings {
+			used[binding] = struct{}{}
+		}
+	}
+	filtered := keys.ToggleHandled[:0]
+	for _, binding := range keys.ToggleHandled {
+		if _, collision := used[binding]; !collision {
+			filtered = append(filtered, binding)
+		}
+	}
+	keys.ToggleHandled = filtered
+}
+
+func yamlMappingHasKey(data []byte, parent, key string) (bool, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return false, err
+	}
+	if len(document.Content) == 0 {
+		return false, nil
+	}
+	root := document.Content[0]
+	for idx := 0; idx+1 < len(root.Content); idx += 2 {
+		if root.Content[idx].Value != parent {
+			continue
+		}
+		mapping := root.Content[idx+1]
+		for child := 0; child+1 < len(mapping.Content); child += 2 {
+			if mapping.Content[child].Value == key {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func isOldDefaultTabKeyMap(keys KeyMapConfig) bool {
@@ -248,12 +303,44 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	data, err := yaml.Marshal(c)
+	var document yaml.Node
+	if err := document.Encode(c); err != nil {
+		return fmt.Errorf("failed to encode config: %w", err)
+	}
+	if !c.Keys.toggleHandledExplicit {
+		removeYAMLMappingKey(&document, "keys", "toggle_handled")
+	}
+	data, err := yaml.Marshal(&document)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
 	return os.WriteFile(path, data, 0o600)
+}
+
+func removeYAMLMappingKey(document *yaml.Node, parent, key string) {
+	if document == nil {
+		return
+	}
+	root := document
+	if document.Kind == yaml.DocumentNode {
+		if len(document.Content) == 0 {
+			return
+		}
+		root = document.Content[0]
+	}
+	for idx := 0; idx+1 < len(root.Content); idx += 2 {
+		if root.Content[idx].Value != parent {
+			continue
+		}
+		mapping := root.Content[idx+1]
+		for child := 0; child+1 < len(mapping.Content); child += 2 {
+			if mapping.Content[child].Value == key {
+				mapping.Content = append(mapping.Content[:child], mapping.Content[child+2:]...)
+				return
+			}
+		}
+	}
 }
 
 // EnsurePrivateDir creates a directory with 0700 permissions if it doesn't exist.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,28 +242,6 @@ func normalizeKeyMap(keys *KeyMapConfig) {
 		keys.Triaged = []string{"2"}
 		keys.All = []string{"3"}
 	}
-
-	used := make(map[string]struct{})
-	existing := [][]string{
-		keys.Sync, keys.PriorityUp, keys.PriorityDown, keys.PriorityNone,
-		keys.Inbox, keys.Unread, keys.Triaged, keys.All, keys.CopyURL,
-		keys.ToggleRead, keys.NextTab, keys.PrevTab, keys.CheckoutPR,
-		keys.StartReviewWorkspace, keys.ViewContextual, keys.OpenBrowser,
-		keys.ToggleDetail, keys.Back, keys.Quit, keys.FilterPR,
-		keys.FilterIssue, keys.FilterDiscussion, keys.Help,
-	}
-	for _, bindings := range existing {
-		for _, binding := range bindings {
-			used[binding] = struct{}{}
-		}
-	}
-	filtered := keys.ToggleHandled[:0]
-	for _, binding := range keys.ToggleHandled {
-		if _, collision := used[binding]; !collision {
-			filtered = append(filtered, binding)
-		}
-	}
-	keys.ToggleHandled = filtered
 }
 
 func yamlMappingHasKey(data []byte, parent, key string) (bool, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -98,6 +101,14 @@ notifications:
 		assert.Contains(t, err.Error(), "check for typos")
 	})
 
+	t.Run("Catch Unknown Key Fields", func(t *testing.T) {
+		content := "version: 1\nkeys:\n  toggle_handeled: [\"x\"]\n"
+		require.NoError(t, os.WriteFile(expectedPath, []byte(content), 0o600))
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field toggle_handeled not found")
+	})
+
 	t.Run("Successful Load with Safe Defaults", func(t *testing.T) {
 		// YAML only provides version and enabled
 		content := `
@@ -184,6 +195,28 @@ keys:
 		assert.Equal(t, []string{"t"}, cfg.Keys.Triaged)
 		assert.Equal(t, []string{"a"}, cfg.Keys.All)
 	})
+
+	t.Run("Handled Binding Presence And Collisions", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			binding string
+			want    []string
+		}{
+			{name: "absent inherits default", want: []string{"x"}},
+			{name: "explicit empty disables", binding: "  toggle_handled: []\n", want: []string{}},
+			{name: "explicit custom", binding: "  toggle_handled: [\"h\"]\n", want: []string{"h"}},
+			{name: "existing binding wins collision", binding: "  toggle_handled: [\"m\"]\n", want: []string{}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				content := "version: 1\nkeys:\n" + tt.binding
+				require.NoError(t, os.WriteFile(expectedPath, []byte(content), 0o600))
+				cfg, err := Load()
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, cfg.Keys.ToggleHandled)
+			})
+		}
+	})
 }
 
 func TestConfig_Persistence(t *testing.T) {
@@ -201,6 +234,20 @@ func TestConfig_Persistence(t *testing.T) {
 	require.NoError(t, cfg.Save())
 
 	assert.FileExists(t, path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is resolved under t.TempDir.
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "toggle_handled:", "inherited defaults must stay readable by old strict decoders")
+
+	explicit := DefaultConfig()
+	explicit.Keys.ToggleHandled = []string{"h"}
+	explicit.Keys.toggleHandledExplicit = true
+	require.NoError(t, explicit.Save())
+	data, err = os.ReadFile(path) // #nosec G304 -- path is resolved under t.TempDir.
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "toggle_handled:")
+	assert.Error(t, decodeLegacyKeyConfig(data))
+	withoutHandled := strings.ReplaceAll(string(data), "    toggle_handled:\n        - h\n", "")
+	assert.NoError(t, decodeLegacyKeyConfig([]byte(withoutHandled)))
 
 	// Test Resolve helpers
 	d, err := ResolveDataDir()
@@ -214,6 +261,45 @@ func TestConfig_Persistence(t *testing.T) {
 	tp, err := ResolveTracePath()
 	require.NoError(t, err)
 	assert.Contains(t, tp, tmpDir)
+}
+
+func decodeLegacyKeyConfig(data []byte) error {
+	var legacy struct {
+		Version       int                 `yaml:"version"`
+		Notifications NotificationsConfig `yaml:"notifications"`
+		Enrichment    EnrichmentConfig    `yaml:"enrichment"`
+		TUI           TUIConfig           `yaml:"tui"`
+		Keys          legacyKeyMapConfig  `yaml:"keys"`
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	return decoder.Decode(&legacy)
+}
+
+type legacyKeyMapConfig struct {
+	Sync                 []string `yaml:"sync"`
+	PriorityUp           []string `yaml:"priority_up"`
+	PriorityDown         []string `yaml:"priority_down"`
+	PriorityNone         []string `yaml:"priority_none"`
+	Inbox                []string `yaml:"inbox"`
+	Unread               []string `yaml:"unread"`
+	Triaged              []string `yaml:"triaged"`
+	All                  []string `yaml:"all"`
+	CopyURL              []string `yaml:"copy_url"`
+	ToggleRead           []string `yaml:"toggle_read"`
+	NextTab              []string `yaml:"next_tab"`
+	PrevTab              []string `yaml:"prev_tab"`
+	CheckoutPR           []string `yaml:"checkout_pr"`
+	StartReviewWorkspace []string `yaml:"start_review_workspace"`
+	ViewContextual       []string `yaml:"view_contextual"`
+	OpenBrowser          []string `yaml:"open_browser"`
+	ToggleDetail         []string `yaml:"toggle_detail"`
+	Back                 []string `yaml:"back"`
+	Quit                 []string `yaml:"quit"`
+	FilterPR             []string `yaml:"filter_pr"`
+	FilterIssue          []string `yaml:"filter_issue"`
+	FilterDiscussion     []string `yaml:"filter_discussion"`
+	Help                 []string `yaml:"help"`
 }
 
 func TestConfig_AuditPermissions(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -205,7 +205,7 @@ keys:
 			{name: "absent inherits default", want: []string{"x"}},
 			{name: "explicit empty disables", binding: "  toggle_handled: []\n", want: []string{}},
 			{name: "explicit custom", binding: "  toggle_handled: [\"h\"]\n", want: []string{"h"}},
-			{name: "existing binding wins collision", binding: "  toggle_handled: [\"m\"]\n", want: []string{}},
+			{name: "explicit collision preserves configured intent", binding: "  toggle_handled: [\"m\"]\n", want: []string{"m"}},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -215,6 +215,20 @@ keys:
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, cfg.Keys.ToggleHandled)
 			})
+		}
+	})
+
+	t.Run("Handled Binding Collisions Round Trip Exactly", func(t *testing.T) {
+		for _, binding := range []string{"[\"m\"]", "[\"m\", \"h\"]"} {
+			content := "version: 1\nkeys:\n  toggle_handled: " + binding + "\n"
+			require.NoError(t, os.WriteFile(expectedPath, []byte(content), 0o600))
+			cfg, err := Load()
+			require.NoError(t, err)
+			want := append([]string(nil), cfg.Keys.ToggleHandled...)
+			require.NoError(t, cfg.Save())
+			reloaded, err := Load()
+			require.NoError(t, err)
+			assert.Equal(t, want, reloaded.Keys.ToggleHandled)
 		}
 	})
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"modernc.org/sqlite"
@@ -354,6 +355,39 @@ func TestRepository_Actions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	assert.Equal(t, "tracking", ns.Status)
+}
+
+func TestRepository_IndependentReadAndHandledMutations(t *testing.T) {
+	ctx := context.Background()
+	db, err := OpenInMemory(ctx, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const id = "independent-state"
+	require.NoError(t, db.UpsertNotifications(ctx, []triage.Notification{{GitHubID: id, UpdatedAt: time.Now()}}))
+	require.NoError(t, db.SetHandledLocally(ctx, id, true))
+	require.NoError(t, db.SetReadLocally(ctx, id, true))
+
+	state, err := db.GetNotification(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.True(t, state.IsReadLocally)
+	assert.True(t, state.IsHandledLocally)
+
+	require.NoError(t, db.SetReadLocally(ctx, id, false))
+	state, err = db.GetNotification(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, state.IsReadLocally)
+	assert.True(t, state.IsHandledLocally, "read mutation must preserve handled state")
+
+	require.NoError(t, db.SetHandledLocally(ctx, id, false))
+	state, err = db.GetNotification(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, state.IsReadLocally, "handled mutation must preserve read state")
+	assert.False(t, state.IsHandledLocally)
+
+	assert.ErrorIs(t, db.SetReadLocally(ctx, "missing", true), types.ErrNotificationNotFound)
+	assert.ErrorIs(t, db.SetHandledLocally(ctx, "missing", true), types.ErrNotificationNotFound)
 }
 
 func TestRepository_MetadataAndEnrichment(t *testing.T) {

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 )
 
 // EnrichNotification updates a notification with detailed content (body, author).
@@ -235,6 +236,40 @@ func (db *DB) MarkReadLocally(ctx context.Context, id string, isRead bool) error
 		WHERE notification_id = ?
 	`, isRead, isRead, id)
 	return err
+}
+
+// SetReadLocally updates only the local read state of a notification.
+func (db *DB) SetReadLocally(ctx context.Context, id string, isRead bool) error {
+	result, err := db.ExecContext(ctx, `
+		UPDATE orbit_state
+		SET is_read_locally = ?
+		WHERE notification_id = ?
+	`, isRead, id)
+	return requireUpdatedNotification(result, err)
+}
+
+// SetHandledLocally updates only the local handled state of a notification.
+func (db *DB) SetHandledLocally(ctx context.Context, id string, isHandled bool) error {
+	result, err := db.ExecContext(ctx, `
+		UPDATE orbit_state
+		SET is_handled_locally = ?
+		WHERE notification_id = ?
+	`, isHandled, id)
+	return requireUpdatedNotification(result, err)
+}
+
+func requireUpdatedNotification(result sql.Result, err error) error {
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking updated notification: %w", err)
+	}
+	if rows == 0 {
+		return types.ErrNotificationNotFound
+	}
+	return nil
 }
 
 // ArchiveThread moves a thread to the archived state.

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -250,21 +250,6 @@ func (a *MCPAdapter) SetHandled(ctx context.Context, id string, handled bool) (t
 	return types.HandledUpdateResult{Status: types.HandledUpdateSuccess, Notifications: notifications}, nil
 }
 
-func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
-	_, err := a.SetRead(ctx, id, isRead)
-	return err
-}
-
-func (a *MCPAdapter) SetReadLocally(ctx context.Context, id string, isRead bool) error {
-	_, err := a.SetRead(ctx, id, isRead)
-	return err
-}
-
-func (a *MCPAdapter) SetHandledLocally(ctx context.Context, id string, handled bool) error {
-	_, err := a.SetHandled(ctx, id, handled)
-	return err
-}
-
 func (a *MCPAdapter) SetPriority(ctx context.Context, id string, priority int) (types.PriorityUpdateResult, error) {
 	before, _ := a.ListNotifications(ctx)
 

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -149,12 +149,12 @@ func (a *MCPAdapter) ResolveUserID(ctx context.Context) (string, error) {
 	return payload.Login, nil
 }
 
-func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (types.MarkReadResult, error) {
+func (a *MCPAdapter) SetRead(ctx context.Context, id string, isRead bool) (types.ReadUpdateResult, error) {
 	before, _ := a.ListNotifications(ctx)
 
 	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name: "mark_read",
+			Name: "set_read",
 			Arguments: map[string]any{
 				"id":   id,
 				"read": isRead,
@@ -162,19 +162,19 @@ func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (type
 		},
 	})
 	if err != nil {
-		return types.MarkReadResult{}, err
+		return types.ReadUpdateResult{}, err
 	}
 	if resp == nil {
-		return types.MarkReadResult{}, errors.New("mark_read returned nil result")
+		return types.ReadUpdateResult{}, errors.New("set_read returned nil result")
 	}
 	if resp.IsError {
-		toolErr := decodeToolResultError("mark_read", resp)
+		toolErr := decodeToolResultError("set_read", resp)
 		if api.IsRemoteMarkReadFailure(toolErr) {
 			notifications, reloadErr := a.ListNotifications(ctx)
 			if reloadErr != nil {
 				notifications = applyReadState(before, id, isRead)
 			}
-			return types.MarkReadResult{
+			return types.ReadUpdateResult{
 				Status:        types.MarkReadRemoteFailure,
 				Notifications: notifications,
 				Toast:         "Marked read locally; GitHub sync failed",
@@ -184,16 +184,16 @@ func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (type
 		notifications, reloadErr := a.ListNotifications(ctx)
 		if reloadErr != nil {
 			if before != nil {
-				return types.MarkReadResult{
+				return types.ReadUpdateResult{
 					Status:        types.MarkReadLocalFailure,
 					Notifications: before,
 					Toast:         "Failed to update read state",
 					Err:           toolErr,
 				}, nil
 			}
-			return types.MarkReadResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, toolErr)
+			return types.ReadUpdateResult{}, fmt.Errorf("reload notifications after local read failure: %w (original error: %v)", reloadErr, toolErr)
 		}
-		return types.MarkReadResult{
+		return types.ReadUpdateResult{
 			Status:        types.MarkReadLocalFailure,
 			Notifications: notifications,
 			Toast:         "Failed to update read state",
@@ -205,17 +205,63 @@ func (a *MCPAdapter) MarkRead(ctx context.Context, id string, isRead bool) (type
 		if before != nil {
 			notifications = applyReadState(before, id, isRead)
 		} else {
-			return types.MarkReadResult{}, err
+			return types.ReadUpdateResult{}, err
 		}
 	}
-	return types.MarkReadResult{
+	return types.ReadUpdateResult{
 		Status:        types.MarkReadSuccess,
 		Notifications: notifications,
 	}, nil
 }
 
+func (a *MCPAdapter) SetHandled(ctx context.Context, id string, handled bool) (types.HandledUpdateResult, error) {
+	before, _ := a.ListNotifications(ctx)
+	resp, err := a.client.CallTool(ctx, mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      "set_handled",
+		Arguments: map[string]any{"id": id, "handled": handled},
+	}})
+	if err != nil {
+		return types.HandledUpdateResult{}, err
+	}
+	if resp == nil {
+		return types.HandledUpdateResult{}, errors.New("set_handled returned nil result")
+	}
+	if resp.IsError {
+		toolErr := decodeToolResultError("set_handled", resp)
+		notifications, reloadErr := a.ListNotifications(ctx)
+		if reloadErr != nil {
+			if before == nil {
+				return types.HandledUpdateResult{}, fmt.Errorf("reload notifications after local handled failure: %w (original error: %v)", reloadErr, toolErr)
+			}
+			notifications = before
+		}
+		return types.HandledUpdateResult{
+			Status: types.HandledUpdateFailure, Notifications: notifications,
+			Toast: "Failed to update handled state", Err: toolErr,
+		}, nil
+	}
+	notifications, err := a.ListNotifications(ctx)
+	if err != nil {
+		if before == nil {
+			return types.HandledUpdateResult{}, err
+		}
+		notifications = applyHandledState(before, id, handled)
+	}
+	return types.HandledUpdateResult{Status: types.HandledUpdateSuccess, Notifications: notifications}, nil
+}
+
 func (a *MCPAdapter) MarkReadLocally(ctx context.Context, id string, isRead bool) error {
-	_, err := a.MarkRead(ctx, id, isRead)
+	_, err := a.SetRead(ctx, id, isRead)
+	return err
+}
+
+func (a *MCPAdapter) SetReadLocally(ctx context.Context, id string, isRead bool) error {
+	_, err := a.SetRead(ctx, id, isRead)
+	return err
+}
+
+func (a *MCPAdapter) SetHandledLocally(ctx context.Context, id string, handled bool) error {
+	_, err := a.SetHandled(ctx, id, handled)
 	return err
 }
 
@@ -395,7 +441,17 @@ func applyReadState(notifications []triage.NotificationWithState, id string, rea
 	for idx := range cloned {
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsReadLocally = read
-			cloned[idx].IsHandledLocally = read
+			break
+		}
+	}
+	return cloned
+}
+
+func applyHandledState(notifications []triage.NotificationWithState, id string, handled bool) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	for idx := range cloned {
+		if cloned[idx].GitHubID == id {
+			cloned[idx].IsHandledLocally = handled
 			break
 		}
 	}

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -243,7 +243,7 @@ func TestMCPAdapter_SyncRejectsInvalidStructuredContract(t *testing.T) {
 func TestMCPAdapter_MarkRead_ClassifiesRemoteFailureFromToolResult(t *testing.T) {
 	adapter := NewMCPAdapter(&blockingMCPClient{
 		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			require.Equal(t, "mark_read", request.Params.Name)
+			require.Equal(t, "set_read", request.Params.Name)
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{
@@ -253,7 +253,7 @@ func TestMCPAdapter_MarkRead_ClassifiesRemoteFailureFromToolResult(t *testing.T)
 		},
 	})
 
-	result, err := adapter.MarkRead(context.Background(), "123", true)
+	result, err := adapter.SetRead(context.Background(), "123", true)
 	require.NoError(t, err)
 	assert.Equal(t, types.MarkReadRemoteFailure, result.Status)
 	require.Error(t, result.Err)
@@ -263,7 +263,7 @@ func TestMCPAdapter_MarkRead_ClassifiesRemoteFailureFromToolResult(t *testing.T)
 func TestMCPAdapter_MarkRead_TreatsLocalToolFailureAsError(t *testing.T) {
 	adapter := NewMCPAdapter(&blockingMCPClient{
 		callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			require.Equal(t, "mark_read", request.Params.Name)
+			require.Equal(t, "set_read", request.Params.Name)
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{
@@ -273,7 +273,7 @@ func TestMCPAdapter_MarkRead_TreatsLocalToolFailureAsError(t *testing.T) {
 		},
 	})
 
-	result, err := adapter.MarkRead(context.Background(), "123", true)
+	result, err := adapter.SetRead(context.Background(), "123", true)
 	require.NoError(t, err)
 	assert.Equal(t, types.MarkReadLocalFailure, result.Status)
 	require.Error(t, result.Err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -14,16 +14,22 @@ import (
 
 // CoreEngine coordinates all headless services of gh-orbit.
 type CoreEngine struct {
-	Config  *config.Config
-	Logger  *slog.Logger
-	Bus     *EventBus
-	DB      types.Repository
-	Client  github.Client
-	Backend types.TUIBackend
-	Sync    types.Syncer
-	Enrich  types.Enricher
-	Traffic types.TrafficController
-	Alert   api.Alerter
+	Config            *config.Config
+	Logger            *slog.Logger
+	Bus               *EventBus
+	DB                types.Repository
+	Client            github.Client
+	Backend           types.TUIBackend
+	legacyReadMutator legacyReadMutator
+	Sync              types.Syncer
+	Enrich            types.Enricher
+	Traffic           types.TrafficController
+	Alert             api.Alerter
+}
+
+// legacyReadMutator is consumed only by the deprecated MCP mark_read tool.
+type legacyReadMutator interface {
+	MarkReadLegacy(ctx context.Context, id string, read bool) (types.ReadUpdateResult, error)
 }
 
 type options struct {
@@ -164,16 +170,17 @@ func NewCoreEngine(
 	}
 
 	return &CoreEngine{
-		Config:  cfg,
-		Logger:  logger,
-		Bus:     bus,
-		DB:      database,
-		Client:  client,
-		Backend: appBackend,
-		Sync:    syncer,
-		Enrich:  enricher,
-		Traffic: traffic,
-		Alert:   alerter,
+		Config:            cfg,
+		Logger:            logger,
+		Bus:               bus,
+		DB:                database,
+		Client:            client,
+		Backend:           appBackend,
+		legacyReadMutator: appBackend,
+		Sync:              syncer,
+		Enrich:            enricher,
+		Traffic:           traffic,
+		Alert:             alerter,
 	}, nil
 }
 

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hirakiuc/gh-orbit/internal/buildinfo"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/engine/transport"
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -39,7 +40,7 @@ type MCPServer struct {
 func NewMCPServer(engine *CoreEngine, socketPath string, insecure bool, verbose bool) *MCPServer {
 	s := server.NewMCPServer(
 		"gh-orbit",
-		"0.1.0",
+		buildinfo.Version,
 		server.WithResourceCapabilities(true, false),
 		server.WithToolCapabilities(true),
 	)
@@ -336,6 +337,32 @@ func markReadToolResult(result types.MarkReadResult, err error) (*mcp.CallToolRe
 	}
 }
 
+func handledToolResult(result types.HandledUpdateResult, err error) (*mcp.CallToolResult, error) {
+	if err != nil {
+		return mutationToolFailureResult("failed to set handled state: %v", err)
+	}
+	if result.Err != nil {
+		return mutationToolFailureResult("failed to set handled state: %v", result.Err)
+	}
+	return mutationToolSuccessResult("Notification handled state updated")
+}
+
+func requiredStateMutationArgs(request mcp.CallToolRequest, stateKey string) (string, bool, error) {
+	args, ok := request.Params.Arguments.(map[string]any)
+	if !ok {
+		return "", false, errors.New("invalid arguments format")
+	}
+	id, ok := args["id"].(string)
+	if !ok || strings.TrimSpace(id) == "" {
+		return "", false, errors.New("id must be a non-empty string")
+	}
+	state, ok := args[stateKey].(bool)
+	if !ok {
+		return "", false, fmt.Errorf("%s must be a boolean", stateKey)
+	}
+	return strings.TrimSpace(id), state, nil
+}
+
 func priorityToolResult(result types.PriorityUpdateResult, err error) (*mcp.CallToolResult, error) {
 	if err != nil {
 		return mutationToolFailureResult("failed to set priority: %v", err)
@@ -425,8 +452,41 @@ func (s *MCPServer) registerTools() {
 			read = r
 		}
 
-		result, err := s.engine.Backend.MarkRead(ctx, id, read)
+		if s.engine.legacyReadMutator == nil {
+			return mcp.NewToolResultError("legacy mark_read backend is unavailable"), nil
+		}
+		result, err := s.engine.legacyReadMutator.MarkReadLegacy(ctx, id, read)
 		return markReadToolResult(result, err)
+	})
+
+	setReadTool := mcp.NewTool(
+		"set_read",
+		mcp.WithDescription("Set a notification's read state without changing local handled state"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The GitHub notification ID")),
+		mcp.WithBoolean("read", mcp.Required(), mcp.Description("The desired read state")),
+	)
+	s.server.AddTool(setReadTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, read, err := requiredStateMutationArgs(request, "read")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := s.engine.Backend.SetRead(ctx, id, read)
+		return markReadToolResult(result, err)
+	})
+
+	setHandledTool := mcp.NewTool(
+		"set_handled",
+		mcp.WithDescription("Set a notification's local handled state without changing read state"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The GitHub notification ID")),
+		mcp.WithBoolean("handled", mcp.Required(), mcp.Description("The desired local handled state")),
+	)
+	s.server.AddTool(setHandledTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, handled, err := requiredStateMutationArgs(request, "handled")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := s.engine.Backend.SetHandled(ctx, id, handled)
+		return handledToolResult(result, err)
 	})
 
 	// 3. Set Priority Tool

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -405,6 +405,15 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		t.Helper()
 		return readJSONLine(t, conn, reader, timeout)
 	}
+	assertNoNotification := func(t *testing.T, conn net.Conn, reader *bufio.Reader) {
+		t.Helper()
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(100*time.Millisecond)))
+		_, err := reader.ReadString('\n')
+		var netErr net.Error
+		require.ErrorAs(t, err, &netErr)
+		assert.True(t, netErr.Timeout())
+		require.NoError(t, conn.SetReadDeadline(time.Time{}))
+	}
 
 	t.Run("direct notification events send coarse resource invalidation", func(t *testing.T) {
 		srv, _, _ := newTestServer(t)
@@ -458,6 +467,62 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		notification := readNotification(t, clientConn, reader, time.Second)
 		require.Contains(t, response, "result")
 		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
+	})
+
+	t.Run("invalid independent requests do not call backend or notify", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			tool string
+			args map[string]any
+		}{
+			{name: "set_read missing boolean", tool: "set_read", args: map[string]any{"id": "1"}},
+			{name: "set_handled wrong boolean type", tool: "set_handled", args: map[string]any{"id": "1", "handled": "true"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				srv, mockRepo, _ := newTestServer(t)
+				sessionCtx, clientConn, reader, cleanup := newSession(t, srv)
+				defer cleanup()
+
+				response := callTool(t, srv, sessionCtx, 2, tc.tool, tc.args)
+				result, ok := response["result"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, result["isError"])
+				mockRepo.AssertNotCalled(t, "ListNotifications", mock.Anything)
+				mockRepo.AssertNotCalled(t, "SetReadLocally", mock.Anything, mock.Anything, mock.Anything)
+				mockRepo.AssertNotCalled(t, "SetHandledLocally", mock.Anything, mock.Anything, mock.Anything)
+				assertNoNotification(t, clientConn, reader)
+			})
+		}
+	})
+
+	t.Run("independent local failures do not notify", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			tool string
+			args map[string]any
+			set  func(*mocks.MockRepository)
+		}{
+			{name: "set_read unknown id", tool: "set_read", args: map[string]any{"id": "missing", "read": true}, set: func(repo *mocks.MockRepository) {
+				repo.EXPECT().SetReadLocally(mock.Anything, "missing", true).Return(types.ErrNotificationNotFound).Once()
+			}},
+			{name: "set_handled unknown id", tool: "set_handled", args: map[string]any{"id": "missing", "handled": true}, set: func(repo *mocks.MockRepository) {
+				repo.EXPECT().SetHandledLocally(mock.Anything, "missing", true).Return(types.ErrNotificationNotFound).Once()
+			}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				srv, mockRepo, _ := newTestServer(t)
+				sessionCtx, clientConn, reader, cleanup := newSession(t, srv)
+				defer cleanup()
+				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Twice()
+				tc.set(mockRepo)
+
+				response := callTool(t, srv, sessionCtx, 2, tc.tool, tc.args)
+				result, ok := response["result"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, result["isError"])
+				assertNoNotification(t, clientConn, reader)
+			})
+		}
 	})
 
 	t.Run("mark_read remote failure still notifies after local commit", func(t *testing.T) {

--- a/internal/engine/mcp_test.go
+++ b/internal/engine/mcp_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/api"
+	"github.com/hirakiuc/gh-orbit/internal/buildinfo"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -113,6 +114,39 @@ func readJSONLine(t *testing.T, conn net.Conn, reader *bufio.Reader, timeout tim
 	return payload
 }
 
+func TestRequiredStateMutationArgs_StrictValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments any
+		stateKey  string
+		wantID    string
+		wantState bool
+		wantError string
+	}{
+		{name: "valid read", arguments: map[string]any{"id": " 123 ", "read": true}, stateKey: "read", wantID: "123", wantState: true},
+		{name: "valid handled false", arguments: map[string]any{"id": "123", "handled": false}, stateKey: "handled", wantID: "123", wantState: false},
+		{name: "missing id", arguments: map[string]any{"read": true}, stateKey: "read", wantError: "id must be a non-empty string"},
+		{name: "blank id", arguments: map[string]any{"id": "  ", "read": true}, stateKey: "read", wantError: "id must be a non-empty string"},
+		{name: "non-string id", arguments: map[string]any{"id": 123, "read": true}, stateKey: "read", wantError: "id must be a non-empty string"},
+		{name: "missing state", arguments: map[string]any{"id": "123"}, stateKey: "handled", wantError: "handled must be a boolean"},
+		{name: "non-boolean state", arguments: map[string]any{"id": "123", "handled": "true"}, stateKey: "handled", wantError: "handled must be a boolean"},
+		{name: "invalid arguments", arguments: []any{"123", true}, stateKey: "read", wantError: "invalid arguments format"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, state, err := requiredStateMutationArgs(mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tt.arguments}}, tt.stateKey)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, id)
+			assert.Equal(t, tt.wantState, state)
+		})
+	}
+}
+
 func TestMCPServer_UDSHandshake(t *testing.T) {
 	// Setup CoreEngine
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -181,6 +215,7 @@ func TestMCPServer_UDSHandshake(t *testing.T) {
 	err = json.Unmarshal(resBytes, &initResult)
 	assert.NoError(t, err)
 	assert.Equal(t, "gh-orbit", initResult.ServerInfo.Name)
+	assert.Equal(t, buildinfo.Version, initResult.ServerInfo.Version)
 
 	// 3. Signal exit
 	cancel()
@@ -292,13 +327,14 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		require.NoError(t, err)
 
 		eng := &CoreEngine{
-			Logger:  slog.Default(),
-			Bus:     bus,
-			DB:      mockRepo,
-			Client:  mockGH,
-			Sync:    mockSync,
-			Enrich:  mockEnrich,
-			Backend: appBackend,
+			Logger:            slog.Default(),
+			Bus:               bus,
+			DB:                mockRepo,
+			Client:            mockGH,
+			Sync:              mockSync,
+			Enrich:            mockEnrich,
+			Backend:           appBackend,
+			legacyReadMutator: appBackend,
 		}
 
 		return NewMCPServer(eng, filepath.Join(t.TempDir(), "mcp-mutation.sock"), true, false), mockRepo, mockGH
@@ -404,6 +440,22 @@ func TestMCPServer_MutationToolsNotifyUDSClients(t *testing.T) {
 		})
 		notification := readNotification(t, clientConn, reader, time.Second)
 
+		require.Contains(t, response, "result")
+		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
+	})
+
+	t.Run("set_handled success sends resources/list_changed", func(t *testing.T) {
+		srv, mockRepo, _ := newTestServer(t)
+		sessionCtx, clientConn, reader, cleanup := newSession(t, srv)
+		defer cleanup()
+
+		mockRepo.EXPECT().SetHandledLocally(mock.Anything, "handled", true).Return(nil).Once()
+		mockRepo.EXPECT().ListNotifications(mock.Anything).Return(nil, nil).Twice()
+
+		response := callTool(t, srv, sessionCtx, 2, "set_handled", map[string]any{
+			"id": "handled", "handled": true,
+		})
+		notification := readNotification(t, clientConn, reader, time.Second)
 		require.Contains(t, response, "result")
 		assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notification["method"])
 	})

--- a/internal/engine/tui_backend_contract_test.go
+++ b/internal/engine/tui_backend_contract_test.go
@@ -23,7 +23,7 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 		{Notification: triage.Notification{GitHubID: "notif-1"}},
 	}
 	after := []triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
+		{Notification: triage.Notification{GitHubID: "notif-1"}, State: triage.State{IsReadLocally: true}},
 	}
 
 	testCases := []struct {
@@ -39,7 +39,7 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 				mockClient := mocks.NewMockClient(t)
 
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(before, nil).Once()
-				mockRepo.EXPECT().MarkReadLocally(mock.Anything, "notif-1", true).Return(nil).Once()
+				mockRepo.EXPECT().SetReadLocally(mock.Anything, "notif-1", true).Return(nil).Once()
 				mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-1").Return(nil).Once()
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
 
@@ -83,7 +83,7 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 						}, nil
 					},
 					callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-						require.Equal(t, "mark_read", request.Params.Name)
+						require.Equal(t, "set_read", request.Params.Name)
 						return mcp.NewToolResultText("Notification read state updated"), nil
 					},
 				})
@@ -93,7 +93,7 @@ func TestTUIBackendContract_MarkReadSuccess(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := tc.backend(t).MarkRead(context.Background(), "notif-1", true)
+			result, err := tc.backend(t).SetRead(context.Background(), "notif-1", true)
 			require.NoError(t, err)
 			assert.Equal(t, types.MarkReadSuccess, result.Status)
 			assert.Equal(t, after, result.Notifications)
@@ -108,7 +108,7 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 		{Notification: triage.Notification{GitHubID: "notif-2"}},
 	}
 	after := []triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "notif-2"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
+		{Notification: triage.Notification{GitHubID: "notif-2"}, State: triage.State{IsReadLocally: true}},
 	}
 	remoteErr := errors.New("boom")
 
@@ -125,7 +125,7 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 				mockClient := mocks.NewMockClient(t)
 
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(before, nil).Once()
-				mockRepo.EXPECT().MarkReadLocally(mock.Anything, "notif-2", true).Return(nil).Once()
+				mockRepo.EXPECT().SetReadLocally(mock.Anything, "notif-2", true).Return(nil).Once()
 				mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "notif-2").Return(remoteErr).Once()
 				mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
 
@@ -169,7 +169,7 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 						}, nil
 					},
 					callTool: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-						require.Equal(t, "mark_read", request.Params.Name)
+						require.Equal(t, "set_read", request.Params.Name)
 						return &mcp.CallToolResult{
 							IsError: true,
 							Content: []mcp.Content{
@@ -184,12 +184,63 @@ func TestTUIBackendContract_MarkReadRemoteFailure(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := tc.backend(t).MarkRead(context.Background(), "notif-2", true)
+			result, err := tc.backend(t).SetRead(context.Background(), "notif-2", true)
 			require.NoError(t, err)
 			assert.Equal(t, types.MarkReadRemoteFailure, result.Status)
 			assert.Equal(t, after, result.Notifications)
 			assert.Equal(t, "Marked read locally; GitHub sync failed", result.Toast)
 			require.Error(t, result.Err)
+		})
+	}
+}
+
+func TestTUIBackendContract_SetHandledSuccess(t *testing.T) {
+	before := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "handled"}, State: triage.State{IsReadLocally: true}}}
+	after := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "handled"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}}}
+
+	testCases := []struct {
+		name    string
+		backend func(*testing.T) types.TUIBackend
+	}{
+		{name: "app backend", backend: func(t *testing.T) types.TUIBackend {
+			repo := mocks.NewMockRepository(t)
+			repo.EXPECT().ListNotifications(mock.Anything).Return(before, nil).Once()
+			repo.EXPECT().SetHandledLocally(mock.Anything, "handled", true).Return(nil).Once()
+			repo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
+			backend, err := api.NewAppBackend(api.AppBackendParams{
+				UserID: "user", Store: repo, Syncer: mocks.NewMockSyncer(t), Enricher: mocks.NewMockEnricher(t),
+			})
+			require.NoError(t, err)
+			return backend
+		}},
+		{name: "mcp adapter", backend: func(t *testing.T) types.TUIBackend {
+			readCount := 0
+			return NewMCPAdapter(&blockingMCPClient{
+				readResource: func(_ context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					snapshot := before
+					if readCount > 0 {
+						snapshot = after
+					}
+					readCount++
+					payload, err := json.Marshal(snapshot)
+					require.NoError(t, err)
+					return &mcp.ReadResourceResult{Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: request.Params.URI, Text: string(payload)}}}, nil
+				},
+				callTool: func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					require.Equal(t, "set_handled", request.Params.Name)
+					return mcp.NewToolResultText("updated"), nil
+				},
+			})
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.backend(t).SetHandled(context.Background(), "handled", true)
+			require.NoError(t, err)
+			assert.Equal(t, types.HandledUpdateSuccess, result.Status)
+			assert.Equal(t, after, result.Notifications)
+			assert.True(t, result.Notifications[0].IsReadLocally)
 		})
 	}
 }

--- a/internal/mocks/mock_alert_repository.go
+++ b/internal/mocks/mock_alert_repository.go
@@ -74,7 +74,7 @@ type MockAlertRepository_GetBridgeHealth_Call struct {
 
 // GetBridgeHealth is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAlertRepository_Expecter) GetBridgeHealth(ctx interface{}) *MockAlertRepository_GetBridgeHealth_Call {
+func (_e *MockAlertRepository_Expecter) GetBridgeHealth(ctx any) *MockAlertRepository_GetBridgeHealth_Call {
 	return &MockAlertRepository_GetBridgeHealth_Call{Call: _e.mock.On("GetBridgeHealth", ctx)}
 }
 
@@ -136,7 +136,7 @@ type MockAlertRepository_ListNotifications_Call struct {
 
 // ListNotifications is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAlertRepository_Expecter) ListNotifications(ctx interface{}) *MockAlertRepository_ListNotifications_Call {
+func (_e *MockAlertRepository_Expecter) ListNotifications(ctx any) *MockAlertRepository_ListNotifications_Call {
 	return &MockAlertRepository_ListNotifications_Call{Call: _e.mock.On("ListNotifications", ctx)}
 }
 
@@ -188,7 +188,7 @@ type MockAlertRepository_UpdateBridgeHealth_Call struct {
 // UpdateBridgeHealth is a helper method to define mock.On call
 //   - ctx context.Context
 //   - h models.BridgeHealth
-func (_e *MockAlertRepository_Expecter) UpdateBridgeHealth(ctx interface{}, h interface{}) *MockAlertRepository_UpdateBridgeHealth_Call {
+func (_e *MockAlertRepository_Expecter) UpdateBridgeHealth(ctx any, h any) *MockAlertRepository_UpdateBridgeHealth_Call {
 	return &MockAlertRepository_UpdateBridgeHealth_Call{Call: _e.mock.On("UpdateBridgeHealth", ctx, h)}
 }
 

--- a/internal/mocks/mock_alerter.go
+++ b/internal/mocks/mock_alerter.go
@@ -161,7 +161,7 @@ type MockAlerter_Notify_Call struct {
 // Notify is a helper method to define mock.On call
 //   - ctx context.Context
 //   - n github.Notification
-func (_e *MockAlerter_Expecter) Notify(ctx interface{}, n interface{}) *MockAlerter_Notify_Call {
+func (_e *MockAlerter_Expecter) Notify(ctx any, n any) *MockAlerter_Notify_Call {
 	return &MockAlerter_Notify_Call{Call: _e.mock.On("Notify", ctx, n)}
 }
 
@@ -206,7 +206,7 @@ type MockAlerter_Shutdown_Call struct {
 
 // Shutdown is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAlerter_Expecter) Shutdown(ctx interface{}) *MockAlerter_Shutdown_Call {
+func (_e *MockAlerter_Expecter) Shutdown(ctx any) *MockAlerter_Shutdown_Call {
 	return &MockAlerter_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
 }
 
@@ -246,7 +246,7 @@ type MockAlerter_SyncStart_Call struct {
 
 // SyncStart is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAlerter_Expecter) SyncStart(ctx interface{}) *MockAlerter_SyncStart_Call {
+func (_e *MockAlerter_Expecter) SyncStart(ctx any) *MockAlerter_SyncStart_Call {
 	return &MockAlerter_SyncStart_Call{Call: _e.mock.On("SyncStart", ctx)}
 }
 
@@ -300,7 +300,7 @@ type MockAlerter_TestNotify_Call struct {
 //   - title string
 //   - subtitle string
 //   - body string
-func (_e *MockAlerter_Expecter) TestNotify(ctx interface{}, title interface{}, subtitle interface{}, body interface{}) *MockAlerter_TestNotify_Call {
+func (_e *MockAlerter_Expecter) TestNotify(ctx any, title any, subtitle any, body any) *MockAlerter_TestNotify_Call {
 	return &MockAlerter_TestNotify_Call{Call: _e.mock.On("TestNotify", ctx, title, subtitle, body)}
 }
 

--- a/internal/mocks/mock_client.go
+++ b/internal/mocks/mock_client.go
@@ -119,7 +119,7 @@ type MockClient_CurrentUser_Call struct {
 
 // CurrentUser is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockClient_Expecter) CurrentUser(ctx interface{}) *MockClient_CurrentUser_Call {
+func (_e *MockClient_Expecter) CurrentUser(ctx any) *MockClient_CurrentUser_Call {
 	return &MockClient_CurrentUser_Call{Call: _e.mock.On("CurrentUser", ctx)}
 }
 
@@ -263,7 +263,7 @@ type MockClient_MarkThreadAsRead_Call struct {
 // MarkThreadAsRead is a helper method to define mock.On call
 //   - ctx context.Context
 //   - threadID string
-func (_e *MockClient_Expecter) MarkThreadAsRead(ctx interface{}, threadID interface{}) *MockClient_MarkThreadAsRead_Call {
+func (_e *MockClient_Expecter) MarkThreadAsRead(ctx any, threadID any) *MockClient_MarkThreadAsRead_Call {
 	return &MockClient_MarkThreadAsRead_Call{Call: _e.mock.On("MarkThreadAsRead", ctx, threadID)}
 }
 
@@ -354,7 +354,7 @@ type MockClient_ReportRateLimit_Call struct {
 
 // ReportRateLimit is a helper method to define mock.On call
 //   - info models.RateLimitInfo
-func (_e *MockClient_Expecter) ReportRateLimit(info interface{}) *MockClient_ReportRateLimit_Call {
+func (_e *MockClient_Expecter) ReportRateLimit(info any) *MockClient_ReportRateLimit_Call {
 	return &MockClient_ReportRateLimit_Call{Call: _e.mock.On("ReportRateLimit", info)}
 }
 
@@ -394,7 +394,7 @@ type MockClient_SetRateLimitReporter_Call struct {
 
 // SetRateLimitReporter is a helper method to define mock.On call
 //   - fn func(models.RateLimitInfo)
-func (_e *MockClient_Expecter) SetRateLimitReporter(fn interface{}) *MockClient_SetRateLimitReporter_Call {
+func (_e *MockClient_Expecter) SetRateLimitReporter(fn any) *MockClient_SetRateLimitReporter_Call {
 	return &MockClient_SetRateLimitReporter_Call{Call: _e.mock.On("SetRateLimitReporter", fn)}
 }
 

--- a/internal/mocks/mock_command_executor.go
+++ b/internal/mocks/mock_command_executor.go
@@ -40,11 +40,11 @@ func (_m *MockCommandExecutor) EXPECT() *MockCommandExecutor_Expecter {
 // Execute provides a mock function for the type MockCommandExecutor
 func (_mock *MockCommandExecutor) Execute(ctx context.Context, name string, args ...string) ([]byte, error) {
 	// string
-	_va := make([]interface{}, len(args))
+	_va := make([]any, len(args))
 	for _i := range args {
 		_va[_i] = args[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, name)
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
@@ -82,9 +82,9 @@ type MockCommandExecutor_Execute_Call struct {
 //   - ctx context.Context
 //   - name string
 //   - args ...string
-func (_e *MockCommandExecutor_Expecter) Execute(ctx interface{}, name interface{}, args ...interface{}) *MockCommandExecutor_Execute_Call {
+func (_e *MockCommandExecutor_Expecter) Execute(ctx any, name any, args ...any) *MockCommandExecutor_Execute_Call {
 	return &MockCommandExecutor_Execute_Call{Call: _e.mock.On("Execute",
-		append([]interface{}{ctx, name}, args...)...)}
+		append([]any{ctx, name}, args...)...)}
 }
 
 func (_c *MockCommandExecutor_Execute_Call) Run(run func(ctx context.Context, name string, args ...string)) *MockCommandExecutor_Execute_Call {
@@ -127,11 +127,11 @@ func (_c *MockCommandExecutor_Execute_Call) RunAndReturn(run func(ctx context.Co
 // Run provides a mock function for the type MockCommandExecutor
 func (_mock *MockCommandExecutor) Run(ctx context.Context, name string, args ...string) error {
 	// string
-	_va := make([]interface{}, len(args))
+	_va := make([]any, len(args))
 	for _i := range args {
 		_va[_i] = args[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, name)
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
@@ -158,9 +158,9 @@ type MockCommandExecutor_Run_Call struct {
 //   - ctx context.Context
 //   - name string
 //   - args ...string
-func (_e *MockCommandExecutor_Expecter) Run(ctx interface{}, name interface{}, args ...interface{}) *MockCommandExecutor_Run_Call {
+func (_e *MockCommandExecutor_Expecter) Run(ctx any, name any, args ...any) *MockCommandExecutor_Run_Call {
 	return &MockCommandExecutor_Run_Call{Call: _e.mock.On("Run",
-		append([]interface{}{ctx, name}, args...)...)}
+		append([]any{ctx, name}, args...)...)}
 }
 
 func (_c *MockCommandExecutor_Run_Call) Run(run func(ctx context.Context, name string, args ...string)) *MockCommandExecutor_Run_Call {

--- a/internal/mocks/mock_enricher.go
+++ b/internal/mocks/mock_enricher.go
@@ -75,7 +75,7 @@ type MockEnricher_FetchDetail_Call struct {
 //   - u string
 //   - subjectType string
 //   - force bool
-func (_e *MockEnricher_Expecter) FetchDetail(ctx interface{}, u interface{}, subjectType interface{}, force interface{}) *MockEnricher_FetchDetail_Call {
+func (_e *MockEnricher_Expecter) FetchDetail(ctx any, u any, subjectType any, force any) *MockEnricher_FetchDetail_Call {
 	return &MockEnricher_FetchDetail_Call{Call: _e.mock.On("FetchDetail", ctx, u, subjectType, force)}
 }
 
@@ -145,7 +145,7 @@ type MockEnricher_FetchHybridBatch_Call struct {
 //   - ctx context.Context
 //   - notifications []triage.NotificationWithState
 //   - force bool
-func (_e *MockEnricher_Expecter) FetchHybridBatch(ctx interface{}, notifications interface{}, force interface{}) *MockEnricher_FetchHybridBatch_Call {
+func (_e *MockEnricher_Expecter) FetchHybridBatch(ctx any, notifications any, force any) *MockEnricher_FetchHybridBatch_Call {
 	return &MockEnricher_FetchHybridBatch_Call{Call: _e.mock.On("FetchHybridBatch", ctx, notifications, force)}
 }
 
@@ -190,11 +190,13 @@ func (_mock *MockEnricher) PersistFetchedDetail(ctx context.Context, id string, 
 		panic("no return value specified for PersistFetchedDetail")
 	}
 
+	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, models.EnrichmentResult) error); ok {
-		return returnFunc(ctx, id, sourceURL, res)
+		r0 = returnFunc(ctx, id, sourceURL, res)
+	} else {
+		r0 = ret.Error(0)
 	}
-
-	return ret.Error(0)
+	return r0
 }
 
 // MockEnricher_PersistFetchedDetail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistFetchedDetail'
@@ -203,7 +205,11 @@ type MockEnricher_PersistFetchedDetail_Call struct {
 }
 
 // PersistFetchedDetail is a helper method to define mock.On call
-func (_e *MockEnricher_Expecter) PersistFetchedDetail(ctx interface{}, id interface{}, sourceURL interface{}, res interface{}) *MockEnricher_PersistFetchedDetail_Call {
+//   - ctx context.Context
+//   - id string
+//   - sourceURL string
+//   - res models.EnrichmentResult
+func (_e *MockEnricher_Expecter) PersistFetchedDetail(ctx any, id any, sourceURL any, res any) *MockEnricher_PersistFetchedDetail_Call {
 	return &MockEnricher_PersistFetchedDetail_Call{Call: _e.mock.On("PersistFetchedDetail", ctx, id, sourceURL, res)}
 }
 
@@ -225,7 +231,12 @@ func (_c *MockEnricher_PersistFetchedDetail_Call) Run(run func(ctx context.Conte
 		if args[3] != nil {
 			arg3 = args[3].(models.EnrichmentResult)
 		}
-		run(arg0, arg1, arg2, arg3)
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }
@@ -248,11 +259,13 @@ func (_mock *MockEnricher) PersistIndependentDetail(ctx context.Context, id stri
 		panic("no return value specified for PersistIndependentDetail")
 	}
 
+	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) error); ok {
-		return returnFunc(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
+		r0 = returnFunc(ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)
+	} else {
+		r0 = ret.Error(0)
 	}
-
-	return ret.Error(0)
+	return r0
 }
 
 // MockEnricher_PersistIndependentDetail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistIndependentDetail'
@@ -261,7 +274,15 @@ type MockEnricher_PersistIndependentDetail_Call struct {
 }
 
 // PersistIndependentDetail is a helper method to define mock.On call
-func (_e *MockEnricher_Expecter) PersistIndependentDetail(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockEnricher_PersistIndependentDetail_Call {
+//   - ctx context.Context
+//   - id string
+//   - nodeID string
+//   - body string
+//   - author string
+//   - htmlURL string
+//   - resourceState string
+//   - resourceSubState string
+func (_e *MockEnricher_Expecter) PersistIndependentDetail(ctx any, id any, nodeID any, body any, author any, htmlURL any, resourceState any, resourceSubState any) *MockEnricher_PersistIndependentDetail_Call {
 	return &MockEnricher_PersistIndependentDetail_Call{Call: _e.mock.On("PersistIndependentDetail", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
 }
 
@@ -299,7 +320,16 @@ func (_c *MockEnricher_PersistIndependentDetail_Call) Run(run func(ctx context.C
 		if args[7] != nil {
 			arg7 = args[7].(string)
 		}
-		run(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+		)
 	})
 	return _c
 }
@@ -327,7 +357,7 @@ type MockEnricher_Shutdown_Call struct {
 
 // Shutdown is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockEnricher_Expecter) Shutdown(ctx interface{}) *MockEnricher_Shutdown_Call {
+func (_e *MockEnricher_Expecter) Shutdown(ctx any) *MockEnricher_Shutdown_Call {
 	return &MockEnricher_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
 }
 

--- a/internal/mocks/mock_enrichment_repository.go
+++ b/internal/mocks/mock_enrichment_repository.go
@@ -68,7 +68,7 @@ type MockEnrichmentRepository_EnrichNotification_Call struct {
 //   - htmlURL string
 //   - resourceState string
 //   - resourceSubState string
-func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockEnrichmentRepository_EnrichNotification_Call {
+func (_e *MockEnrichmentRepository_Expecter) EnrichNotification(ctx any, id any, nodeID any, body any, author any, htmlURL any, resourceState any, resourceSubState any) *MockEnrichmentRepository_EnrichNotification_Call {
 	return &MockEnrichmentRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
 }
 
@@ -157,7 +157,7 @@ type MockEnrichmentRepository_UpdateResourceStateByNodeID_Call struct {
 //   - nodeID string
 //   - state string
 //   - resourceSubState string
-func (_e *MockEnrichmentRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}, resourceSubState interface{}) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
+func (_e *MockEnrichmentRepository_Expecter) UpdateResourceStateByNodeID(ctx any, nodeID any, state any, resourceSubState any) *MockEnrichmentRepository_UpdateResourceStateByNodeID_Call {
 	return &MockEnrichmentRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state, resourceSubState)}
 }
 

--- a/internal/mocks/mock_fetcher.go
+++ b/internal/mocks/mock_fetcher.go
@@ -90,7 +90,7 @@ type MockFetcher_FetchNotifications_Call struct {
 //   - ctx context.Context
 //   - meta *models.SyncMeta
 //   - force bool
-func (_e *MockFetcher_Expecter) FetchNotifications(ctx interface{}, meta interface{}, force interface{}) *MockFetcher_FetchNotifications_Call {
+func (_e *MockFetcher_Expecter) FetchNotifications(ctx any, meta any, force any) *MockFetcher_FetchNotifications_Call {
 	return &MockFetcher_FetchNotifications_Call{Call: _e.mock.On("FetchNotifications", ctx, meta, force)}
 }
 

--- a/internal/mocks/mock_graph_ql_client.go
+++ b/internal/mocks/mock_graph_ql_client.go
@@ -64,7 +64,7 @@ type MockGraphQLClient_DoWithContext_Call struct {
 //   - query string
 //   - variables map[string]any
 //   - response any
-func (_e *MockGraphQLClient_Expecter) DoWithContext(ctx interface{}, query interface{}, variables interface{}, response interface{}) *MockGraphQLClient_DoWithContext_Call {
+func (_e *MockGraphQLClient_Expecter) DoWithContext(ctx any, query any, variables any, response any) *MockGraphQLClient_DoWithContext_Call {
 	return &MockGraphQLClient_DoWithContext_Call{Call: _e.mock.On("DoWithContext", ctx, query, variables, response)}
 }
 

--- a/internal/mocks/mock_notifier.go
+++ b/internal/mocks/mock_notifier.go
@@ -67,7 +67,7 @@ type MockNotifier_Notify_Call struct {
 //   - body string
 //   - url string
 //   - priority int
-func (_e *MockNotifier_Expecter) Notify(ctx interface{}, title interface{}, subtitle interface{}, body interface{}, url interface{}, priority interface{}) *MockNotifier_Notify_Call {
+func (_e *MockNotifier_Expecter) Notify(ctx any, title any, subtitle any, body any, url any, priority any) *MockNotifier_Notify_Call {
 	return &MockNotifier_Notify_Call{Call: _e.mock.On("Notify", ctx, title, subtitle, body, url, priority)}
 }
 
@@ -132,7 +132,7 @@ type MockNotifier_Shutdown_Call struct {
 
 // Shutdown is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockNotifier_Expecter) Shutdown(ctx interface{}) *MockNotifier_Shutdown_Call {
+func (_e *MockNotifier_Expecter) Shutdown(ctx any) *MockNotifier_Shutdown_Call {
 	return &MockNotifier_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
 }
 

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -64,7 +64,7 @@ type MockRepository_ArchiveThread_Call struct {
 // ArchiveThread is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockRepository_Expecter) ArchiveThread(ctx interface{}, id interface{}) *MockRepository_ArchiveThread_Call {
+func (_e *MockRepository_Expecter) ArchiveThread(ctx any, id any) *MockRepository_ArchiveThread_Call {
 	return &MockRepository_ArchiveThread_Call{Call: _e.mock.On("ArchiveThread", ctx, id)}
 }
 
@@ -127,7 +127,7 @@ type MockRepository_EnrichNotification_Call struct {
 //   - htmlURL string
 //   - resourceState string
 //   - resourceSubState string
-func (_e *MockRepository_Expecter) EnrichNotification(ctx interface{}, id interface{}, nodeID interface{}, body interface{}, author interface{}, htmlURL interface{}, resourceState interface{}, resourceSubState interface{}) *MockRepository_EnrichNotification_Call {
+func (_e *MockRepository_Expecter) EnrichNotification(ctx any, id any, nodeID any, body any, author any, htmlURL any, resourceState any, resourceSubState any) *MockRepository_EnrichNotification_Call {
 	return &MockRepository_EnrichNotification_Call{Call: _e.mock.On("EnrichNotification", ctx, id, nodeID, body, author, htmlURL, resourceState, resourceSubState)}
 }
 
@@ -224,7 +224,7 @@ type MockRepository_GetBridgeHealth_Call struct {
 
 // GetBridgeHealth is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockRepository_Expecter) GetBridgeHealth(ctx interface{}) *MockRepository_GetBridgeHealth_Call {
+func (_e *MockRepository_Expecter) GetBridgeHealth(ctx any) *MockRepository_GetBridgeHealth_Call {
 	return &MockRepository_GetBridgeHealth_Call{Call: _e.mock.On("GetBridgeHealth", ctx)}
 }
 
@@ -287,7 +287,7 @@ type MockRepository_GetNotification_Call struct {
 // GetNotification is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockRepository_Expecter) GetNotification(ctx interface{}, id interface{}) *MockRepository_GetNotification_Call {
+func (_e *MockRepository_Expecter) GetNotification(ctx any, id any) *MockRepository_GetNotification_Call {
 	return &MockRepository_GetNotification_Call{Call: _e.mock.On("GetNotification", ctx, id)}
 }
 
@@ -356,7 +356,7 @@ type MockRepository_GetSyncMeta_Call struct {
 //   - ctx context.Context
 //   - userID string
 //   - key string
-func (_e *MockRepository_Expecter) GetSyncMeta(ctx interface{}, userID interface{}, key interface{}) *MockRepository_GetSyncMeta_Call {
+func (_e *MockRepository_Expecter) GetSyncMeta(ctx any, userID any, key any) *MockRepository_GetSyncMeta_Call {
 	return &MockRepository_GetSyncMeta_Call{Call: _e.mock.On("GetSyncMeta", ctx, userID, key)}
 }
 
@@ -428,7 +428,7 @@ type MockRepository_ListNotifications_Call struct {
 
 // ListNotifications is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockRepository_Expecter) ListNotifications(ctx interface{}) *MockRepository_ListNotifications_Call {
+func (_e *MockRepository_Expecter) ListNotifications(ctx any) *MockRepository_ListNotifications_Call {
 	return &MockRepository_ListNotifications_Call{Call: _e.mock.On("ListNotifications", ctx)}
 }
 
@@ -480,7 +480,7 @@ type MockRepository_MarkNotifiedBatch_Call struct {
 // MarkNotifiedBatch is a helper method to define mock.On call
 //   - ctx context.Context
 //   - ids []string
-func (_e *MockRepository_Expecter) MarkNotifiedBatch(ctx interface{}, ids interface{}) *MockRepository_MarkNotifiedBatch_Call {
+func (_e *MockRepository_Expecter) MarkNotifiedBatch(ctx any, ids any) *MockRepository_MarkNotifiedBatch_Call {
 	return &MockRepository_MarkNotifiedBatch_Call{Call: _e.mock.On("MarkNotifiedBatch", ctx, ids)}
 }
 
@@ -538,7 +538,7 @@ type MockRepository_MarkReadLocally_Call struct {
 //   - ctx context.Context
 //   - id string
 //   - isRead bool
-func (_e *MockRepository_Expecter) MarkReadLocally(ctx interface{}, id interface{}, isRead interface{}) *MockRepository_MarkReadLocally_Call {
+func (_e *MockRepository_Expecter) MarkReadLocally(ctx any, id any, isRead any) *MockRepository_MarkReadLocally_Call {
 	return &MockRepository_MarkReadLocally_Call{Call: _e.mock.On("MarkReadLocally", ctx, id, isRead)}
 }
 
@@ -600,7 +600,7 @@ type MockRepository_MuteThread_Call struct {
 // MuteThread is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockRepository_Expecter) MuteThread(ctx interface{}, id interface{}) *MockRepository_MuteThread_Call {
+func (_e *MockRepository_Expecter) MuteThread(ctx any, id any) *MockRepository_MuteThread_Call {
 	return &MockRepository_MuteThread_Call{Call: _e.mock.On("MuteThread", ctx, id)}
 }
 
@@ -632,6 +632,69 @@ func (_c *MockRepository_MuteThread_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// SetHandledLocally provides a mock function for the type MockRepository
+func (_mock *MockRepository) SetHandledLocally(ctx context.Context, id string, isHandled bool) error {
+	ret := _mock.Called(ctx, id, isHandled)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetHandledLocally")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) error); ok {
+		r0 = returnFunc(ctx, id, isHandled)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRepository_SetHandledLocally_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetHandledLocally'
+type MockRepository_SetHandledLocally_Call struct {
+	*mock.Call
+}
+
+// SetHandledLocally is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - isHandled bool
+func (_e *MockRepository_Expecter) SetHandledLocally(ctx any, id any, isHandled any) *MockRepository_SetHandledLocally_Call {
+	return &MockRepository_SetHandledLocally_Call{Call: _e.mock.On("SetHandledLocally", ctx, id, isHandled)}
+}
+
+func (_c *MockRepository_SetHandledLocally_Call) Run(run func(ctx context.Context, id string, isHandled bool)) *MockRepository_SetHandledLocally_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_SetHandledLocally_Call) Return(err error) *MockRepository_SetHandledLocally_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRepository_SetHandledLocally_Call) RunAndReturn(run func(ctx context.Context, id string, isHandled bool) error) *MockRepository_SetHandledLocally_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetPriority provides a mock function for the type MockRepository
 func (_mock *MockRepository) SetPriority(ctx context.Context, id string, priority int) error {
 	ret := _mock.Called(ctx, id, priority)
@@ -658,7 +721,7 @@ type MockRepository_SetPriority_Call struct {
 //   - ctx context.Context
 //   - id string
 //   - priority int
-func (_e *MockRepository_Expecter) SetPriority(ctx interface{}, id interface{}, priority interface{}) *MockRepository_SetPriority_Call {
+func (_e *MockRepository_Expecter) SetPriority(ctx any, id any, priority any) *MockRepository_SetPriority_Call {
 	return &MockRepository_SetPriority_Call{Call: _e.mock.On("SetPriority", ctx, id, priority)}
 }
 
@@ -695,6 +758,69 @@ func (_c *MockRepository_SetPriority_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// SetReadLocally provides a mock function for the type MockRepository
+func (_mock *MockRepository) SetReadLocally(ctx context.Context, id string, isRead bool) error {
+	ret := _mock.Called(ctx, id, isRead)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetReadLocally")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) error); ok {
+		r0 = returnFunc(ctx, id, isRead)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRepository_SetReadLocally_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReadLocally'
+type MockRepository_SetReadLocally_Call struct {
+	*mock.Call
+}
+
+// SetReadLocally is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - isRead bool
+func (_e *MockRepository_Expecter) SetReadLocally(ctx any, id any, isRead any) *MockRepository_SetReadLocally_Call {
+	return &MockRepository_SetReadLocally_Call{Call: _e.mock.On("SetReadLocally", ctx, id, isRead)}
+}
+
+func (_c *MockRepository_SetReadLocally_Call) Run(run func(ctx context.Context, id string, isRead bool)) *MockRepository_SetReadLocally_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_SetReadLocally_Call) Return(err error) *MockRepository_SetReadLocally_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRepository_SetReadLocally_Call) RunAndReturn(run func(ctx context.Context, id string, isRead bool) error) *MockRepository_SetReadLocally_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UnarchiveThread provides a mock function for the type MockRepository
 func (_mock *MockRepository) UnarchiveThread(ctx context.Context, id string) error {
 	ret := _mock.Called(ctx, id)
@@ -720,7 +846,7 @@ type MockRepository_UnarchiveThread_Call struct {
 // UnarchiveThread is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockRepository_Expecter) UnarchiveThread(ctx interface{}, id interface{}) *MockRepository_UnarchiveThread_Call {
+func (_e *MockRepository_Expecter) UnarchiveThread(ctx any, id any) *MockRepository_UnarchiveThread_Call {
 	return &MockRepository_UnarchiveThread_Call{Call: _e.mock.On("UnarchiveThread", ctx, id)}
 }
 
@@ -777,7 +903,7 @@ type MockRepository_UnmuteThread_Call struct {
 // UnmuteThread is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockRepository_Expecter) UnmuteThread(ctx interface{}, id interface{}) *MockRepository_UnmuteThread_Call {
+func (_e *MockRepository_Expecter) UnmuteThread(ctx any, id any) *MockRepository_UnmuteThread_Call {
 	return &MockRepository_UnmuteThread_Call{Call: _e.mock.On("UnmuteThread", ctx, id)}
 }
 
@@ -834,7 +960,7 @@ type MockRepository_UpdateBridgeHealth_Call struct {
 // UpdateBridgeHealth is a helper method to define mock.On call
 //   - ctx context.Context
 //   - h models.BridgeHealth
-func (_e *MockRepository_Expecter) UpdateBridgeHealth(ctx interface{}, h interface{}) *MockRepository_UpdateBridgeHealth_Call {
+func (_e *MockRepository_Expecter) UpdateBridgeHealth(ctx any, h any) *MockRepository_UpdateBridgeHealth_Call {
 	return &MockRepository_UpdateBridgeHealth_Call{Call: _e.mock.On("UpdateBridgeHealth", ctx, h)}
 }
 
@@ -893,7 +1019,7 @@ type MockRepository_UpdateResourceStateByNodeID_Call struct {
 //   - nodeID string
 //   - state string
 //   - resourceSubState string
-func (_e *MockRepository_Expecter) UpdateResourceStateByNodeID(ctx interface{}, nodeID interface{}, state interface{}, resourceSubState interface{}) *MockRepository_UpdateResourceStateByNodeID_Call {
+func (_e *MockRepository_Expecter) UpdateResourceStateByNodeID(ctx any, nodeID any, state any, resourceSubState any) *MockRepository_UpdateResourceStateByNodeID_Call {
 	return &MockRepository_UpdateResourceStateByNodeID_Call{Call: _e.mock.On("UpdateResourceStateByNodeID", ctx, nodeID, state, resourceSubState)}
 }
 
@@ -960,7 +1086,7 @@ type MockRepository_UpdateSyncMeta_Call struct {
 // UpdateSyncMeta is a helper method to define mock.On call
 //   - ctx context.Context
 //   - s models.SyncMeta
-func (_e *MockRepository_Expecter) UpdateSyncMeta(ctx interface{}, s interface{}) *MockRepository_UpdateSyncMeta_Call {
+func (_e *MockRepository_Expecter) UpdateSyncMeta(ctx any, s any) *MockRepository_UpdateSyncMeta_Call {
 	return &MockRepository_UpdateSyncMeta_Call{Call: _e.mock.On("UpdateSyncMeta", ctx, s)}
 }
 
@@ -1017,7 +1143,7 @@ type MockRepository_UpsertNotifications_Call struct {
 // UpsertNotifications is a helper method to define mock.On call
 //   - ctx context.Context
 //   - notifications []triage.Notification
-func (_e *MockRepository_Expecter) UpsertNotifications(ctx interface{}, notifications interface{}) *MockRepository_UpsertNotifications_Call {
+func (_e *MockRepository_Expecter) UpsertNotifications(ctx any, notifications any) *MockRepository_UpsertNotifications_Call {
 	return &MockRepository_UpsertNotifications_Call{Call: _e.mock.On("UpsertNotifications", ctx, notifications)}
 }
 

--- a/internal/mocks/mock_rest_client.go
+++ b/internal/mocks/mock_rest_client.go
@@ -66,7 +66,7 @@ type MockRESTClient_DoWithContext_Call struct {
 //   - path string
 //   - body io.Reader
 //   - response any
-func (_e *MockRESTClient_Expecter) DoWithContext(ctx interface{}, method interface{}, path interface{}, body interface{}, response interface{}) *MockRESTClient_DoWithContext_Call {
+func (_e *MockRESTClient_Expecter) DoWithContext(ctx any, method any, path any, body any, response any) *MockRESTClient_DoWithContext_Call {
 	return &MockRESTClient_DoWithContext_Call{Call: _e.mock.On("DoWithContext", ctx, method, path, body, response)}
 }
 

--- a/internal/mocks/mock_sync_repository.go
+++ b/internal/mocks/mock_sync_repository.go
@@ -75,7 +75,7 @@ type MockSyncRepository_GetNotification_Call struct {
 // GetNotification is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockSyncRepository_Expecter) GetNotification(ctx interface{}, id interface{}) *MockSyncRepository_GetNotification_Call {
+func (_e *MockSyncRepository_Expecter) GetNotification(ctx any, id any) *MockSyncRepository_GetNotification_Call {
 	return &MockSyncRepository_GetNotification_Call{Call: _e.mock.On("GetNotification", ctx, id)}
 }
 
@@ -144,7 +144,7 @@ type MockSyncRepository_GetSyncMeta_Call struct {
 //   - ctx context.Context
 //   - userID string
 //   - key string
-func (_e *MockSyncRepository_Expecter) GetSyncMeta(ctx interface{}, userID interface{}, key interface{}) *MockSyncRepository_GetSyncMeta_Call {
+func (_e *MockSyncRepository_Expecter) GetSyncMeta(ctx any, userID any, key any) *MockSyncRepository_GetSyncMeta_Call {
 	return &MockSyncRepository_GetSyncMeta_Call{Call: _e.mock.On("GetSyncMeta", ctx, userID, key)}
 }
 
@@ -206,7 +206,7 @@ type MockSyncRepository_MarkNotifiedBatch_Call struct {
 // MarkNotifiedBatch is a helper method to define mock.On call
 //   - ctx context.Context
 //   - ids []string
-func (_e *MockSyncRepository_Expecter) MarkNotifiedBatch(ctx interface{}, ids interface{}) *MockSyncRepository_MarkNotifiedBatch_Call {
+func (_e *MockSyncRepository_Expecter) MarkNotifiedBatch(ctx any, ids any) *MockSyncRepository_MarkNotifiedBatch_Call {
 	return &MockSyncRepository_MarkNotifiedBatch_Call{Call: _e.mock.On("MarkNotifiedBatch", ctx, ids)}
 }
 
@@ -263,7 +263,7 @@ type MockSyncRepository_UpdateSyncMeta_Call struct {
 // UpdateSyncMeta is a helper method to define mock.On call
 //   - ctx context.Context
 //   - s models.SyncMeta
-func (_e *MockSyncRepository_Expecter) UpdateSyncMeta(ctx interface{}, s interface{}) *MockSyncRepository_UpdateSyncMeta_Call {
+func (_e *MockSyncRepository_Expecter) UpdateSyncMeta(ctx any, s any) *MockSyncRepository_UpdateSyncMeta_Call {
 	return &MockSyncRepository_UpdateSyncMeta_Call{Call: _e.mock.On("UpdateSyncMeta", ctx, s)}
 }
 
@@ -320,7 +320,7 @@ type MockSyncRepository_UpsertNotifications_Call struct {
 // UpsertNotifications is a helper method to define mock.On call
 //   - ctx context.Context
 //   - notifications []triage.Notification
-func (_e *MockSyncRepository_Expecter) UpsertNotifications(ctx interface{}, notifications interface{}) *MockSyncRepository_UpsertNotifications_Call {
+func (_e *MockSyncRepository_Expecter) UpsertNotifications(ctx any, notifications any) *MockSyncRepository_UpsertNotifications_Call {
 	return &MockSyncRepository_UpsertNotifications_Call{Call: _e.mock.On("UpsertNotifications", ctx, notifications)}
 }
 

--- a/internal/mocks/mock_syncer.go
+++ b/internal/mocks/mock_syncer.go
@@ -96,7 +96,7 @@ type MockSyncer_Shutdown_Call struct {
 
 // Shutdown is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockSyncer_Expecter) Shutdown(ctx interface{}) *MockSyncer_Shutdown_Call {
+func (_e *MockSyncer_Expecter) Shutdown(ctx any) *MockSyncer_Shutdown_Call {
 	return &MockSyncer_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
 }
 
@@ -158,7 +158,7 @@ type MockSyncer_Sync_Call struct {
 //   - ctx context.Context
 //   - userID string
 //   - force bool
-func (_e *MockSyncer_Expecter) Sync(ctx interface{}, userID interface{}, force interface{}) *MockSyncer_Sync_Call {
+func (_e *MockSyncer_Expecter) Sync(ctx any, userID any, force any) *MockSyncer_Sync_Call {
 	return &MockSyncer_Sync_Call{Call: _e.mock.On("Sync", ctx, userID, force)}
 }
 

--- a/internal/mocks/mock_traffic_controller.go
+++ b/internal/mocks/mock_traffic_controller.go
@@ -96,7 +96,7 @@ type MockTrafficController_ReportRateLimit_Call struct {
 
 // ReportRateLimit is a helper method to define mock.On call
 //   - info models.RateLimitInfo
-func (_e *MockTrafficController_Expecter) ReportRateLimit(info interface{}) *MockTrafficController_ReportRateLimit_Call {
+func (_e *MockTrafficController_Expecter) ReportRateLimit(info any) *MockTrafficController_ReportRateLimit_Call {
 	return &MockTrafficController_ReportRateLimit_Call{Call: _e.mock.On("ReportRateLimit", info)}
 }
 
@@ -136,7 +136,7 @@ type MockTrafficController_Shutdown_Call struct {
 
 // Shutdown is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockTrafficController_Expecter) Shutdown(ctx interface{}) *MockTrafficController_Shutdown_Call {
+func (_e *MockTrafficController_Expecter) Shutdown(ctx any) *MockTrafficController_Shutdown_Call {
 	return &MockTrafficController_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
 }
 
@@ -200,7 +200,7 @@ type MockTrafficController_Submit_Call struct {
 //   - ctx context.Context
 //   - priority int
 //   - fn types.TaskFunc
-func (_e *MockTrafficController_Expecter) Submit(ctx interface{}, priority interface{}, fn interface{}) *MockTrafficController_Submit_Call {
+func (_e *MockTrafficController_Expecter) Submit(ctx any, priority any, fn any) *MockTrafficController_Submit_Call {
 	return &MockTrafficController_Submit_Call{Call: _e.mock.On("Submit", ctx, priority, fn)}
 }
 
@@ -251,7 +251,7 @@ type MockTrafficController_UpdateRateLimit_Call struct {
 // UpdateRateLimit is a helper method to define mock.On call
 //   - ctx context.Context
 //   - info models.RateLimitInfo
-func (_e *MockTrafficController_Expecter) UpdateRateLimit(ctx interface{}, info interface{}) *MockTrafficController_UpdateRateLimit_Call {
+func (_e *MockTrafficController_Expecter) UpdateRateLimit(ctx any, info any) *MockTrafficController_UpdateRateLimit_Call {
 	return &MockTrafficController_UpdateRateLimit_Call{Call: _e.mock.On("UpdateRateLimit", ctx, info)}
 }
 

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -28,7 +28,6 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 	for idx, n := range m.allNotifications {
 		if n.GitHubID == id {
 			m.allNotifications[idx].IsReadLocally = read
-			m.allNotifications[idx].IsHandledLocally = read
 			break
 		}
 	}
@@ -37,7 +36,7 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 
 	// 2. Persistent Local & Remote Update via Traffic Controller
 	return m.submitMutationTask("read:"+id, func(ctx context.Context) (mutationAppliedMsg, error) {
-		result, err := m.backend.MarkRead(ctx, id, read)
+		result, err := m.backend.SetRead(ctx, id, read)
 		if err != nil {
 			return mutationAppliedMsg{}, err
 		}
@@ -46,6 +45,35 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 			notifications: result.Notifications,
 			err:           result.Err,
 			toast:         result.Toast,
+		}, nil
+	})
+}
+
+// SetHandledByID changes only the local triage state and immediately reconciles
+// list/detail identity if the active filter removes the target.
+func (m *Model) SetHandledByID(id string, handled bool, previousIndex int) tea.Cmd {
+	for idx, n := range m.allNotifications {
+		if n.GitHubID == id {
+			m.allNotifications[idx].IsHandledLocally = handled
+			break
+		}
+	}
+
+	m.applyFilters()
+	m.reconcileHandledTarget(id, previousIndex, true)
+
+	return m.submitMutationTask("handled:"+id, func(ctx context.Context) (mutationAppliedMsg, error) {
+		result, err := m.backend.SetHandled(ctx, id, handled)
+		if err != nil {
+			return mutationAppliedMsg{}, err
+		}
+		return mutationAppliedMsg{
+			notifications: result.Notifications,
+			toast:         result.Toast,
+			err:           result.Err,
+			targetID:      id,
+			previousIndex: previousIndex,
+			reconcileItem: true,
 		}, nil
 	})
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -52,6 +52,7 @@ func (m *Model) MarkReadByID(id string, read bool) tea.Cmd {
 // SetHandledByID changes only the local triage state and immediately reconciles
 // list/detail identity if the active filter removes the target.
 func (m *Model) SetHandledByID(id string, handled bool, previousIndex int) tea.Cmd {
+	before := append([]triage.NotificationWithState(nil), m.allNotifications...)
 	for idx, n := range m.allNotifications {
 		if n.GitHubID == id {
 			m.allNotifications[idx].IsHandledLocally = handled
@@ -65,7 +66,18 @@ func (m *Model) SetHandledByID(id string, handled bool, previousIndex int) tea.C
 	return m.submitMutationTask("handled:"+id, func(ctx context.Context) (mutationAppliedMsg, error) {
 		result, err := m.backend.SetHandled(ctx, id, handled)
 		if err != nil {
-			return mutationAppliedMsg{}, err
+			notifications, reloadErr := m.backend.ListNotifications(ctx)
+			if reloadErr != nil {
+				notifications = before
+			}
+			return mutationAppliedMsg{
+				notifications: notifications,
+				toast:         "Failed to update handled state",
+				err:           err,
+				targetID:      id,
+				previousIndex: previousIndex,
+				reconcileItem: true,
+			}, nil
 		}
 		return mutationAppliedMsg{
 			notifications: result.Notifications,

--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -72,6 +72,14 @@ type ActionMarkRead struct {
 
 func (a ActionMarkRead) Type() string { return "mark_read" }
 
+type ActionSetHandled struct {
+	ID            string
+	Handled       bool
+	PreviousIndex int
+}
+
+func (a ActionSetHandled) Type() string { return "set_handled" }
+
 type ActionArchive struct {
 	ID string
 }

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -39,6 +39,8 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 		return i.model.syncNotificationsWithForce(a.Force, a.IsManual)
 	case ActionMarkRead:
 		return i.model.MarkReadByID(a.ID, a.Read)
+	case ActionSetHandled:
+		return i.model.SetHandledByID(a.ID, a.Handled, a.PreviousIndex)
 	case ActionSetPriority:
 		return i.model.setPriorityByID(a.ID, a.Priority)
 	case ActionViewWeb:

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -35,6 +35,7 @@ type KeyMap struct {
 // NewKeyMap returns keybindings initialized from configuration.
 func NewKeyMap(cfg *config.Config) KeyMap {
 	k := cfg.Keys
+	handledKeys := availableHandledKeys(k)
 	return KeyMap{
 		Sync: key.NewBinding(
 			key.WithKeys(k.Sync...),
@@ -72,7 +73,7 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 			key.WithKeys(k.ToggleRead...),
 			key.WithHelp(k.ToggleRead[0], "mark read/unread"),
 		),
-		ToggleHandled: optionalBinding(k.ToggleHandled, "mark handled/unhandled"),
+		ToggleHandled: optionalBinding(handledKeys, "mark handled/unhandled"),
 		NextTab: key.NewBinding(
 			key.WithKeys(k.NextTab...),
 			key.WithHelp(k.NextTab[0], "next tab"),
@@ -126,6 +127,30 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 			key.WithHelp(k.Help[0], "help"),
 		),
 	}
+}
+
+func availableHandledKeys(keys config.KeyMapConfig) []string {
+	used := make(map[string]struct{})
+	existing := [][]string{
+		keys.Sync, keys.PriorityUp, keys.PriorityDown, keys.PriorityNone,
+		keys.Inbox, keys.Unread, keys.Triaged, keys.All, keys.CopyURL,
+		keys.ToggleRead, keys.NextTab, keys.PrevTab, keys.CheckoutPR,
+		keys.StartReviewWorkspace, keys.ViewContextual, keys.OpenBrowser,
+		keys.ToggleDetail, keys.Back, keys.Quit, keys.FilterPR,
+		keys.FilterIssue, keys.FilterDiscussion, keys.Help,
+	}
+	for _, bindings := range existing {
+		for _, binding := range bindings {
+			used[binding] = struct{}{}
+		}
+	}
+	filtered := make([]string, 0, len(keys.ToggleHandled))
+	for _, binding := range keys.ToggleHandled {
+		if _, collision := used[binding]; !collision {
+			filtered = append(filtered, binding)
+		}
+	}
+	return filtered
 }
 
 func optionalBinding(keys []string, description string) key.Binding {

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -16,6 +16,7 @@ type KeyMap struct {
 	Tab3                 key.Binding
 	CopyURL              key.Binding
 	ToggleRead           key.Binding
+	ToggleHandled        key.Binding
 	NextTab              key.Binding
 	PrevTab              key.Binding
 	CheckoutPR           key.Binding
@@ -71,6 +72,7 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 			key.WithKeys(k.ToggleRead...),
 			key.WithHelp(k.ToggleRead[0], "mark read/unread"),
 		),
+		ToggleHandled: optionalBinding(k.ToggleHandled, "mark handled/unhandled"),
 		NextTab: key.NewBinding(
 			key.WithKeys(k.NextTab...),
 			key.WithHelp(k.NextTab[0], "next tab"),
@@ -126,12 +128,23 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 	}
 }
 
+func optionalBinding(keys []string, description string) key.Binding {
+	if len(keys) == 0 {
+		return key.NewBinding(key.WithDisabled())
+	}
+	return key.NewBinding(
+		key.WithKeys(keys...),
+		key.WithHelp(keys[0], description),
+	)
+}
+
 // ShortHelp returns the keybindings to be displayed in the mini help view.
 func (k KeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help,
 		k.Sync,
 		k.ToggleRead,
+		k.ToggleHandled,
 		k.ToggleDetail,
 		k.Quit,
 	}
@@ -141,7 +154,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Sync, k.CopyURL, k.OpenBrowser, k.ViewContextual},
-		{k.ToggleDetail, k.Back, k.FilterPR, k.FilterIssue, k.FilterDiscussion},
+		{k.ToggleRead, k.ToggleHandled, k.ToggleDetail, k.Back, k.FilterPR, k.FilterIssue, k.FilterDiscussion},
 		{k.PriorityUp, k.PriorityDown, k.PriorityNone},
 		{k.Tab1, k.Tab2, k.Tab3},
 		{k.NextTab, k.PrevTab, k.CheckoutPR, k.StartReviewWorkspace, k.Help, k.Quit},

--- a/internal/tui/keymap_test.go
+++ b/internal/tui/keymap_test.go
@@ -21,4 +21,13 @@ func TestKeyMap_HandledBindingHelpAndDisablement(t *testing.T) {
 	disabled := NewKeyMap(cfg)
 	assert.False(t, disabled.ToggleHandled.Enabled())
 	assert.Empty(t, disabled.ToggleHandled.Keys())
+
+	cfg.Keys.ToggleHandled = []string{"m", "h"}
+	partialCollision := NewKeyMap(cfg)
+	assert.Equal(t, []string{"h"}, partialCollision.ToggleHandled.Keys())
+	assert.Equal(t, []string{"m", "h"}, cfg.Keys.ToggleHandled, "runtime collision filtering must not mutate persisted intent")
+
+	cfg.Keys.ToggleHandled = []string{"m"}
+	fullyCollided := NewKeyMap(cfg)
+	assert.False(t, fullyCollided.ToggleHandled.Enabled())
 }

--- a/internal/tui/keymap_test.go
+++ b/internal/tui/keymap_test.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/hirakiuc/gh-orbit/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyMap_HandledBindingHelpAndDisablement(t *testing.T) {
+	cfg := config.DefaultConfig()
+	keys := NewKeyMap(cfg)
+	assert.True(t, keys.ToggleHandled.Enabled())
+	assert.Equal(t, "x", keys.ToggleHandled.Help().Key)
+	assert.Contains(t, keys.ShortHelp(), keys.ToggleRead)
+	assert.Contains(t, keys.ShortHelp(), keys.ToggleHandled)
+	assert.Contains(t, keys.FullHelp()[1], keys.ToggleRead)
+	assert.Contains(t, keys.FullHelp()[1], keys.ToggleHandled)
+
+	cfg.Keys.ToggleHandled = nil
+	disabled := NewKeyMap(cfg)
+	assert.False(t, disabled.ToggleHandled.Enabled())
+	assert.Empty(t, disabled.ToggleHandled.Keys())
+}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -279,9 +279,9 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
-	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testRepo(m).EXPECT().SetReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -294,7 +294,7 @@ func TestModel_MarkReadByID_ConnectedModeDoesNotRequireClient(t *testing.T) {
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
-	assert.True(t, m.allNotifications[0].IsHandledLocally)
+	assert.False(t, m.allNotifications[0].IsHandledLocally)
 	assert.Nil(t, actions)
 	assert.NoError(t, m.err)
 }
@@ -308,10 +308,10 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
-	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testRepo(m).EXPECT().SetReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(nil).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -324,7 +324,7 @@ func TestModel_MarkReadByID_StandaloneModeForwardsToGitHub(t *testing.T) {
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
-	assert.True(t, m.allNotifications[0].IsHandledLocally)
+	assert.False(t, m.allNotifications[0].IsHandledLocally)
 	assert.Nil(t, actions)
 	assert.NoError(t, m.err)
 }
@@ -340,7 +340,7 @@ func TestModel_MarkReadByID_LocalFailureReconcilesToPersistedState(t *testing.T)
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
-	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
+	testRepo(m).EXPECT().SetReadLocally(mock.Anything, "1", true).Return(localErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
@@ -372,7 +372,7 @@ func TestModel_MarkReadByID_LocalFailureReloadFailureRollsBackOptimisticState(t 
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
-	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(localErr).Once()
+	testRepo(m).EXPECT().SetReadLocally(mock.Anything, "1", true).Return(localErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(nil, reloadErr).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -399,10 +399,10 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
 		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: false}},
 	}, nil).Once()
-	testRepo(m).EXPECT().MarkReadLocally(mock.Anything, "1", true).Return(nil).Once()
+	testRepo(m).EXPECT().SetReadLocally(mock.Anything, "1", true).Return(nil).Once()
 	testClient(m).EXPECT().MarkThreadAsRead(mock.Anything, "1").Return(remoteErr).Once()
 	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return([]triage.NotificationWithState{
-		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true, IsHandledLocally: true}},
+		{Notification: triage.Notification{GitHubID: "1"}, State: triage.State{IsReadLocally: true}},
 	}, nil).Once()
 
 	cmd := m.MarkReadByID("1", true)
@@ -415,7 +415,7 @@ func TestModel_MarkReadByID_RemoteFailureKeepsCommittedLocalState(t *testing.T) 
 
 	actions := m.Transition(reconciled, 0)
 	assert.True(t, m.allNotifications[0].IsReadLocally)
-	assert.True(t, m.allNotifications[0].IsHandledLocally)
+	assert.False(t, m.allNotifications[0].IsHandledLocally)
 	assert.ErrorIs(t, m.err, remoteErr)
 	assert.Contains(t, actions, ActionShowToast{Message: "Marked read locally; GitHub sync failed"})
 }
@@ -655,6 +655,63 @@ func TestModel_Transition_Priority(t *testing.T) {
 	msg = keyPress("0") // Matches PriorityNone
 	actions = m.Transition(msg, 0)
 	assert.Contains(t, actions, ActionSetPriority{ID: "1", Priority: 0})
+}
+
+func TestModel_Transition_ToggleHandledFromListAndDetail(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state AppState
+	}{{"list", StateList}, {"detail", StateDetail}} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel(t)
+			n := triage.NotificationWithState{
+				Notification: triage.Notification{GitHubID: "1", UpdatedAt: time.Now()},
+				State:        triage.State{IsReadLocally: true, IsHandledLocally: false},
+			}
+			m.allNotifications = []triage.NotificationWithState{n}
+			m.applyFilters()
+			m.state = tc.state
+
+			actions := m.Transition(keyPress("x"), 0)
+			assert.Contains(t, actions, ActionSetHandled{ID: "1", Handled: true, PreviousIndex: 0})
+			assert.Contains(t, actions, ActionShowToast{Message: "Marked as handled"})
+		})
+	}
+}
+
+func TestModel_SetHandledByID_OptimisticRemovalAndRollbackPreserveIdentity(t *testing.T) {
+	m := newTestModel(t)
+	m.traffic = nil
+	m.config.Notifications.MaxVisibleAgeDays = 0
+	before := []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "first", UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "target", UpdatedAt: time.Now()}, State: triage.State{IsReadLocally: true}},
+		{Notification: triage.Notification{GitHubID: "last", UpdatedAt: time.Now()}},
+	}
+	persisted := append([]triage.NotificationWithState(nil), before...)
+	m.allNotifications = before
+	m.applyFilters()
+	m.listView.list.Select(1)
+	m.state = StateDetail
+
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(persisted, nil).Once()
+	testRepo(m).EXPECT().SetHandledLocally(mock.Anything, "target", true).Return(assert.AnError).Once()
+	testRepo(m).EXPECT().ListNotifications(mock.Anything).Return(persisted, nil).Once()
+
+	cmd := m.SetHandledByID("target", true, 1)
+	assert.Equal(t, StateList, m.state)
+	selected, ok := m.selectedNotification()
+	require.True(t, ok)
+	assert.Equal(t, "last", selected.GitHubID, "optimistic filtering selects the same-index neighbor")
+	assert.True(t, m.allNotifications[1].IsReadLocally, "handled mutation must preserve read state")
+
+	msg, ok := executeCmd(cmd).(mutationAppliedMsg)
+	require.True(t, ok)
+	m.Transition(msg, 1)
+	selected, ok = m.selectedNotification()
+	require.True(t, ok)
+	assert.Equal(t, "target", selected.GitHubID, "rollback reselects the restored target")
+	assert.Equal(t, StateList, m.state, "rollback must not reopen detail")
 }
 
 func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +17,20 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type hardHandledErrorBackend struct {
+	types.TUIBackend
+	notifications []triage.NotificationWithState
+	reloadErr     error
+}
+
+func (b hardHandledErrorBackend) SetHandled(context.Context, string, bool) (types.HandledUpdateResult, error) {
+	return types.HandledUpdateResult{}, errors.New("connected transport failed")
+}
+
+func (b hardHandledErrorBackend) ListNotifications(context.Context) ([]triage.NotificationWithState, error) {
+	return append([]triage.NotificationWithState(nil), b.notifications...), b.reloadErr
+}
 
 // keyPress is a helper to create a KeyPressMsg for tests.
 func keyPress(s string) tea.KeyPressMsg {
@@ -712,6 +727,48 @@ func TestModel_SetHandledByID_OptimisticRemovalAndRollbackPreserveIdentity(t *te
 	require.True(t, ok)
 	assert.Equal(t, "target", selected.GitHubID, "rollback reselects the restored target")
 	assert.Equal(t, StateList, m.state, "rollback must not reopen detail")
+}
+
+func TestModel_SetHandledByID_HardTransportErrorRollsBackOptimisticRemoval(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		state       AppState
+		targetIndex int
+		reloadErr   error
+	}{
+		{name: "detail next-row selection with authoritative reload", state: StateDetail, targetIndex: 1},
+		{name: "list last-row selection with snapshot fallback", state: StateList, targetIndex: 2, reloadErr: errors.New("reload failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel(t)
+			m.traffic = nil
+			m.config.Notifications.MaxVisibleAgeDays = 0
+			persisted := []triage.NotificationWithState{
+				{Notification: triage.Notification{GitHubID: "first", UpdatedAt: time.Now()}},
+				{Notification: triage.Notification{GitHubID: "middle", UpdatedAt: time.Now()}, State: triage.State{IsReadLocally: true}},
+				{Notification: triage.Notification{GitHubID: "last", UpdatedAt: time.Now()}, State: triage.State{IsReadLocally: true}},
+			}
+			m.backend = hardHandledErrorBackend{notifications: persisted, reloadErr: tc.reloadErr}
+			m.allNotifications = append([]triage.NotificationWithState(nil), persisted...)
+			m.applyFilters()
+			m.listView.list.Select(tc.targetIndex)
+			m.state = tc.state
+			targetID := persisted[tc.targetIndex].GitHubID
+
+			msg, ok := executeCmd(m.SetHandledByID(targetID, true, tc.targetIndex)).(mutationAppliedMsg)
+			require.True(t, ok)
+			m.Transition(msg, tc.targetIndex)
+
+			selected, ok := m.selectedNotification()
+			require.True(t, ok)
+			assert.Equal(t, targetID, selected.GitHubID)
+			assert.True(t, selected.IsReadLocally, "handled rollback must preserve read state")
+			assert.False(t, selected.IsHandledLocally)
+			assert.Equal(t, StateList, m.state, "hard-error rollback must not reopen detail")
+			assert.Contains(t, msg.toast, "Failed to update handled state")
+			assert.Error(t, msg.err)
+		})
+	}
 }
 
 func TestModel_Transition_DetailRefreshStartsFetchingViaAction(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -424,6 +424,9 @@ type mutationAppliedMsg struct {
 	notifications []triage.NotificationWithState
 	toast         string
 	err           error
+	targetID      string
+	previousIndex int
+	reconcileItem bool
 }
 
 type reviewWorkspaceStartedMsg struct {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -156,6 +156,10 @@ func (m *Model) transitionDetail(msg tea.Msg) []Action {
 					Force:       true,
 				})
 			}
+		case key.Matches(msg, m.keys.ToggleRead):
+			return m.handleToggleReadKey()
+		case key.Matches(msg, m.keys.ToggleHandled):
+			return m.handleToggleHandledKey()
 		case key.Matches(msg, m.keys.Help):
 			m.showHelp = !m.showHelp
 			m.help.ShowAll = m.showHelp
@@ -423,6 +427,46 @@ func (m *Model) restoreSelection(selectedID string) {
 	}
 }
 
+func (m *Model) selectNotificationByID(id string) bool {
+	for index, li := range m.listView.list.Items() {
+		if i, ok := li.(item); ok && i.notification.GitHubID == id {
+			m.listView.list.Select(index)
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Model) selectClosestIndex(previousIndex int) {
+	items := m.listView.list.Items()
+	if len(items) == 0 {
+		return
+	}
+	if previousIndex < 0 {
+		previousIndex = 0
+	}
+	if previousIndex >= len(items) {
+		previousIndex = len(items) - 1
+	}
+	m.listView.list.Select(previousIndex)
+}
+
+func (m *Model) reconcileHandledTarget(id string, previousIndex int, optimistic bool) {
+	if m.selectNotificationByID(id) {
+		if m.state == StateDetail {
+			m.refreshDetailView()
+		}
+		return
+	}
+
+	if m.state == StateDetail {
+		m.state = StateList
+	}
+	if optimistic || id != "" {
+		m.selectClosestIndex(previousIndex)
+	}
+}
+
 func (m *Model) isNotificationWithinVisibleAge(n triage.NotificationWithState, now time.Time) bool {
 	maxVisibleAgeDays := m.maxVisibleNotificationAgeDays()
 	if maxVisibleAgeDays == 0 || n.UpdatedAt.IsZero() {
@@ -551,6 +595,9 @@ func (m *Model) filterSelectedDetailRefreshCandidate(notifications []triage.Noti
 func (m *Model) handleMutationApplied(msg mutationAppliedMsg) []Action {
 	m.allNotifications = msg.notifications
 	m.applyFilters()
+	if msg.reconcileItem {
+		m.reconcileHandledTarget(msg.targetID, msg.previousIndex, false)
+	}
 	m.err = msg.err
 	if msg.toast == "" {
 		return nil
@@ -731,6 +778,8 @@ func (m *Model) handleNavigationKeys(msg tea.KeyMsg) []Action {
 		return m.handleToggleDetailKey()
 	case key.Matches(msg, m.keys.ToggleRead):
 		return m.handleToggleReadKey()
+	case key.Matches(msg, m.keys.ToggleHandled):
+		return m.handleToggleHandledKey()
 	case key.Matches(msg, m.keys.Help):
 		m.showHelp = !m.showHelp
 		m.help.ShowAll = m.showHelp
@@ -834,6 +883,24 @@ func (m *Model) handleToggleReadKey() []Action {
 
 	return []Action{
 		ActionMarkRead{ID: n.GitHubID, Read: newState},
+		ActionShowToast{Message: toast},
+	}
+}
+
+func (m *Model) handleToggleHandledKey() []Action {
+	n, ok := m.selectedNotification()
+	if !ok {
+		return nil
+	}
+
+	newState := !n.IsHandledLocally
+	toast := "Marked as unhandled"
+	if newState {
+		toast = "Marked as handled"
+	}
+
+	return []Action{
+		ActionSetHandled{ID: n.GitHubID, Handled: newState, PreviousIndex: m.listView.list.Index()},
 		ActionShowToast{Message: toast},
 	}
 }

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -18,6 +18,7 @@ var (
 	ErrNetworkTimeout                = errors.New("github: network timeout")
 	ErrReviewWorkspaceUnsupported    = errors.New("review workspace start is unavailable in this session")
 	ErrInvalidReviewWorkspaceRequest = errors.New("review workspace request is invalid")
+	ErrNotificationNotFound          = errors.New("notification not found")
 )
 
 // ConnectedSyncTimeout bounds connected/native sync requests so stalled MCP calls
@@ -129,17 +130,43 @@ type CommandExecutor interface {
 type ErrMsg struct{ Err error }
 
 // MarkReadStatus describes the outcome of a backend-owned mark-read mutation.
-type MarkReadStatus uint8
+type ReadUpdateStatus uint8
 
 const (
-	MarkReadSuccess MarkReadStatus = iota
-	MarkReadLocalFailure
-	MarkReadRemoteFailure
+	ReadUpdateSuccess ReadUpdateStatus = iota
+	ReadUpdateLocalFailure
+	ReadUpdateRemoteFailure
 )
 
-// MarkReadResult captures the backend-visible outcome of a mark-read mutation.
-type MarkReadResult struct {
-	Status        MarkReadStatus
+// ReadUpdateResult captures the backend-visible outcome of a read-state mutation.
+type ReadUpdateResult struct {
+	Status        ReadUpdateStatus
+	Notifications []triage.NotificationWithState
+	Toast         string
+	Err           error
+}
+
+// Deprecated compatibility names for the legacy mark_read transport contract.
+type (
+	MarkReadStatus = ReadUpdateStatus
+	MarkReadResult = ReadUpdateResult
+)
+
+const (
+	MarkReadSuccess       = ReadUpdateSuccess
+	MarkReadLocalFailure  = ReadUpdateLocalFailure
+	MarkReadRemoteFailure = ReadUpdateRemoteFailure
+)
+
+type HandledUpdateStatus uint8
+
+const (
+	HandledUpdateSuccess HandledUpdateStatus = iota
+	HandledUpdateFailure
+)
+
+type HandledUpdateResult struct {
+	Status        HandledUpdateStatus
 	Notifications []triage.NotificationWithState
 	Toast         string
 	Err           error
@@ -165,7 +192,8 @@ type PriorityUpdateResult struct {
 type TUIBackend interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
 	Sync(ctx context.Context, force bool) (models.RateLimitInfo, error)
-	MarkRead(ctx context.Context, id string, read bool) (MarkReadResult, error)
+	SetRead(ctx context.Context, id string, read bool) (ReadUpdateResult, error)
+	SetHandled(ctx context.Context, id string, handled bool) (HandledUpdateResult, error)
 	SetPriority(ctx context.Context, id string, priority int) (PriorityUpdateResult, error)
 	StartReviewWorkspace(ctx context.Context, request ReviewWorkspaceStartRequest) error
 	FetchDetail(ctx context.Context, u string, subjectType string, force bool) (models.EnrichmentResult, error)
@@ -182,6 +210,9 @@ type TUIBackend interface {
 // standalone and connected mode.
 type NotificationStore interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
+	SetReadLocally(ctx context.Context, id string, isRead bool) error
+	SetHandledLocally(ctx context.Context, id string, isHandled bool) error
+	// MarkReadLocally preserves the deprecated coupled read/handled mutation for legacy MCP clients.
 	MarkReadLocally(ctx context.Context, id string, isRead bool) error
 	SetPriority(ctx context.Context, id string, priority int) error
 	EnrichNotification(ctx context.Context, id, nodeID, body, author, htmlURL, resourceState, resourceSubState string) error


### PR DESCRIPTION
## Summary

- add an independent local handled/unhandled action on `x` in list and detail views
- split read and handled persistence/MCP contracts while preserving legacy `mark_read` compatibility
- capability-gate connected clients, preserve downgrade-safe configuration, and reconcile optimistic filtering failures

## Validation

- `make go/generate`
- `make go/test`
- `make check`
- strategy implementation review: signed off after one action-required revision

Closes #473
