### PR TITLE
feat(tui): support multiple selection and batch notification operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ gh orbit
 | `r` | Sync notifications (Manual) |
 | `m` | Toggle Read/Unread state |
 | `x` | Toggle local Handled/Unhandled state |
+| `S` | Enter or leave multiple-selection mode |
+| `s` | Add or remove the current notification from the selection |
+| `R` / `U` | Mark selected notifications Read / Unread |
+| `H` / `N` | Mark selected notifications Handled / Unhandled locally |
 | `enter` | View notification details (Description/Body) |
 | `o` | Open in default browser |
 | `c` | Checkout PR locally (`gh pr checkout`) |
@@ -65,6 +69,32 @@ the inherited `x` default, and `[]` disables the action. If you explicitly add
 `toggle_handled` to your config and later downgrade to a version from before
 Issue #473, remove that one line first because older versions strictly reject
 unknown configuration keys.
+
+### Multiple selection and batch operations
+
+Batch operations use a direct, Vim-style workflow with no confirmation dialog:
+
+1. Press `S` to enter multiple-selection mode.
+2. Navigate normally and press `s` to add or remove the current notification.
+3. Press `R`, `U`, `H`, or `N` to apply that state to every selected item.
+
+For example, `S`, `s`, `j`, `j`, `s`, `R` selects the current notification and
+another notification two rows below it, then marks both as read. The `▌`
+indicator remains the list cursor, while `✓` marks every notification included
+in the batch. The footer reports the selected count and changes from `SELECT`
+to `APPLYING`, `REFRESH`, or `UNCERTAIN` as the operation progresses.
+
+`R` updates local read state and sends bounded per-notification read requests to
+GitHub. `U` is local-only because GitHub does not provide an arbitrary
+mark-thread-unread operation. `H` and `N` change only gh-orbit's local handled
+state. If some remote read requests fail, the unsuccessful notifications remain
+selected for retry. A single batch accepts at most 100 distinct notifications.
+
+Press `esc` or `S` again to cancel and clear the selection. Changing tabs or
+filters, or entering the detail view, also clears it. All batch bindings are
+configurable through `keys.selection_mode`, `keys.select_notification`,
+`keys.batch_read`, `keys.batch_unread`, `keys.batch_handled`, and
+`keys.batch_unhandled` in the gh-orbit configuration file.
 
 ---
 

--- a/cmd/gh-orbit/main.go
+++ b/cmd/gh-orbit/main.go
@@ -432,14 +432,14 @@ func requireIndependentMutationTools(ctx context.Context, capabilityClient toolC
 	if result == nil {
 		return errors.New("listing engine tools returned an empty response")
 	}
-	required := map[string]bool{"set_read": false, "set_handled": false}
+	required := map[string]bool{"set_read": false, "set_handled": false, "batch_set_state": false}
 	for _, tool := range result.Tools {
 		if _, ok := required[tool.Name]; ok {
 			required[tool.Name] = true
 		}
 	}
 	var missing []string
-	for _, name := range []string{"set_read", "set_handled"} {
+	for _, name := range []string{"set_read", "set_handled", "batch_set_state"} {
 		if !required[name] {
 			missing = append(missing, name)
 		}
@@ -487,9 +487,6 @@ func launchTUIMCP(ctx context.Context, env *environment, cfg *config.Config, ada
 }
 
 func launchTUIStandalone(ctx context.Context, env *environment, eng *engine.CoreEngine, userID string) error {
-	// Step 6.15: Connect Client to TrafficController for intelligent rate limit propagation
-	eng.Client.SetRateLimitReporter(eng.Traffic.ReportRateLimit)
-
 	lifecycle := api.NewAppLifecycle(ctx)
 	lifecycleOwned := true
 	defer func() {

--- a/cmd/gh-orbit/main_test.go
+++ b/cmd/gh-orbit/main_test.go
@@ -29,7 +29,7 @@ func TestRequireIndependentMutationTools(t *testing.T) {
 		return result
 	}
 
-	require.NoError(t, requireIndependentMutationTools(context.Background(), capabilityClientStub{result: tools("set_read", "set_handled")}))
+	require.NoError(t, requireIndependentMutationTools(context.Background(), capabilityClientStub{result: tools("set_read", "set_handled", "batch_set_state")}))
 
 	for _, tc := range []struct {
 		name   string
@@ -38,8 +38,9 @@ func TestRequireIndependentMutationTools(t *testing.T) {
 	}{
 		{name: "list error", client: capabilityClientStub{err: errors.New("timeout")}, want: "listing engine tools"},
 		{name: "nil response", client: capabilityClientStub{}, want: "empty response"},
-		{name: "missing read", client: capabilityClientStub{result: tools("set_handled")}, want: "set_read"},
-		{name: "missing handled", client: capabilityClientStub{result: tools("set_read")}, want: "set_handled"},
+		{name: "missing read", client: capabilityClientStub{result: tools("set_handled", "batch_set_state")}, want: "set_read"},
+		{name: "missing handled", client: capabilityClientStub{result: tools("set_read", "batch_set_state")}, want: "set_handled"},
+		{name: "missing batch", client: capabilityClientStub{result: tools("set_read", "set_handled")}, want: "batch_set_state"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := requireIndependentMutationTools(context.Background(), tc.client)
@@ -64,8 +65,9 @@ func TestPrepareConnectedMutationClient_FailuresCloseWithoutConstructing(t *test
 	}{
 		{name: "rpc error", client: capabilityClientStub{err: errors.New("timeout")}},
 		{name: "nil malformed response", client: capabilityClientStub{}},
-		{name: "missing read", client: capabilityClientStub{result: tools("set_handled")}},
-		{name: "missing handled", client: capabilityClientStub{result: tools("set_read")}},
+		{name: "missing read", client: capabilityClientStub{result: tools("set_handled", "batch_set_state")}},
+		{name: "missing handled", client: capabilityClientStub{result: tools("set_read", "batch_set_state")}},
+		{name: "missing batch", client: capabilityClientStub{result: tools("set_read", "set_handled")}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			closed, adapterConstructed, standaloneConstructed := 0, 0, 0

--- a/internal/api/notification_batch_executor.go
+++ b/internal/api/notification_batch_executor.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hirakiuc/gh-orbit/internal/types"
+)
+
+const notificationBatchRemoteLimit = 3
+
+type notificationBatchPlan struct {
+	Request types.NotificationBatchRequest
+	Prepare func(context.Context) error
+	Remote  func(context.Context, string) error
+}
+
+type notificationBatchExecution struct {
+	Committed bool
+	Outcomes  []types.NotificationBatchItemResult
+	Err       error
+}
+
+// notificationBatchExecutor is deliberately consumer-owned and narrow. The
+// controller implementation is the sole production implementation.
+type notificationBatchExecutor interface {
+	RunNotificationBatch(context.Context, notificationBatchPlan) (notificationBatchExecution, error)
+}
+
+func (c *APITrafficController) RunNotificationBatch(ctx context.Context, plan notificationBatchPlan) (notificationBatchExecution, error) {
+	if plan.Prepare == nil {
+		return notificationBatchExecution{}, errors.New("notification batch prepare function is required")
+	}
+	taskCtx, cleanup := c.composeTaskContext(ctx)
+	task := &apiTask{
+		id:       atomicAddUint64(&c.taskCounter),
+		priority: PriorityUser,
+		resp:     make(chan any, 1),
+		ctx:      taskCtx,
+		cleanup:  cleanup,
+		batch:    &plan,
+	}
+
+	c.stateMu.RLock()
+	select {
+	case <-c.done:
+		c.stateMu.RUnlock()
+		cleanup()
+		return notificationBatchExecution{}, errors.New("traffic controller shutdown")
+	default:
+	}
+	select {
+	case <-taskCtx.Done():
+		c.stateMu.RUnlock()
+		cleanup()
+		return notificationBatchExecution{}, taskCtx.Err()
+	case c.high <- task:
+		c.stateMu.RUnlock()
+	default:
+		c.stateMu.RUnlock()
+		cleanup()
+		return notificationBatchExecution{}, ErrTrafficQueueFull
+	}
+
+	result := <-task.resp
+	if result == nil {
+		return notificationBatchExecution{}, taskCtx.Err()
+	}
+	execution, ok := result.(notificationBatchExecution)
+	if !ok {
+		return notificationBatchExecution{}, errors.New("invalid notification batch execution result")
+	}
+	return execution, nil
+}
+
+func atomicAddUint64(value *uint64) uint64 {
+	return atomic.AddUint64(value, 1)
+}
+
+func (c *APITrafficController) executeNotificationBatch(ctx context.Context, plan notificationBatchPlan) notificationBatchExecution {
+	if err := plan.Prepare(ctx); err != nil {
+		return notificationBatchExecution{Err: err}
+	}
+	execution := notificationBatchExecution{Committed: true}
+	if !plan.Request.Operation.RequiresRemoteRead() || plan.Remote == nil {
+		for _, id := range plan.Request.IDs {
+			execution.Outcomes = append(execution.Outcomes, types.NotificationBatchItemResult{ID: id, Status: types.NotificationRemoteNotRequired})
+		}
+		return execution
+	}
+
+	type childResult struct {
+		item types.NotificationBatchItemResult
+	}
+	results := make(chan childResult, len(plan.Request.IDs))
+	var workers sync.WaitGroup
+	next := 0
+	active := 0
+	for next < len(plan.Request.IDs) || active > 0 {
+		for next < len(plan.Request.IDs) && active < notificationBatchRemoteLimit && ctx.Err() == nil {
+			if !c.acquireCapacity(ctx) {
+				break
+			}
+			id := plan.Request.IDs[next]
+			next++
+			active++
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				defer c.releaseCapacity()
+				item := types.NotificationBatchItemResult{ID: id, Status: types.NotificationRemoteSucceeded}
+				if err := plan.Remote(ctx, id); err != nil {
+					item.Err = err
+					item.ErrorCode = "remote_failed"
+					item.Status = types.NotificationRemoteFailed
+					if ctx.Err() != nil {
+						item.ErrorCode = "canceled"
+						item.Status = types.NotificationRemoteCanceled
+					}
+				}
+				results <- childResult{item: item}
+			}()
+		}
+		if active > 0 {
+			result := <-results
+			execution.Outcomes = append(execution.Outcomes, result.item)
+			active--
+			continue
+		}
+		break
+	}
+	for ; next < len(plan.Request.IDs); next++ {
+		execution.Outcomes = append(execution.Outcomes, types.NotificationBatchItemResult{ID: plan.Request.IDs[next], Status: types.NotificationRemoteNotAttempted})
+	}
+	workers.Wait()
+	sort.Slice(execution.Outcomes, func(i, j int) bool { return execution.Outcomes[i].ID < execution.Outcomes[j].ID })
+	return execution
+}

--- a/internal/api/traffic.go
+++ b/internal/api/traffic.go
@@ -29,6 +29,7 @@ type apiTask struct {
 	resp     chan any
 	ctx      context.Context
 	cleanup  func()
+	batch    *notificationBatchPlan
 }
 
 type taskPolicyDecision int
@@ -62,6 +63,7 @@ type APITrafficController struct {
 	// Workers
 	workerLimit        int32
 	activeWorkersCount int32
+	userTaskActive     int32
 	done               chan struct{}
 	workerWG           sync.WaitGroup
 
@@ -232,8 +234,18 @@ func (c *APITrafficController) supervisor() {
 		case <-c.done:
 			return
 		default:
-			if atomic.LoadInt32(&c.activeWorkersCount) >= atomic.LoadInt32(&c.workerLimit) {
-				// At worker limit, wait for a worker to finish.
+			if atomic.LoadInt32(&c.userTaskActive) == 0 {
+				if t := c.dequeueUserTask(); t != nil {
+					atomic.StoreInt32(&c.userTaskActive, 1)
+					c.spawnUserTask(t)
+					continue
+				}
+			}
+
+			// User work has priority and owns serialization before capacity. Do
+			// not let later work consume a permit that the active user task or
+			// notification batch children need.
+			if atomic.LoadInt32(&c.userTaskActive) != 0 || !c.tryAcquireCapacity() {
 				select {
 				case <-c.done:
 					return
@@ -242,10 +254,11 @@ func (c *APITrafficController) supervisor() {
 				continue
 			}
 
-			if t := c.dequeueTask(); t != nil {
-				c.spawnTask(t)
+			if t := c.dequeueBackgroundTask(); t != nil {
+				c.spawnReservedTask(t)
 				continue
 			}
+			c.releaseCapacity()
 
 			select {
 			case <-c.done:
@@ -256,13 +269,16 @@ func (c *APITrafficController) supervisor() {
 	}
 }
 
-func (c *APITrafficController) dequeueTask() *apiTask {
+func (c *APITrafficController) dequeueUserTask() *apiTask {
 	select {
 	case t := <-c.high:
 		return t
 	default:
 	}
+	return nil
+}
 
+func (c *APITrafficController) dequeueBackgroundTask() *apiTask {
 	select {
 	case t := <-c.med:
 		return t
@@ -278,17 +294,25 @@ func (c *APITrafficController) dequeueTask() *apiTask {
 	return nil
 }
 
-func (c *APITrafficController) spawnTask(t *apiTask) {
-	atomic.AddInt32(&c.activeWorkersCount, 1)
+func (c *APITrafficController) spawnReservedTask(t *apiTask) {
 	c.workerWG.Add(1)
 	go func() {
 		defer c.workerWG.Done()
-		c.runTask(t)
+		defer c.releaseCapacity()
+		c.runBackgroundTask(t)
 	}()
 }
 
-func (c *APITrafficController) runTask(t *apiTask) {
-	defer atomic.AddInt32(&c.activeWorkersCount, -1)
+func (c *APITrafficController) spawnUserTask(t *apiTask) {
+	c.workerWG.Add(1)
+	go func() {
+		defer c.workerWG.Done()
+		defer atomic.StoreInt32(&c.userTaskActive, 0)
+		c.runUserTask(t)
+	}()
+}
+
+func (c *APITrafficController) runBackgroundTask(t *apiTask) {
 	defer t.cleanup()
 
 	switch c.evaluateTaskPolicy(t) {
@@ -298,6 +322,31 @@ func (c *APITrafficController) runTask(t *apiTask) {
 		t.resp <- nil
 		return
 	}
+}
+
+func (c *APITrafficController) runUserTask(t *apiTask) {
+	defer t.cleanup()
+
+	if c.evaluateTaskPolicy(t) != taskPolicyProceed {
+		t.resp <- nil
+		return
+	}
+
+	// User serialization is always acquired before global API capacity. Batch
+	// children run while this lock is held but acquire capacity internally.
+	c.userMu.Lock()
+	defer c.userMu.Unlock()
+
+	if t.batch != nil {
+		t.resp <- c.executeNotificationBatch(t.ctx, *t.batch)
+		return
+	}
+	if !c.acquireCapacity(t.ctx) {
+		t.resp <- nil
+		return
+	}
+	defer c.releaseCapacity()
+	t.resp <- t.fn(t.ctx)
 }
 
 func (c *APITrafficController) taskCanceledBeforeExecution(t *apiTask) bool {
@@ -347,12 +396,40 @@ func (c *APITrafficController) requiresSerializedUserExecution(t *apiTask) bool 
 }
 
 func (c *APITrafficController) executeTask(t *apiTask) {
-	if c.requiresSerializedUserExecution(t) {
-		c.userMu.Lock()
-		defer c.userMu.Unlock()
-	}
-
 	t.resp <- t.fn(t.ctx)
+}
+
+func (c *APITrafficController) tryAcquireCapacity() bool {
+	for {
+		active := atomic.LoadInt32(&c.activeWorkersCount)
+		if active >= atomic.LoadInt32(&c.workerLimit) {
+			return false
+		}
+		if atomic.CompareAndSwapInt32(&c.activeWorkersCount, active, active+1) {
+			return true
+		}
+	}
+}
+
+func (c *APITrafficController) acquireCapacity(ctx context.Context) bool {
+	ticker := time.NewTicker(2 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if c.tryAcquireCapacity() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-c.done:
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *APITrafficController) releaseCapacity() {
+	atomic.AddInt32(&c.activeWorkersCount, -1)
 }
 
 func (c *APITrafficController) Shutdown(ctx context.Context) {

--- a/internal/api/traffic_test.go
+++ b/internal/api/traffic_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -95,6 +96,52 @@ func TestTrafficController_UserPriorityPreemption(t *testing.T) {
 
 		cancel()
 	})
+}
+
+func TestTrafficController_NotificationBatchRunsBeforeQueuedScalarAtLimitOne(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := NewAPITrafficController(ctx, slog.Default())
+	atomic.StoreInt32(&tc.workerLimit, 1)
+	t.Cleanup(func() { tc.Shutdown(context.Background()) })
+
+	prepared := make(chan struct{})
+	childStarted := make(chan struct{})
+	releaseChild := make(chan struct{})
+	batchDone := make(chan notificationBatchExecution, 1)
+	go func() {
+		result, _ := tc.RunNotificationBatch(ctx, notificationBatchPlan{
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"1"}},
+			Prepare: func(context.Context) error { close(prepared); return nil },
+			Remote: func(context.Context, string) error {
+				close(childStarted)
+				<-releaseChild
+				return nil
+			},
+		})
+		batchDone <- result
+	}()
+	<-prepared
+	<-childStarted
+
+	scalarStarted := make(chan struct{})
+	scalarResult, err := tc.Submit(ctx, PriorityUser, func(context.Context) any {
+		close(scalarStarted)
+		return "scalar"
+	})
+	assert.NoError(t, err)
+	select {
+	case <-scalarStarted:
+		t.Fatal("scalar user work acquired capacity while the batch owned serialization")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseChild)
+	result := <-batchDone
+	assert.True(t, result.Committed)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&tc.activeWorkersCount))
+	assert.Equal(t, "scalar", <-scalarResult)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&tc.activeWorkersCount))
 }
 
 func TestTrafficController_RateLimitAtomic(t *testing.T) {

--- a/internal/api/traffic_test.go
+++ b/internal/api/traffic_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTrafficController_Concurrency(t *testing.T) {
@@ -142,6 +143,169 @@ func TestTrafficController_NotificationBatchRunsBeforeQueuedScalarAtLimitOne(t *
 	assert.Equal(t, int32(0), atomic.LoadInt32(&tc.activeWorkersCount))
 	assert.Equal(t, "scalar", <-scalarResult)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&tc.activeWorkersCount))
+}
+
+func TestTrafficController_NotificationBatchRejectsFullQueueBeforePrepare(t *testing.T) {
+	tc := NewAPITrafficController(context.Background(), slog.Default())
+	t.Cleanup(func() { tc.Shutdown(context.Background()) })
+	atomic.StoreInt32(&tc.userTaskActive, 1)
+	t.Cleanup(func() { atomic.StoreInt32(&tc.userTaskActive, 0) })
+	for range cap(tc.high) {
+		tc.high <- &apiTask{resp: make(chan any, 1), ctx: context.Background(), cleanup: func() {}}
+	}
+	t.Cleanup(func() { tc.drainQueue(tc.high) })
+
+	prepared := false
+	_, err := tc.RunNotificationBatch(context.Background(), notificationBatchPlan{
+		Request: types.NotificationBatchRequest{Operation: types.NotificationBatchHandled, IDs: []string{"1"}},
+		Prepare: func(context.Context) error { prepared = true; return nil },
+	})
+	assert.ErrorIs(t, err, ErrTrafficQueueFull)
+	assert.False(t, prepared)
+}
+
+func TestTrafficController_NotificationBatchCancellationWhileWaitingForCapacity(t *testing.T) {
+	tc := NewAPITrafficController(context.Background(), slog.Default())
+	atomic.StoreInt32(&tc.workerLimit, 1)
+	t.Cleanup(func() { tc.Shutdown(context.Background()) })
+
+	backgroundStarted := make(chan struct{})
+	releaseBackground := make(chan struct{})
+	_, err := tc.Submit(context.Background(), PrioritySync, func(context.Context) any {
+		close(backgroundStarted)
+		<-releaseBackground
+		return nil
+	})
+	require.NoError(t, err)
+	<-backgroundStarted
+
+	batchCtx, cancelBatch := context.WithCancel(context.Background())
+	prepared := make(chan struct{})
+	done := make(chan notificationBatchExecution, 1)
+	go func() {
+		result, _ := tc.RunNotificationBatch(batchCtx, notificationBatchPlan{
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"1"}},
+			Prepare: func(context.Context) error { close(prepared); return nil },
+			Remote:  func(context.Context, string) error { return nil },
+		})
+		done <- result
+	}()
+	<-prepared
+	cancelBatch()
+	result := <-done
+	assert.True(t, result.Committed)
+	assert.Equal(t, []types.NotificationBatchItemResult{{ID: "1", Status: types.NotificationRemoteNotAttempted}}, result.Outcomes)
+	close(releaseBackground)
+}
+
+func TestTrafficController_NotificationBatchShutdownWhileWaitingForCapacity(t *testing.T) {
+	tc := NewAPITrafficController(context.Background(), slog.Default())
+	atomic.StoreInt32(&tc.workerLimit, 1)
+
+	backgroundStarted := make(chan struct{})
+	_, err := tc.Submit(context.Background(), PrioritySync, func(ctx context.Context) any {
+		close(backgroundStarted)
+		<-ctx.Done()
+		return nil
+	})
+	require.NoError(t, err)
+	<-backgroundStarted
+
+	prepared := make(chan struct{})
+	done := make(chan notificationBatchExecution, 1)
+	go func() {
+		result, _ := tc.RunNotificationBatch(context.Background(), notificationBatchPlan{
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"1"}},
+			Prepare: func(context.Context) error { close(prepared); return nil },
+			Remote:  func(context.Context, string) error { return nil },
+		})
+		done <- result
+	}()
+	<-prepared
+	tc.Shutdown(context.Background())
+	result := <-done
+	assert.True(t, result.Committed)
+	assert.Equal(t, types.NotificationRemoteNotAttempted, result.Outcomes[0].Status)
+}
+
+func TestTrafficController_NotificationBatchSharesCapacityWithBackgroundWork(t *testing.T) {
+	tc := NewAPITrafficController(context.Background(), slog.Default())
+	t.Cleanup(func() { tc.Shutdown(context.Background()) })
+
+	backgroundStarted := make(chan struct{})
+	releaseBackground := make(chan struct{})
+	_, err := tc.Submit(context.Background(), PrioritySync, func(context.Context) any {
+		close(backgroundStarted)
+		<-releaseBackground
+		return nil
+	})
+	require.NoError(t, err)
+	<-backgroundStarted
+
+	childStarted := make(chan string, 3)
+	releaseChildren := make(chan struct{})
+	done := make(chan notificationBatchExecution, 1)
+	go func() {
+		result, _ := tc.RunNotificationBatch(context.Background(), notificationBatchPlan{
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"1", "2", "3"}},
+			Prepare: func(context.Context) error { return nil },
+			Remote: func(_ context.Context, id string) error {
+				childStarted <- id
+				<-releaseChildren
+				return nil
+			},
+		})
+		done <- result
+	}()
+	<-childStarted
+	<-childStarted
+	select {
+	case <-childStarted:
+		t.Fatal("batch exceeded shared capacity while background work was active")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseBackground)
+	<-childStarted
+	close(releaseChildren)
+	assert.True(t, (<-done).Committed)
+}
+
+func TestTrafficController_NotificationBatchHonorsDynamicScaleDown(t *testing.T) {
+	tc := NewAPITrafficController(context.Background(), slog.Default())
+	t.Cleanup(func() { tc.Shutdown(context.Background()) })
+
+	started := make(chan string, 4)
+	releases := map[string]chan struct{}{"1": make(chan struct{}), "2": make(chan struct{}), "3": make(chan struct{}), "4": make(chan struct{})}
+	done := make(chan notificationBatchExecution, 1)
+	go func() {
+		result, _ := tc.RunNotificationBatch(context.Background(), notificationBatchPlan{
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"1", "2", "3", "4"}},
+			Prepare: func(context.Context) error { return nil },
+			Remote: func(_ context.Context, id string) error {
+				started <- id
+				<-releases[id]
+				return nil
+			},
+		})
+		done <- result
+	}()
+	first := <-started
+	second := <-started
+	third := <-started
+	tc.UpdateRateLimit(context.Background(), models.RateLimitInfo{Remaining: 100})
+
+	close(releases[first])
+	close(releases[second])
+	select {
+	case <-started:
+		t.Fatal("new child started before active work reached the scaled-down limit")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releases[third])
+	fourth := <-started
+	assert.Equal(t, "4", fourth)
+	close(releases[fourth])
+	assert.True(t, (<-done).Committed)
 }
 
 func TestTrafficController_RateLimitAtomic(t *testing.T) {

--- a/internal/api/tui_backend.go
+++ b/internal/api/tui_backend.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -16,11 +17,12 @@ import (
 // operations. It composes narrower services but owns direct mutation semantics
 // and their corresponding event publication.
 type AppBackend struct {
-	UserID   string
-	Store    types.NotificationStore
-	Client   github.Client
-	Syncer   types.Syncer
-	Enricher types.Enricher
+	UserID        string
+	Store         types.NotificationStore
+	Client        github.Client
+	Syncer        types.Syncer
+	Enricher      types.Enricher
+	batchExecutor notificationBatchExecutor
 
 	resolveUserID func(context.Context) (string, error)
 	userMu        sync.RWMutex
@@ -33,11 +35,12 @@ type AppBackend struct {
 // the in-process AppBackend owner without introducing a broader builder
 // abstraction.
 type AppBackendParams struct {
-	UserID   string
-	Store    types.NotificationStore
-	Client   github.Client
-	Syncer   types.Syncer
-	Enricher types.Enricher
+	UserID        string
+	Store         types.NotificationStore
+	Client        github.Client
+	Syncer        types.Syncer
+	Enricher      types.Enricher
+	BatchExecutor notificationBatchExecutor
 
 	ResolveUserID func(context.Context) (string, error)
 
@@ -71,6 +74,7 @@ func NewAppBackend(params AppBackendParams) (*AppBackend, error) {
 		Client:                      params.Client,
 		Syncer:                      params.Syncer,
 		Enricher:                    params.Enricher,
+		batchExecutor:               params.BatchExecutor,
 		resolveUserID:               params.ResolveUserID,
 		publishNotificationsChanged: params.PublishNotificationsChanged,
 		publishEnrichmentUpdated:    params.PublishEnrichmentUpdated,
@@ -98,6 +102,61 @@ func NewTUIBackendClient(
 
 func (b *AppBackend) ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error) {
 	return b.Store.ListNotifications(ctx)
+}
+
+func (b *AppBackend) ApplyNotificationBatch(ctx context.Context, request types.NotificationBatchRequest) (types.NotificationBatchResult, error) {
+	normalized, err := types.NormalizeNotificationBatchRequest(request)
+	if err != nil {
+		return types.NotificationBatchResult{Status: types.NotificationBatchRejected, Request: request, Err: err}, nil
+	}
+	before, _ := b.Store.ListNotifications(ctx)
+	if b.batchExecutor == nil {
+		err := errors.New("notification batch executor is unavailable")
+		return types.NotificationBatchResult{Status: types.NotificationBatchRejected, Request: normalized, Notifications: before, Err: err}, nil
+	}
+
+	execution, runErr := b.batchExecutor.RunNotificationBatch(ctx, notificationBatchPlan{
+		Request: normalized,
+		Prepare: func(prepareCtx context.Context) error {
+			if err := b.Store.ApplyNotificationBatchLocally(prepareCtx, normalized); err != nil {
+				return err
+			}
+			b.publishNotificationsChanged()
+			return nil
+		},
+		Remote: func(remoteCtx context.Context, id string) error {
+			if b.Client == nil {
+				return errors.New("GitHub client is unavailable")
+			}
+			return b.Client.MarkThreadAsRead(remoteCtx, id)
+		},
+	})
+	if runErr != nil || !execution.Committed {
+		if runErr == nil {
+			runErr = execution.Err
+		}
+		return types.NotificationBatchResult{
+			Status:         types.NotificationBatchRejected,
+			Reconciliation: types.NotificationBatchAuthoritative,
+			Request:        normalized,
+			Notifications:  before,
+			Err:            runErr,
+		}, nil
+	}
+
+	result := types.NotificationBatchResult{
+		Status:         types.NotificationBatchCommitted,
+		Reconciliation: types.NotificationBatchAuthoritative,
+		Request:        normalized,
+		Outcomes:       execution.Outcomes,
+	}
+	result.Notifications, err = b.Store.ListNotifications(ctx)
+	if err != nil {
+		result.Reconciliation = types.NotificationBatchReconciliationPending
+		result.Notifications = applyNotificationBatchFallback(before, normalized)
+		result.Err = err
+	}
+	return result, nil
 }
 
 func (b *AppBackend) Sync(ctx context.Context, force bool) (models.RateLimitInfo, error) {
@@ -337,6 +396,30 @@ func withReadState(notifications []triage.NotificationWithState, id string, read
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsReadLocally = read
 			break
+		}
+	}
+	return cloned
+}
+
+func applyNotificationBatchFallback(notifications []triage.NotificationWithState, request types.NotificationBatchRequest) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	selected := make(map[string]struct{}, len(request.IDs))
+	for _, id := range request.IDs {
+		selected[id] = struct{}{}
+	}
+	for index := range cloned {
+		if _, ok := selected[cloned[index].GitHubID]; !ok {
+			continue
+		}
+		switch request.Operation {
+		case types.NotificationBatchRead:
+			cloned[index].IsReadLocally = true
+		case types.NotificationBatchUnread:
+			cloned[index].IsReadLocally = false
+		case types.NotificationBatchHandled:
+			cloned[index].IsHandledLocally = true
+		case types.NotificationBatchUnhandled:
+			cloned[index].IsHandledLocally = false
 		}
 	}
 	return cloned

--- a/internal/api/tui_backend_test.go
+++ b/internal/api/tui_backend_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hirakiuc/gh-orbit/internal/config"
@@ -63,6 +65,39 @@ func TestAppBackend_MarkReadPublishesNotificationsChanged(t *testing.T) {
 	assert.Equal(t, 1, published)
 	assert.Equal(t, types.MarkReadSuccess, result.Status)
 	assert.Equal(t, snapshot, result.Notifications)
+}
+
+func TestAppBackend_ApplyNotificationBatchPublishesOnceAndReportsPartialRemoteFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	traffic := NewAPITrafficController(ctx, slog.Default())
+	t.Cleanup(func() { traffic.Shutdown(context.Background()) })
+
+	mockRepo := mocks.NewMockRepository(t)
+	mockSyncer := mocks.NewMockSyncer(t)
+	mockEnricher := mocks.NewMockEnricher(t)
+	mockClient := mocks.NewMockClient(t)
+	before := []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "a"}}, {Notification: triage.Notification{GitHubID: "b"}}}
+	after := applyNotificationBatchFallback(before, types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}})
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(before, nil).Once()
+	mockRepo.EXPECT().ApplyNotificationBatchLocally(mock.Anything, types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}}).Return(nil).Once()
+	mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "a").Return(nil).Once()
+	mockClient.EXPECT().MarkThreadAsRead(mock.Anything, "b").Return(errors.New("remote unavailable")).Once()
+	mockRepo.EXPECT().ListNotifications(mock.Anything).Return(after, nil).Once()
+
+	var published atomic.Int32
+	backend, err := NewAppBackend(AppBackendParams{
+		UserID: "user", Store: mockRepo, Client: mockClient, Syncer: mockSyncer, Enricher: mockEnricher,
+		BatchExecutor: traffic, PublishNotificationsChanged: func() { published.Add(1) },
+	})
+	require.NoError(t, err)
+	result, err := backend.ApplyNotificationBatch(ctx, types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"b", "a"}})
+	require.NoError(t, err)
+	assert.Equal(t, types.NotificationBatchCommitted, result.Status)
+	assert.Equal(t, int32(1), published.Load())
+	require.Len(t, result.Outcomes, 2)
+	assert.Equal(t, types.NotificationRemoteSucceeded, result.Outcomes[0].Status)
+	assert.Equal(t, types.NotificationRemoteFailed, result.Outcomes[1].Status)
 }
 
 func TestAppBackend_IndependentReadAndHandledMutations(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,12 @@ type KeyMapConfig struct {
 	CopyURL              []string `yaml:"copy_url"`
 	ToggleRead           []string `yaml:"toggle_read"`
 	ToggleHandled        []string `yaml:"toggle_handled"`
+	SelectionMode        []string `yaml:"selection_mode"`
+	SelectNotification   []string `yaml:"select_notification"`
+	BatchRead            []string `yaml:"batch_read"`
+	BatchUnread          []string `yaml:"batch_unread"`
+	BatchHandled         []string `yaml:"batch_handled"`
+	BatchUnhandled       []string `yaml:"batch_unhandled"`
 	NextTab              []string `yaml:"next_tab"`
 	PrevTab              []string `yaml:"prev_tab"`
 	CheckoutPR           []string `yaml:"checkout_pr"`
@@ -50,6 +56,7 @@ type KeyMapConfig struct {
 	Help                 []string `yaml:"help"`
 
 	toggleHandledExplicit bool
+	batchKeysExplicit     map[string]bool
 }
 
 // TUIConfig represents settings for the Terminal UI.
@@ -110,6 +117,12 @@ func DefaultConfig() *Config {
 			CopyURL:              []string{"y"},
 			ToggleRead:           []string{"m"},
 			ToggleHandled:        []string{"x"},
+			SelectionMode:        []string{"S"},
+			SelectNotification:   []string{"s"},
+			BatchRead:            []string{"R"},
+			BatchUnread:          []string{"U"},
+			BatchHandled:         []string{"H"},
+			BatchUnhandled:       []string{"N"},
 			NextTab:              []string{"]", "tab"},
 			PrevTab:              []string{"[", "shift+tab"},
 			CheckoutPR:           []string{"c"},
@@ -225,6 +238,14 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid config.yml (check for typos): %w", err)
 	}
 	cfg.Keys.toggleHandledExplicit = toggleHandledExplicit
+	cfg.Keys.batchKeysExplicit = make(map[string]bool)
+	for _, name := range []string{"selection_mode", "select_notification", "batch_read", "batch_unread", "batch_handled", "batch_unhandled"} {
+		explicit, explicitErr := yamlMappingHasKey(data, "keys", name)
+		if explicitErr != nil {
+			return nil, fmt.Errorf("invalid config.yml: %w", explicitErr)
+		}
+		cfg.Keys.batchKeysExplicit[name] = explicit
+	}
 
 	normalizeKeyMap(&cfg.Keys)
 
@@ -287,6 +308,11 @@ func (c *Config) Save() error {
 	}
 	if !c.Keys.toggleHandledExplicit {
 		removeYAMLMappingKey(&document, "keys", "toggle_handled")
+	}
+	for _, name := range []string{"selection_mode", "select_notification", "batch_read", "batch_unread", "batch_handled", "batch_unhandled"} {
+		if !c.Keys.batchKeysExplicit[name] {
+			removeYAMLMappingKey(&document, "keys", name)
+		}
 	}
 	data, err := yaml.Marshal(&document)
 	if err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -390,6 +390,41 @@ func TestRepository_IndependentReadAndHandledMutations(t *testing.T) {
 	assert.ErrorIs(t, db.SetHandledLocally(ctx, "missing", true), types.ErrNotificationNotFound)
 }
 
+func TestRepository_ApplyNotificationBatchLocally(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenInMemory(ctx, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+
+	for _, id := range []string{"batch-a", "batch-b"} {
+		require.NoError(t, database.UpsertNotifications(ctx, []triage.Notification{{GitHubID: id, UpdatedAt: time.Now()}}))
+	}
+	require.NoError(t, database.SetHandledLocally(ctx, "batch-a", true))
+
+	require.NoError(t, database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{
+		Operation: types.NotificationBatchRead,
+		IDs:       []string{"batch-b", "batch-a", "batch-a"},
+	}))
+	for _, id := range []string{"batch-a", "batch-b"} {
+		state, getErr := database.GetNotification(ctx, id)
+		require.NoError(t, getErr)
+		assert.True(t, state.IsReadLocally)
+	}
+	state, err := database.GetNotification(ctx, "batch-a")
+	require.NoError(t, err)
+	assert.True(t, state.IsHandledLocally, "read batch must preserve handled state")
+
+	err = database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{
+		Operation: types.NotificationBatchUnhandled,
+		IDs:       []string{"batch-a", "missing"},
+	})
+	assert.ErrorIs(t, err, types.ErrNotificationNotFound)
+	state, err = database.GetNotification(ctx, "batch-a")
+	require.NoError(t, err)
+	assert.True(t, state.IsHandledLocally, "missing target must roll back the entire batch")
+	assert.True(t, state.IsReadLocally, "handled batch must preserve read state")
+}
+
 func TestRepository_MetadataAndEnrichment(t *testing.T) {
 	logger := slog.Default()
 	ctx := context.Background()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -423,6 +424,57 @@ func TestRepository_ApplyNotificationBatchLocally(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, state.IsHandledLocally, "missing target must roll back the entire batch")
 	assert.True(t, state.IsReadLocally, "handled batch must preserve read state")
+}
+
+func TestRepository_ApplyNotificationBatchLocallyOperations(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenInMemory(ctx, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	require.NoError(t, database.UpsertNotifications(ctx, []triage.Notification{{GitHubID: "target", UpdatedAt: time.Now()}}))
+
+	tests := []struct {
+		operation types.NotificationBatchOperation
+		read      bool
+		handled   bool
+	}{
+		{types.NotificationBatchRead, true, false},
+		{types.NotificationBatchHandled, true, true},
+		{types.NotificationBatchUnread, false, true},
+		{types.NotificationBatchUnhandled, false, false},
+	}
+	for _, test := range tests {
+		require.NoError(t, database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{Operation: test.operation, IDs: []string{"target"}}))
+		state, getErr := database.GetNotification(ctx, "target")
+		require.NoError(t, getErr)
+		assert.Equal(t, test.read, state.IsReadLocally)
+		assert.Equal(t, test.handled, state.IsHandledLocally)
+	}
+	assert.Error(t, database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{Operation: "invalid", IDs: []string{"target"}}))
+}
+
+func TestRepository_ApplyNotificationBatchLocallyExactLimit(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenInMemory(ctx, slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+
+	ids := make([]string, types.MaxBatchNotifications)
+	notifications := make([]triage.Notification, types.MaxBatchNotifications)
+	for index := range ids {
+		ids[index] = fmt.Sprintf("batch-%03d", index)
+		notifications[index] = triage.Notification{GitHubID: ids[index], UpdatedAt: time.Now()}
+	}
+	require.NoError(t, database.UpsertNotifications(ctx, notifications))
+	require.NoError(t, database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{Operation: types.NotificationBatchHandled, IDs: ids}))
+	for _, id := range ids {
+		state, getErr := database.GetNotification(ctx, id)
+		require.NoError(t, getErr)
+		assert.True(t, state.IsHandledLocally)
+	}
+
+	overLimit := append(append([]string(nil), ids...), "batch-over-limit")
+	assert.Error(t, database.ApplyNotificationBatchLocally(ctx, types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: overLimit}))
 }
 
 func TestRepository_MetadataAndEnrichment(t *testing.T) {

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -258,6 +258,59 @@ func (db *DB) SetHandledLocally(ctx context.Context, id string, isHandled bool) 
 	return requireUpdatedNotification(result, err)
 }
 
+// ApplyNotificationBatchLocally updates one independent local-state column for
+// every requested notification in one all-or-nothing transaction.
+func (db *DB) ApplyNotificationBatchLocally(ctx context.Context, request types.NotificationBatchRequest) error {
+	normalized, err := types.NormalizeNotificationBatchRequest(request)
+	if err != nil {
+		return err
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin notification batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, id := range normalized.IDs {
+		var exists int
+		if err := tx.QueryRowContext(ctx, "SELECT 1 FROM orbit_state WHERE notification_id = ?", id).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return types.ErrNotificationNotFound
+			}
+			return fmt.Errorf("verify notification batch target: %w", err)
+		}
+	}
+
+	query, value := notificationBatchUpdate(normalized.Operation)
+	for _, id := range normalized.IDs {
+		result, err := tx.ExecContext(ctx, query, value, id)
+		if err := requireUpdatedNotification(result, err); err != nil {
+			return fmt.Errorf("update notification batch target: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit notification batch: %w", err)
+	}
+	return nil
+}
+
+func notificationBatchUpdate(operation types.NotificationBatchOperation) (string, bool) {
+	switch operation {
+	case types.NotificationBatchRead:
+		return "UPDATE orbit_state SET is_read_locally = ? WHERE notification_id = ?", true
+	case types.NotificationBatchUnread:
+		return "UPDATE orbit_state SET is_read_locally = ? WHERE notification_id = ?", false
+	case types.NotificationBatchHandled:
+		return "UPDATE orbit_state SET is_handled_locally = ? WHERE notification_id = ?", true
+	case types.NotificationBatchUnhandled:
+		return "UPDATE orbit_state SET is_handled_locally = ? WHERE notification_id = ?", false
+	default:
+		panic("notification batch operation must be normalized")
+	}
+}
+
 func requireUpdatedNotification(result sql.Result, err error) error {
 	if err != nil {
 		return err

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -149,6 +149,68 @@ func (a *MCPAdapter) ResolveUserID(ctx context.Context) (string, error) {
 	return payload.Login, nil
 }
 
+func (a *MCPAdapter) ApplyNotificationBatch(ctx context.Context, request types.NotificationBatchRequest) (types.NotificationBatchResult, error) {
+	normalized, err := types.NormalizeNotificationBatchRequest(request)
+	if err != nil {
+		return types.NotificationBatchResult{Status: types.NotificationBatchRejected, Request: request, Err: err}, nil
+	}
+	before, _ := a.ListNotifications(ctx)
+	resp, callErr := a.client.CallTool(ctx, mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name: "batch_set_state",
+		Arguments: map[string]any{
+			"ids":       normalized.IDs,
+			"operation": string(normalized.Operation),
+		},
+	}})
+	if callErr != nil || resp == nil {
+		if callErr == nil {
+			callErr = errors.New("batch_set_state returned nil result")
+		}
+		return types.NotificationBatchResult{
+			Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
+			Request: normalized, Notifications: before, Err: callErr,
+		}, nil
+	}
+	if resp.IsError {
+		return types.NotificationBatchResult{
+			Status: types.NotificationBatchRejected, Reconciliation: types.NotificationBatchAuthoritative,
+			Request: normalized, Notifications: before, Err: decodeToolResultError("batch_set_state", resp),
+		}, nil
+	}
+
+	result, ok := decodeNotificationBatchToolResult(resp)
+	if !ok || (result.Status != types.NotificationBatchCommitted && result.Status != types.NotificationBatchRejected) {
+		return types.NotificationBatchResult{
+			Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
+			Request: normalized, Notifications: before, Err: errors.New("batch_set_state returned an untrustworthy result"),
+		}, nil
+	}
+	result.Request = normalized
+	result.Reconciliation = types.NotificationBatchAuthoritative
+	result.Notifications, err = a.ListNotifications(ctx)
+	if err != nil {
+		result.Reconciliation = types.NotificationBatchReconciliationPending
+		result.Notifications = applyBatchState(before, normalized)
+		result.Err = err
+	}
+	return result, nil
+}
+
+func decodeNotificationBatchToolResult(resp *mcp.CallToolResult) (types.NotificationBatchResult, bool) {
+	if resp == nil || resp.StructuredContent == nil {
+		return types.NotificationBatchResult{}, false
+	}
+	raw, err := json.Marshal(resp.StructuredContent)
+	if err != nil {
+		return types.NotificationBatchResult{}, false
+	}
+	var result types.NotificationBatchResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return types.NotificationBatchResult{}, false
+	}
+	return result, true
+}
+
 func (a *MCPAdapter) SetRead(ctx context.Context, id string, isRead bool) (types.ReadUpdateResult, error) {
 	before, _ := a.ListNotifications(ctx)
 
@@ -438,6 +500,30 @@ func applyHandledState(notifications []triage.NotificationWithState, id string, 
 		if cloned[idx].GitHubID == id {
 			cloned[idx].IsHandledLocally = handled
 			break
+		}
+	}
+	return cloned
+}
+
+func applyBatchState(notifications []triage.NotificationWithState, request types.NotificationBatchRequest) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	selected := make(map[string]struct{}, len(request.IDs))
+	for _, id := range request.IDs {
+		selected[id] = struct{}{}
+	}
+	for index := range cloned {
+		if _, ok := selected[cloned[index].GitHubID]; !ok {
+			continue
+		}
+		switch request.Operation {
+		case types.NotificationBatchRead:
+			cloned[index].IsReadLocally = true
+		case types.NotificationBatchUnread:
+			cloned[index].IsReadLocally = false
+		case types.NotificationBatchHandled:
+			cloned[index].IsHandledLocally = true
+		case types.NotificationBatchUnhandled:
+			cloned[index].IsHandledLocally = false
 		}
 	}
 	return cloned

--- a/internal/engine/adapter.go
+++ b/internal/engine/adapter.go
@@ -179,13 +179,12 @@ func (a *MCPAdapter) ApplyNotificationBatch(ctx context.Context, request types.N
 	}
 
 	result, ok := decodeNotificationBatchToolResult(resp)
-	if !ok || (result.Status != types.NotificationBatchCommitted && result.Status != types.NotificationBatchRejected) {
+	if !ok || types.ValidateNotificationBatchResult(normalized, result) != nil {
 		return types.NotificationBatchResult{
 			Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
 			Request: normalized, Notifications: before, Err: errors.New("batch_set_state returned an untrustworthy result"),
 		}, nil
 	}
-	result.Request = normalized
 	result.Reconciliation = types.NotificationBatchAuthoritative
 	result.Notifications, err = a.ListNotifications(ctx)
 	if err != nil {

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -2,17 +2,77 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func notificationResource(t *testing.T, request mcp.ReadResourceRequest, notifications []triage.NotificationWithState) *mcp.ReadResourceResult {
+	t.Helper()
+	payload, err := json.Marshal(notifications)
+	require.NoError(t, err)
+	return &mcp.ReadResourceResult{Contents: []mcp.ResourceContents{
+		mcp.TextResourceContents{URI: request.Params.URI, Text: string(payload)},
+	}}
+}
+
+func TestMCPAdapter_NotificationBatchTransportLossIsCommitUnknown(t *testing.T) {
+	callCount := 0
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		readResource: func(_ context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return notificationResource(t, request, []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}), nil
+		},
+		callTool: func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			callCount++
+			return nil, errors.New("connection lost")
+		},
+	})
+
+	result, err := adapter.ApplyNotificationBatch(context.Background(), types.NotificationBatchRequest{
+		Operation: types.NotificationBatchRead, IDs: []string{"1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, types.NotificationBatchCommitUnknown, result.Status)
+	assert.Equal(t, types.NotificationBatchReconciliationPending, result.Reconciliation)
+	assert.Equal(t, 1, callCount, "an indeterminate request must not be replayed")
+}
+
+func TestMCPAdapter_NotificationBatchConfirmedCommitSurvivesReloadFailure(t *testing.T) {
+	reads := 0
+	outcomes := []types.NotificationBatchItemResult{{ID: "1", Status: types.NotificationRemoteFailed, ErrorCode: "remote_failed"}}
+	adapter := NewMCPAdapter(&blockingMCPClient{
+		readResource: func(_ context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			reads++
+			if reads > 1 {
+				return nil, errors.New("reload failed")
+			}
+			return notificationResource(t, request, []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}), nil
+		},
+		callTool: func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{
+				"status": "committed", "outcomes": outcomes,
+			}}, nil
+		},
+	})
+
+	result, err := adapter.ApplyNotificationBatch(context.Background(), types.NotificationBatchRequest{
+		Operation: types.NotificationBatchRead, IDs: []string{"1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, types.NotificationBatchCommitted, result.Status)
+	assert.Equal(t, types.NotificationBatchReconciliationPending, result.Reconciliation)
+	assert.Equal(t, outcomes, result.Outcomes)
+}
 
 type blockingMCPClient struct {
 	callTool     func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)

--- a/internal/engine/adapter_sync_test.go
+++ b/internal/engine/adapter_sync_test.go
@@ -60,7 +60,9 @@ func TestMCPAdapter_NotificationBatchConfirmedCommitSurvivesReloadFailure(t *tes
 		},
 		callTool: func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{StructuredContent: map[string]any{
-				"status": "committed", "outcomes": outcomes,
+				"status": "committed", "reconciliation": "authoritative",
+				"request":  map[string]any{"operation": "read", "ids": []string{"1"}},
+				"outcomes": outcomes,
 			}}, nil
 		},
 	})
@@ -72,6 +74,69 @@ func TestMCPAdapter_NotificationBatchConfirmedCommitSurvivesReloadFailure(t *tes
 	assert.Equal(t, types.NotificationBatchCommitted, result.Status)
 	assert.Equal(t, types.NotificationBatchReconciliationPending, result.Reconciliation)
 	assert.Equal(t, outcomes, result.Outcomes)
+}
+
+func TestMCPAdapter_NotificationBatchRejectsUntrustworthyStructuredResults(t *testing.T) {
+	validRequest := map[string]any{"operation": "read", "ids": []string{"1"}}
+	tests := map[string]map[string]any{
+		"malformed": {"outcomes": make(chan int)},
+		"missing request": {
+			"status": "committed", "reconciliation": "authoritative",
+			"outcomes": []map[string]any{{"id": "1", "status": "succeeded"}},
+		},
+		"missing outcomes": {
+			"status": "committed", "reconciliation": "authoritative", "request": validRequest,
+		},
+		"duplicate target": {
+			"status": "committed", "reconciliation": "authoritative", "request": validRequest,
+			"outcomes": []map[string]any{{"id": "1", "status": "succeeded"}, {"id": "1", "status": "succeeded"}},
+		},
+		"foreign target": {
+			"status": "committed", "reconciliation": "authoritative", "request": validRequest,
+			"outcomes": []map[string]any{{"id": "2", "status": "succeeded"}},
+		},
+		"invalid status": {
+			"status": "committed", "reconciliation": "authoritative", "request": validRequest,
+			"outcomes": []map[string]any{{"id": "1", "status": "running"}},
+		},
+		"unbounded error code": {
+			"status": "committed", "reconciliation": "authoritative", "request": validRequest,
+			"outcomes": []map[string]any{{"id": "1", "status": "failed", "error_code": string(make([]byte, 65))}},
+		},
+		"contradictory local-only result": {
+			"status": "committed", "reconciliation": "authoritative",
+			"request":  map[string]any{"operation": "handled", "ids": []string{"1"}},
+			"outcomes": []map[string]any{{"id": "1", "status": "succeeded"}},
+		},
+		"mismatched operation": {
+			"status": "committed", "reconciliation": "authoritative",
+			"request":  map[string]any{"operation": "unread", "ids": []string{"1"}},
+			"outcomes": []map[string]any{{"id": "1", "status": "not_required"}},
+		},
+	}
+
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			calls := 0
+			adapter := NewMCPAdapter(&blockingMCPClient{
+				readResource: func(_ context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					return notificationResource(t, request, []triage.NotificationWithState{{Notification: triage.Notification{GitHubID: "1"}}}), nil
+				},
+				callTool: func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					calls++
+					return &mcp.CallToolResult{StructuredContent: payload}, nil
+				},
+			})
+			operation := types.NotificationBatchRead
+			if name == "contradictory local-only result" {
+				operation = types.NotificationBatchHandled
+			}
+			result, err := adapter.ApplyNotificationBatch(context.Background(), types.NotificationBatchRequest{Operation: operation, IDs: []string{"1"}})
+			require.NoError(t, err)
+			assert.Equal(t, types.NotificationBatchCommitUnknown, result.Status)
+			assert.Equal(t, 1, calls, "an untrustworthy response must not be replayed")
+		})
+	}
 }
 
 type blockingMCPClient struct {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/db"
 	"github.com/hirakiuc/gh-orbit/internal/github"
+	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 )
 
@@ -121,7 +122,7 @@ func NewCoreEngine(
 	bus := NewEventBus()
 	hooks := newBackendPublishHooks(bus)
 	traffic := api.NewAPITrafficController(ctx, logger)
-	client.SetRateLimitReporter(traffic.ReportRateLimit)
+	wireRateLimitReporter(client, traffic.ReportRateLimit)
 
 	enricher, err := api.NewEnrichmentEngine(ctx, api.EnrichParams{
 		Client: client,
@@ -184,6 +185,10 @@ func NewCoreEngine(
 		Traffic:           traffic,
 		Alert:             alerter,
 	}, nil
+}
+
+func wireRateLimitReporter(client github.Client, reporter func(models.RateLimitInfo)) {
+	client.SetRateLimitReporter(reporter)
 }
 
 // Shutdown ensures all background resources are released cleanly.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -68,12 +68,13 @@ func newBackendPublishHooks(bus *EventBus) backendPublishHooks {
 	}
 }
 
-func newAppBackend(database types.Repository, client github.Client, syncer types.Syncer, enricher types.Enricher, hooks backendPublishHooks) (*api.AppBackend, error) {
+func newAppBackend(database types.Repository, client github.Client, syncer types.Syncer, enricher types.Enricher, traffic *api.APITrafficController, hooks backendPublishHooks) (*api.AppBackend, error) {
 	return api.NewAppBackend(api.AppBackendParams{
 		Store:                       database,
 		Client:                      client,
 		Syncer:                      syncer,
 		Enricher:                    enricher,
+		BatchExecutor:               traffic,
 		ResolveUserID:               currentUserResolver(client),
 		PublishNotificationsChanged: hooks.notificationsChanged,
 		PublishEnrichmentUpdated:    hooks.enrichmentChanged,
@@ -120,6 +121,7 @@ func NewCoreEngine(
 	bus := NewEventBus()
 	hooks := newBackendPublishHooks(bus)
 	traffic := api.NewAPITrafficController(ctx, logger)
+	client.SetRateLimitReporter(traffic.ReportRateLimit)
 
 	enricher, err := api.NewEnrichmentEngine(ctx, api.EnrichParams{
 		Client: client,
@@ -163,7 +165,7 @@ func NewCoreEngine(
 	}
 	syncer.OnMutation = hooks.notificationsChanged
 
-	appBackend, err := newAppBackend(database, client, syncer, enricher, hooks)
+	appBackend, err := newAppBackend(database, client, syncer, enricher, traffic, hooks)
 	if err != nil {
 		_ = database.Close()
 		return nil, err

--- a/internal/engine/engine_wiring_test.go
+++ b/internal/engine/engine_wiring_test.go
@@ -1,0 +1,25 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/hirakiuc/gh-orbit/internal/mocks"
+	"github.com/hirakiuc/gh-orbit/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWireRateLimitReporterRegistersEngineOwnedTrafficCallback(t *testing.T) {
+	client := mocks.NewMockClient(t)
+	var installed func(models.RateLimitInfo)
+	client.EXPECT().SetRateLimitReporter(mock.Anything).Run(func(fn func(models.RateLimitInfo)) {
+		installed = fn
+	}).Once()
+
+	var reported models.RateLimitInfo
+	wireRateLimitReporter(client, func(info models.RateLimitInfo) { reported = info })
+	assert.NotNil(t, installed)
+	want := models.RateLimitInfo{Remaining: 321}
+	installed(want)
+	assert.Equal(t, want, reported)
+}

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -351,8 +351,8 @@ func notificationBatchToolResult(result types.NotificationBatchResult, err error
 	if err != nil {
 		return mcp.NewToolResultError("notification batch failed"), nil
 	}
-	if result.Status == types.NotificationBatchRejected {
-		return mcp.NewToolResultError("notification batch rejected"), nil
+	if err := types.ValidateNotificationBatchResult(result.Request, result); err != nil {
+		return mcp.NewToolResultError("notification batch returned an invalid result"), nil
 	}
 	payload := struct {
 		Status         types.NotificationBatchStatus         `json:"status"`

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -347,6 +347,53 @@ func handledToolResult(result types.HandledUpdateResult, err error) (*mcp.CallTo
 	return mutationToolSuccessResult("Notification handled state updated")
 }
 
+func notificationBatchToolResult(result types.NotificationBatchResult, err error) (*mcp.CallToolResult, error) {
+	if err != nil {
+		return mcp.NewToolResultError("notification batch failed"), nil
+	}
+	if result.Status == types.NotificationBatchRejected {
+		return mcp.NewToolResultError("notification batch rejected"), nil
+	}
+	payload := struct {
+		Status         types.NotificationBatchStatus         `json:"status"`
+		Reconciliation types.NotificationBatchReconciliation `json:"reconciliation"`
+		Request        types.NotificationBatchRequest        `json:"request"`
+		Outcomes       []types.NotificationBatchItemResult   `json:"outcomes"`
+	}{
+		Status: result.Status, Reconciliation: result.Reconciliation,
+		Request: result.Request, Outcomes: result.Outcomes,
+	}
+	data, _ := json.Marshal(payload)
+	return mcp.NewToolResultStructured(payload, string(data)), nil
+}
+
+func requiredNotificationBatchArgs(request mcp.CallToolRequest) (types.NotificationBatchRequest, error) {
+	args, ok := request.Params.Arguments.(map[string]any)
+	if !ok {
+		return types.NotificationBatchRequest{}, errors.New("invalid arguments format")
+	}
+	operation, ok := args["operation"].(string)
+	if !ok {
+		return types.NotificationBatchRequest{}, errors.New("operation must be a string")
+	}
+	rawIDs, ok := args["ids"].([]any)
+	if !ok {
+		if ids, stringsOK := args["ids"].([]string); stringsOK {
+			return types.NormalizeNotificationBatchRequest(types.NotificationBatchRequest{Operation: types.NotificationBatchOperation(operation), IDs: ids})
+		}
+		return types.NotificationBatchRequest{}, errors.New("ids must be an array")
+	}
+	ids := make([]string, len(rawIDs))
+	for index, rawID := range rawIDs {
+		id, stringOK := rawID.(string)
+		if !stringOK {
+			return types.NotificationBatchRequest{}, fmt.Errorf("id at position %d must be a string", index)
+		}
+		ids[index] = id
+	}
+	return types.NormalizeNotificationBatchRequest(types.NotificationBatchRequest{Operation: types.NotificationBatchOperation(operation), IDs: ids})
+}
+
 func requiredStateMutationArgs(request mcp.CallToolRequest, stateKey string) (string, bool, error) {
 	args, ok := request.Params.Arguments.(map[string]any)
 	if !ok {
@@ -487,6 +534,21 @@ func (s *MCPServer) registerTools() {
 		}
 		result, err := s.engine.Backend.SetHandled(ctx, id, handled)
 		return handledToolResult(result, err)
+	})
+
+	batchSetStateTool := mcp.NewTool(
+		"batch_set_state",
+		mcp.WithDescription("Set one explicit read or handled state for up to 100 notifications"),
+		mcp.WithArray("ids", mcp.Required(), mcp.WithStringItems(), mcp.Description("GitHub notification IDs")),
+		mcp.WithString("operation", mcp.Required(), mcp.Enum("read", "unread", "handled", "unhandled")),
+	)
+	s.server.AddTool(batchSetStateTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		batchRequest, err := requiredNotificationBatchArgs(request)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := s.engine.Backend.ApplyNotificationBatch(ctx, batchRequest)
+		return notificationBatchToolResult(result, err)
 	})
 
 	// 3. Set Priority Tool

--- a/internal/engine/notification_batch_contract_test.go
+++ b/internal/engine/notification_batch_contract_test.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/hirakiuc/gh-orbit/internal/types"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiredNotificationBatchArgs(t *testing.T) {
+	request := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"operation": "read", "ids": []any{" b ", "a", "a"},
+	}}}
+	got, err := requiredNotificationBatchArgs(request)
+	require.NoError(t, err)
+	assert.Equal(t, types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}}, got)
+
+	request.Params.Arguments = map[string]any{"operation": "read", "ids": []any{"a", 2}}
+	_, err = requiredNotificationBatchArgs(request)
+	assert.Error(t, err)
+}
+
+func TestNotificationBatchToolResultRequiresValidCommittedPayload(t *testing.T) {
+	request := types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a"}}
+	valid := types.NotificationBatchResult{
+		Status: types.NotificationBatchCommitted, Reconciliation: types.NotificationBatchAuthoritative,
+		Request: request, Outcomes: []types.NotificationBatchItemResult{{ID: "a", Status: types.NotificationRemoteSucceeded}},
+	}
+	result, err := notificationBatchToolResult(valid, nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.NotNil(t, result.StructuredContent)
+
+	invalid := valid
+	invalid.Outcomes = nil
+	result, err = notificationBatchToolResult(invalid, nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
 	"github.com/hirakiuc/gh-orbit/internal/triage"
+	"github.com/hirakiuc/gh-orbit/internal/types"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -37,6 +38,63 @@ type MockRepository_Expecter struct {
 
 func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 	return &MockRepository_Expecter{mock: &_m.Mock}
+}
+
+// ApplyNotificationBatchLocally provides a mock function for the type MockRepository
+func (_mock *MockRepository) ApplyNotificationBatchLocally(ctx context.Context, request types.NotificationBatchRequest) error {
+	ret := _mock.Called(ctx, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyNotificationBatchLocally")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.NotificationBatchRequest) error); ok {
+		r0 = returnFunc(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRepository_ApplyNotificationBatchLocally_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplyNotificationBatchLocally'
+type MockRepository_ApplyNotificationBatchLocally_Call struct {
+	*mock.Call
+}
+
+// ApplyNotificationBatchLocally is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request types.NotificationBatchRequest
+func (_e *MockRepository_Expecter) ApplyNotificationBatchLocally(ctx any, request any) *MockRepository_ApplyNotificationBatchLocally_Call {
+	return &MockRepository_ApplyNotificationBatchLocally_Call{Call: _e.mock.On("ApplyNotificationBatchLocally", ctx, request)}
+}
+
+func (_c *MockRepository_ApplyNotificationBatchLocally_Call) Run(run func(ctx context.Context, request types.NotificationBatchRequest)) *MockRepository_ApplyNotificationBatchLocally_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 types.NotificationBatchRequest
+		if args[1] != nil {
+			arg1 = args[1].(types.NotificationBatchRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_ApplyNotificationBatchLocally_Call) Return(err error) *MockRepository_ApplyNotificationBatchLocally_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRepository_ApplyNotificationBatchLocally_Call) RunAndReturn(run func(ctx context.Context, request types.NotificationBatchRequest) error) *MockRepository_ApplyNotificationBatchLocally_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ArchiveThread provides a mock function for the type MockRepository

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,6 +12,70 @@ import (
 	"github.com/hirakiuc/gh-orbit/internal/triage"
 	"github.com/hirakiuc/gh-orbit/internal/types"
 )
+
+func (m *Model) ApplyNotificationBatch(request types.NotificationBatchRequest) tea.Cmd {
+	normalized, err := types.NormalizeNotificationBatchRequest(request)
+	before := append([]triage.NotificationWithState(nil), m.allNotifications...)
+	if err != nil {
+		return func() tea.Msg {
+			return batchMutationAppliedMsg{before: before, result: types.NotificationBatchResult{
+				Status: types.NotificationBatchRejected, Request: request, Notifications: before, Err: err,
+			}}
+		}
+	}
+
+	m.pendingBatchRequest = normalized
+	m.batchPending = true
+	m.allNotifications = applyBatchOptimistically(m.allNotifications, normalized)
+	m.applyFilters()
+
+	return m.submitBackendTask("notification-batch", 0, func(ctx context.Context) any {
+		result, callErr := m.backend.ApplyNotificationBatch(ctx, normalized)
+		if callErr != nil {
+			result = types.NotificationBatchResult{
+				Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
+				Request: normalized, Notifications: before, Err: callErr,
+			}
+		}
+		return batchMutationAppliedMsg{result: result, before: before}
+	})
+}
+
+func applyBatchOptimistically(notifications []triage.NotificationWithState, request types.NotificationBatchRequest) []triage.NotificationWithState {
+	cloned := append([]triage.NotificationWithState(nil), notifications...)
+	selected := make(map[string]struct{}, len(request.IDs))
+	for _, id := range request.IDs {
+		selected[id] = struct{}{}
+	}
+	for index := range cloned {
+		if _, ok := selected[cloned[index].GitHubID]; !ok {
+			continue
+		}
+		switch request.Operation {
+		case types.NotificationBatchRead:
+			cloned[index].IsReadLocally = true
+		case types.NotificationBatchUnread:
+			cloned[index].IsReadLocally = false
+		case types.NotificationBatchHandled:
+			cloned[index].IsHandledLocally = true
+		case types.NotificationBatchUnhandled:
+			cloned[index].IsHandledLocally = false
+		}
+	}
+	return cloned
+}
+
+func (m *Model) selectedBatchRequest(operation types.NotificationBatchOperation) (types.NotificationBatchRequest, bool) {
+	if len(m.selectedIDs) == 0 {
+		return types.NotificationBatchRequest{}, false
+	}
+	ids := make([]string, 0, len(m.selectedIDs))
+	for id := range m.selectedIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return types.NotificationBatchRequest{Operation: operation, IDs: ids}, true
+}
 
 var _ = slog.LevelInfo
 

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -24,6 +24,11 @@ func (m *Model) ApplyNotificationBatch(request types.NotificationBatchRequest) t
 		}
 	}
 
+	// A retry starts a new mutation lifecycle. Keep the current selection while
+	// replacing any prior recovery record with the new immutable request.
+	m.batchRecovery = nil
+	m.batchUncertain = false
+	m.batchRefreshPending = false
 	m.pendingBatchRequest = normalized
 	m.batchPending = true
 	m.allNotifications = applyBatchOptimistically(m.allNotifications, normalized)

--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -147,6 +147,12 @@ type ActionLoadNotifications struct {
 
 func (a ActionLoadNotifications) Type() string { return "load_notifications" }
 
+type ActionLoadBatchReconciliation struct {
+	Generation uint64
+}
+
+func (a ActionLoadBatchReconciliation) Type() string { return "load_batch_reconciliation" }
+
 type ActionUpdateRateLimit struct {
 	Info models.RateLimitInfo
 }

--- a/internal/tui/actions_types.go
+++ b/internal/tui/actions_types.go
@@ -80,6 +80,12 @@ type ActionSetHandled struct {
 
 func (a ActionSetHandled) Type() string { return "set_handled" }
 
+type ActionApplyNotificationBatch struct {
+	Request types.NotificationBatchRequest
+}
+
+func (a ActionApplyNotificationBatch) Type() string { return "apply_notification_batch" }
+
 type ActionArchive struct {
 	ID string
 }

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -11,10 +11,11 @@ import (
 )
 
 type RenderContext struct {
-	Styles     Styles
-	Width      int
-	IsFetching bool
-	IsSelected bool
+	Styles          Styles
+	Width           int
+	IsFetching      bool
+	IsSelected      bool
+	IsMultiSelected bool
 }
 
 // RenderNotificationRow provides a consistent, high-density Repo-First row layout.
@@ -58,7 +59,7 @@ func RenderNotificationRow(ctx RenderContext, n triage.NotificationWithState) st
 	titleWidth := flexibleSpace - repoWidth
 
 	// 3. Prepare cells with fixed widths and strict truncation
-	indicator := renderSelectionIndicator(ctx.Styles, ctx.IsSelected)
+	indicator := renderSelectionIndicator(ctx.Styles, ctx.IsSelected, ctx.IsMultiSelected)
 	icon := renderNotificationIcon(n.SubjectType)
 	unread := renderUnreadIndicator(ctx.Styles, n.IsReadLocally)
 	indicatorCell := renderCell(indicator+icon+unread, indicatorCellWidth, false)
@@ -162,11 +163,16 @@ func renderUnreadIndicator(styles Styles, isRead bool) string {
 	return styles.Unread.Render("• ")
 }
 
-func renderSelectionIndicator(styles Styles, isSelected bool) string {
+func renderSelectionIndicator(styles Styles, isSelected, isMultiSelected bool) string {
+	cursor := " "
 	if isSelected {
-		return styles.Cursor.Render("▌ ")
+		cursor = styles.Cursor.Render("▌")
 	}
-	return "  "
+	membership := " "
+	if isMultiSelected {
+		membership = styles.Assign.Render("✓")
+	}
+	return cursor + membership
 }
 
 func renderNotificationIcon(subjectType triage.SubjectType) string {

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -21,13 +21,14 @@ func (i item) FilterValue() string {
 }
 
 type itemDelegate struct {
-	styles     Styles
-	keys       KeyMap
-	IsFetching bool
+	styles      Styles
+	keys        KeyMap
+	IsFetching  bool
+	SelectedIDs map[string]struct{}
 }
 
-func newItemDelegate(s Styles, k KeyMap) itemDelegate {
-	return itemDelegate{styles: s, keys: k}
+func newItemDelegate(s Styles, k KeyMap, selectedIDs map[string]struct{}) itemDelegate {
+	return itemDelegate{styles: s, keys: k, SelectedIDs: selectedIDs}
 }
 
 func (d itemDelegate) Height() int                               { return 1 }
@@ -57,6 +58,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		IsFetching: isSelected && d.IsFetching,
 		IsSelected: isSelected,
 	}
+	_, ctx.IsMultiSelected = d.SelectedIDs[i.notification.GitHubID]
 	str := RenderNotificationRow(ctx, i.notification)
 
 	_, _ = fmt.Fprint(w, str)

--- a/internal/tui/guards_test.go
+++ b/internal/tui/guards_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/hirakiuc/gh-orbit/internal/api"
 	"github.com/hirakiuc/gh-orbit/internal/config"
 	"github.com/hirakiuc/gh-orbit/internal/mocks"
@@ -85,6 +86,50 @@ func TestModel_NewTaskContext_UsesTaskRootCancellation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected scoped task context to be canceled when task root is canceled")
 	}
+}
+
+func TestModel_SubmitBackendTaskSupersedesAndCleansUpScope(t *testing.T) {
+	m := newTestModel(t)
+	firstStarted := make(chan context.Context, 1)
+	firstDone := make(chan tea.Msg, 1)
+	first := m.submitBackendTask("notification-batch", 0, func(ctx context.Context) any {
+		firstStarted <- ctx
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	go func() { firstDone <- first() }()
+	firstCtx := <-firstStarted
+
+	second := m.submitBackendTask("notification-batch", 0, func(ctx context.Context) any {
+		return ctx.Err()
+	})
+	assert.Nil(t, second())
+	assert.Equal(t, context.Canceled, <-firstDone)
+	assert.ErrorIs(t, firstCtx.Err(), context.Canceled)
+
+	m.taskCancelMu.Lock()
+	assert.Empty(t, m.taskCancels)
+	m.taskCancelMu.Unlock()
+}
+
+func TestModel_SubmitBackendTaskHonorsTaskRootCancellation(t *testing.T) {
+	taskRoot, cancel := context.WithCancel(context.Background())
+	m := newTestModelWithTaskRoot(t, taskRoot)
+	started := make(chan struct{})
+	done := make(chan tea.Msg, 1)
+	cmd := m.submitBackendTask("notification-batch", 0, func(ctx context.Context) any {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	go func() { done <- cmd() }()
+	<-started
+	cancel()
+	assert.Equal(t, context.Canceled, <-done)
+
+	m.taskCancelMu.Lock()
+	assert.Empty(t, m.taskCancels)
+	m.taskCancelMu.Unlock()
 }
 
 func TestModel_Shutdown_ConnectedModeAllowsNilTraffic(t *testing.T) {

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -41,6 +41,8 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 		return i.model.MarkReadByID(a.ID, a.Read)
 	case ActionSetHandled:
 		return i.model.SetHandledByID(a.ID, a.Handled, a.PreviousIndex)
+	case ActionApplyNotificationBatch:
+		return i.model.ApplyNotificationBatch(a.Request)
 	case ActionSetPriority:
 		return i.model.setPriorityByID(a.ID, a.Priority)
 	case ActionViewWeb:

--- a/internal/tui/interpreter.go
+++ b/internal/tui/interpreter.go
@@ -59,6 +59,8 @@ func (i *Interpreter) Execute(action Action) tea.Cmd {
 		return i.model.FetchDetailCmd(a.ID, a.URL, a.SubjectType, a.Force)
 	case ActionLoadNotifications:
 		return i.model.loadNotifications(a.IsInitial, a.IsForced, a.IsManual)
+	case ActionLoadBatchReconciliation:
+		return i.model.loadBatchReconciliation(a.Generation)
 	case ActionUpdateRateLimit:
 		return func() tea.Msg {
 			i.model.RateLimit = a.Info

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -17,6 +17,12 @@ type KeyMap struct {
 	CopyURL              key.Binding
 	ToggleRead           key.Binding
 	ToggleHandled        key.Binding
+	SelectionMode        key.Binding
+	SelectNotification   key.Binding
+	BatchRead            key.Binding
+	BatchUnread          key.Binding
+	BatchHandled         key.Binding
+	BatchUnhandled       key.Binding
 	NextTab              key.Binding
 	PrevTab              key.Binding
 	CheckoutPR           key.Binding
@@ -36,6 +42,13 @@ type KeyMap struct {
 func NewKeyMap(cfg *config.Config) KeyMap {
 	k := cfg.Keys
 	handledKeys := availableHandledKeys(k)
+	used := establishedKeySet(k)
+	selectionModeKeys := availableKeys(k.SelectionMode, used)
+	selectNotificationKeys := availableKeys(k.SelectNotification, used)
+	batchReadKeys := availableKeys(k.BatchRead, used)
+	batchUnreadKeys := availableKeys(k.BatchUnread, used)
+	batchHandledKeys := availableKeys(k.BatchHandled, used)
+	batchUnhandledKeys := availableKeys(k.BatchUnhandled, used)
 	return KeyMap{
 		Sync: key.NewBinding(
 			key.WithKeys(k.Sync...),
@@ -73,7 +86,13 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 			key.WithKeys(k.ToggleRead...),
 			key.WithHelp(k.ToggleRead[0], "mark read/unread"),
 		),
-		ToggleHandled: optionalBinding(handledKeys, "mark handled/unhandled"),
+		ToggleHandled:      optionalBinding(handledKeys, "mark handled/unhandled"),
+		SelectionMode:      optionalBinding(selectionModeKeys, "selection mode"),
+		SelectNotification: optionalBinding(selectNotificationKeys, "select notification"),
+		BatchRead:          optionalBinding(batchReadKeys, "mark selected read"),
+		BatchUnread:        optionalBinding(batchUnreadKeys, "mark selected unread"),
+		BatchHandled:       optionalBinding(batchHandledKeys, "mark selected handled"),
+		BatchUnhandled:     optionalBinding(batchUnhandledKeys, "mark selected unhandled"),
 		NextTab: key.NewBinding(
 			key.WithKeys(k.NextTab...),
 			key.WithHelp(k.NextTab[0], "next tab"),
@@ -130,6 +149,11 @@ func NewKeyMap(cfg *config.Config) KeyMap {
 }
 
 func availableHandledKeys(keys config.KeyMapConfig) []string {
+	used := establishedKeySet(keys)
+	return availableKeys(keys.ToggleHandled, used)
+}
+
+func establishedKeySet(keys config.KeyMapConfig) map[string]struct{} {
 	used := make(map[string]struct{})
 	existing := [][]string{
 		keys.Sync, keys.PriorityUp, keys.PriorityDown, keys.PriorityNone,
@@ -144,8 +168,12 @@ func availableHandledKeys(keys config.KeyMapConfig) []string {
 			used[binding] = struct{}{}
 		}
 	}
-	filtered := make([]string, 0, len(keys.ToggleHandled))
-	for _, binding := range keys.ToggleHandled {
+	return used
+}
+
+func availableKeys(bindings []string, used map[string]struct{}) []string {
+	filtered := make([]string, 0, len(bindings))
+	for _, binding := range bindings {
 		if _, collision := used[binding]; !collision {
 			filtered = append(filtered, binding)
 		}
@@ -168,6 +196,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help,
 		k.Sync,
+		k.SelectionMode,
 		k.ToggleRead,
 		k.ToggleHandled,
 		k.ToggleDetail,
@@ -180,6 +209,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Sync, k.CopyURL, k.OpenBrowser, k.ViewContextual},
 		{k.ToggleRead, k.ToggleHandled, k.ToggleDetail, k.Back, k.FilterPR, k.FilterIssue, k.FilterDiscussion},
+		{k.SelectionMode, k.SelectNotification, k.BatchRead, k.BatchUnread, k.BatchHandled, k.BatchUnhandled},
 		{k.PriorityUp, k.PriorityDown, k.PriorityNone},
 		{k.Tab1, k.Tab2, k.Tab3},
 		{k.NextTab, k.PrevTab, k.CheckoutPR, k.StartReviewWorkspace, k.Help, k.Quit},

--- a/internal/tui/keymap_test.go
+++ b/internal/tui/keymap_test.go
@@ -31,3 +31,16 @@ func TestKeyMap_HandledBindingHelpAndDisablement(t *testing.T) {
 	fullyCollided := NewKeyMap(cfg)
 	assert.False(t, fullyCollided.ToggleHandled.Enabled())
 }
+
+func TestKeyMap_BatchBindingsRespectEstablishedCollisions(t *testing.T) {
+	cfg := config.DefaultConfig()
+	keys := NewKeyMap(cfg)
+	assert.True(t, keys.SelectionMode.Enabled())
+	assert.True(t, keys.SelectNotification.Enabled())
+	assert.True(t, keys.BatchRead.Enabled())
+	assert.Contains(t, keys.FullHelp()[2], keys.BatchHandled)
+
+	cfg.Keys.SelectionMode = []string{"m"}
+	collided := NewKeyMap(cfg)
+	assert.False(t, collided.SelectionMode.Enabled(), "existing scalar binding must win")
+}

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -923,14 +923,16 @@ func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
 
 		// A generic load queued before the batch result is not causal proof of
 		// post-mutation state and must leave recovery pending.
-		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
 		assert.True(t, m.batchRefreshPending)
+		assert.Contains(t, actions, ActionLoadBatchReconciliation{Generation: generation})
 		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation - 1})
 		assert.True(t, m.batchRefreshPending)
 
-		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
+		actions = m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
 		assert.False(t, m.batchRefreshPending)
 		assert.Contains(t, m.selectedIDs, "a")
+		assert.NotContains(t, actions, ActionLoadBatchReconciliation{Generation: generation})
 	})
 
 	t.Run("commit unknown", func(t *testing.T) {
@@ -948,15 +950,17 @@ func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
 		assert.True(t, m.batchRecovery.awaitingAuthoritative)
 		assert.True(t, m.batchUncertain)
 
-		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
 		assert.True(t, m.batchUncertain, "an older generic load cannot complete recovery")
 		assert.True(t, m.batchRecovery.awaitingAuthoritative)
+		assert.Contains(t, actions, ActionLoadBatchReconciliation{Generation: generation}, "a later reload must keep recovery live")
 
-		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
+		actions = m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
 		assert.False(t, m.batchUncertain)
 		assert.False(t, m.batchRecovery.awaitingAuthoritative)
 		assert.Equal(t, request, m.pendingBatchRequest)
 		assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, m.selectedIDs)
+		assert.NotContains(t, actions, ActionLoadBatchReconciliation{Generation: generation})
 
 		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications, IsManual: true})
 		assert.Equal(t, request, m.pendingBatchRequest)

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -885,6 +885,70 @@ func TestModel_HandleBatchMutationAppliedRetainsFailedIDsAndReloadsUnknown(t *te
 	assert.True(t, m.batchUncertain)
 }
 
+func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
+	m := newTestModel(t)
+	notifications := []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "a"}},
+		{Notification: triage.Notification{GitHubID: "b"}},
+	}
+
+	t.Run("partial remote failure", func(t *testing.T) {
+		m.handleBatchMutationApplied(batchMutationAppliedMsg{result: types.NotificationBatchResult{
+			Status: types.NotificationBatchCommitted, Reconciliation: types.NotificationBatchAuthoritative,
+			Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}},
+			Outcomes: []types.NotificationBatchItemResult{
+				{ID: "a", Status: types.NotificationRemoteSucceeded},
+				{ID: "b", Status: types.NotificationRemoteFailed, ErrorCode: "remote_failed"},
+			}, Notifications: notifications,
+		}})
+		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		assert.Equal(t, map[string]struct{}{"b": {}}, m.selectedIDs)
+		assert.Equal(t, []string{"a", "b"}, m.pendingBatchRequest.IDs)
+
+		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications, IsForced: true})
+		assert.Equal(t, map[string]struct{}{"b": {}}, m.selectedIDs, "resource and reconnect reloads preserve the retry set")
+	})
+
+	t.Run("committed reconciliation pending", func(t *testing.T) {
+		m.clearSelection()
+		m.handleBatchMutationApplied(batchMutationAppliedMsg{result: types.NotificationBatchResult{
+			Status: types.NotificationBatchCommitted, Reconciliation: types.NotificationBatchReconciliationPending,
+			Request:       types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a"}},
+			Outcomes:      []types.NotificationBatchItemResult{{ID: "a", Status: types.NotificationRemoteFailed, ErrorCode: "remote_failed"}},
+			Notifications: notifications,
+		}})
+		assert.True(t, m.batchRefreshPending)
+		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		assert.False(t, m.batchRefreshPending)
+		assert.Contains(t, m.selectedIDs, "a")
+	})
+
+	t.Run("commit unknown", func(t *testing.T) {
+		m.clearSelection()
+		request := types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}}
+		m.handleBatchMutationApplied(batchMutationAppliedMsg{result: types.NotificationBatchResult{
+			Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
+			Request: request, Notifications: notifications,
+		}})
+		assert.True(t, m.batchUncertain)
+		assert.Equal(t, request, m.pendingBatchRequest)
+
+		// A failed load produces no notificationsLoadedMsg, so recovery remains.
+		assert.True(t, m.batchRecovery.awaitingAuthoritative)
+		assert.True(t, m.batchUncertain)
+
+		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		assert.False(t, m.batchUncertain)
+		assert.False(t, m.batchRecovery.awaitingAuthoritative)
+		assert.Equal(t, request, m.pendingBatchRequest)
+		assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, m.selectedIDs)
+
+		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications, IsManual: true})
+		assert.Equal(t, request, m.pendingBatchRequest)
+		assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, m.selectedIDs)
+	})
+}
+
 func TestModel_ApplyFilters_ActiveTriageTabs(t *testing.T) {
 	m := newTestModel(t)
 	m.config.Notifications.MaxVisibleAgeDays = 0

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -109,6 +109,7 @@ func TestInterpreter_Execute(t *testing.T) {
 		},
 		ActionEnrichItems{Notifications: []triage.NotificationWithState{notif}},
 		ActionLoadNotifications{IsInitial: true, IsManual: false},
+		ActionLoadBatchReconciliation{Generation: 1},
 		ActionUpdateRateLimit{Info: models.RateLimitInfo{Remaining: 100}},
 		ActionScheduleTick{TickType: TickHeartbeat, Interval: time.Millisecond},
 		ActionScheduleTick{TickType: TickClock, Interval: time.Millisecond},
@@ -881,7 +882,7 @@ func TestModel_HandleBatchMutationAppliedRetainsFailedIDsAndReloadsUnknown(t *te
 		Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
 		Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a"}},
 	}})
-	assert.Contains(t, actions, ActionLoadNotifications{})
+	assert.Contains(t, actions, ActionLoadBatchReconciliation{Generation: m.batchRecovery.generation})
 	assert.True(t, m.batchUncertain)
 }
 
@@ -918,7 +919,16 @@ func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
 			Notifications: notifications,
 		}})
 		assert.True(t, m.batchRefreshPending)
+		generation := m.batchRecovery.generation
+
+		// A generic load queued before the batch result is not causal proof of
+		// post-mutation state and must leave recovery pending.
 		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		assert.True(t, m.batchRefreshPending)
+		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation - 1})
+		assert.True(t, m.batchRefreshPending)
+
+		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
 		assert.False(t, m.batchRefreshPending)
 		assert.Contains(t, m.selectedIDs, "a")
 	})
@@ -932,12 +942,17 @@ func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
 		}})
 		assert.True(t, m.batchUncertain)
 		assert.Equal(t, request, m.pendingBatchRequest)
+		generation := m.batchRecovery.generation
 
 		// A failed load produces no notificationsLoadedMsg, so recovery remains.
 		assert.True(t, m.batchRecovery.awaitingAuthoritative)
 		assert.True(t, m.batchUncertain)
 
 		m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications})
+		assert.True(t, m.batchUncertain, "an older generic load cannot complete recovery")
+		assert.True(t, m.batchRecovery.awaitingAuthoritative)
+
+		m.handleBatchReconciliationLoaded(batchReconciliationLoadedMsg{notifications: notifications, generation: generation})
 		assert.False(t, m.batchUncertain)
 		assert.False(t, m.batchRecovery.awaitingAuthoritative)
 		assert.Equal(t, request, m.pendingBatchRequest)
@@ -947,6 +962,33 @@ func TestModel_BatchRecoverySurvivesAuthoritativeAndLaterReloads(t *testing.T) {
 		assert.Equal(t, request, m.pendingBatchRequest)
 		assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, m.selectedIDs)
 	})
+}
+
+func TestModel_BatchRecoveryMembershipEditsSurviveReload(t *testing.T) {
+	m := newTestModel(t)
+	notifications := []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "a", UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "b", UpdatedAt: time.Now()}},
+	}
+	m.allNotifications = notifications
+	m.applyFilters()
+	m.listView.list.Select(0)
+	m.setBatchRecovery(
+		types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}},
+		[]string{"a", "b"},
+		types.NotificationBatchCommitUnknown,
+		true,
+	)
+
+	actions, handled := m.handleSelectionKeys(keyPress("s"))
+	assert.True(t, handled)
+	assert.Empty(t, actions)
+	assert.Equal(t, []string{"b"}, m.batchRecovery.retryIDs)
+	assert.Equal(t, map[string]struct{}{"b": {}}, m.selectedIDs)
+
+	m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: notifications, IsForced: true})
+	assert.Equal(t, []string{"b"}, m.batchRecovery.retryIDs)
+	assert.Equal(t, map[string]struct{}{"b": {}}, m.selectedIDs, "reload must not undo the user's membership edit")
 }
 
 func TestModel_ApplyFilters_ActiveTriageTabs(t *testing.T) {

--- a/internal/tui/logic_test.go
+++ b/internal/tui/logic_test.go
@@ -831,6 +831,60 @@ func TestModel_Transition_Tabs(t *testing.T) {
 	assert.Equal(t, TabAll, m.listView.activeTab)
 }
 
+func TestModel_Transition_MultipleSelectionAndBatchAction(t *testing.T) {
+	m := newTestModel(t)
+	m.allNotifications = []triage.NotificationWithState{
+		{Notification: triage.Notification{GitHubID: "a", UpdatedAt: time.Now()}},
+		{Notification: triage.Notification{GitHubID: "b", UpdatedAt: time.Now()}},
+	}
+	m.listView.activeTab = TabAll
+	m.applyFilters()
+
+	assert.Empty(t, m.Transition(keyPress("S"), 0))
+	assert.True(t, m.selectionMode)
+	assert.Empty(t, m.Transition(keyPress("s"), 0))
+	assert.Contains(t, m.selectedIDs, "a")
+
+	actions := m.Transition(keyPress("R"), 0)
+	require.Len(t, actions, 1)
+	batch, ok := actions[0].(ActionApplyNotificationBatch)
+	require.True(t, ok)
+	assert.Equal(t, types.NotificationBatchRead, batch.Request.Operation)
+	assert.Equal(t, []string{"a"}, batch.Request.IDs)
+
+	_ = m.Transition(keyPress("tab"), 0)
+	assert.False(t, m.selectionMode)
+	assert.Empty(t, m.selectedIDs)
+}
+
+func TestModel_HandleBatchMutationAppliedRetainsFailedIDsAndReloadsUnknown(t *testing.T) {
+	m := newTestModel(t)
+	m.selectedIDs["a"] = struct{}{}
+	m.selectedIDs["b"] = struct{}{}
+	m.selectionMode = true
+	m.batchPending = true
+
+	actions := m.handleBatchMutationApplied(batchMutationAppliedMsg{result: types.NotificationBatchResult{
+		Status: types.NotificationBatchCommitted, Reconciliation: types.NotificationBatchAuthoritative,
+		Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a", "b"}},
+		Outcomes: []types.NotificationBatchItemResult{
+			{ID: "a", Status: types.NotificationRemoteSucceeded},
+			{ID: "b", Status: types.NotificationRemoteFailed},
+		},
+	}})
+	assert.False(t, m.batchPending)
+	assert.Equal(t, map[string]struct{}{"b": {}}, m.selectedIDs)
+	assert.True(t, m.selectionMode)
+	assert.NotEmpty(t, actions)
+
+	actions = m.handleBatchMutationApplied(batchMutationAppliedMsg{result: types.NotificationBatchResult{
+		Status: types.NotificationBatchCommitUnknown, Reconciliation: types.NotificationBatchReconciliationPending,
+		Request: types.NotificationBatchRequest{Operation: types.NotificationBatchRead, IDs: []string{"a"}},
+	}})
+	assert.Contains(t, actions, ActionLoadNotifications{})
+	assert.True(t, m.batchUncertain)
+}
+
 func TestModel_ApplyFilters_ActiveTriageTabs(t *testing.T) {
 	m := newTestModel(t)
 	m.config.Notifications.MaxVisibleAgeDays = 0

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -76,6 +76,7 @@ type Model struct {
 	batchUncertain      bool
 	batchRefreshPending bool
 	pendingBatchRequest types.NotificationBatchRequest
+	batchRecovery       *batchRecoveryState
 	err                 error
 	state               AppState
 	isDark              bool
@@ -121,6 +122,13 @@ type Model struct {
 type scopedTaskCancel struct {
 	id     uint64
 	cancel context.CancelFunc
+}
+
+type batchRecoveryState struct {
+	request               types.NotificationBatchRequest
+	retryIDs              []string
+	status                types.NotificationBatchStatus
+	awaitingAuthoritative bool
 }
 
 // Option defines a functional option for Model configuration.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -77,6 +77,7 @@ type Model struct {
 	batchRefreshPending bool
 	pendingBatchRequest types.NotificationBatchRequest
 	batchRecovery       *batchRecoveryState
+	batchRecoverySeq    uint64
 	err                 error
 	state               AppState
 	isDark              bool
@@ -129,6 +130,7 @@ type batchRecoveryState struct {
 	retryIDs              []string
 	status                types.NotificationBatchStatus
 	awaitingAuthoritative bool
+	generation            uint64
 }
 
 // Option defines a functional option for Model configuration.
@@ -409,6 +411,16 @@ func (m *Model) loadNotifications(isInitial bool, isForced bool, isManual bool) 
 	})
 }
 
+func (m *Model) loadBatchReconciliation(generation uint64) tea.Cmd {
+	return m.submitTask("notification-batch:reconcile", 0, api.PrioritySync, func(ctx context.Context) any {
+		notifications, err := m.backend.ListNotifications(ctx)
+		if err != nil {
+			return types.ErrMsg{Err: err}
+		}
+		return batchReconciliationLoadedMsg{notifications: notifications, generation: generation}
+	})
+}
+
 func (m *Model) syncNotificationsWithForce(force bool, isManual bool) tea.Cmd {
 	return m.submitTask("notifications:sync", types.ConnectedSyncTimeout, api.PrioritySync, func(ctx context.Context) any {
 		rl, err := m.backend.Sync(ctx, force)
@@ -442,6 +454,11 @@ type notificationsLoadedMsg struct {
 	IsInitial     bool
 	IsForced      bool
 	IsManual      bool
+}
+
+type batchReconciliationLoadedMsg struct {
+	notifications []triage.NotificationWithState
+	generation    uint64
 }
 
 type mutationAppliedMsg struct {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -57,30 +57,36 @@ type Model struct {
 	detailView DetailModel
 
 	// Shared State & Services (Interfaces)
-	backend          types.TUIBackend
-	traffic          types.TrafficController
-	alerter          api.Alerter
-	ui               UIController
-	config           *config.Config
-	logger           *slog.Logger
-	userID           string
-	version          string
-	styles           Styles
-	keys             KeyMap
-	help             *help.Model
-	showHelp         bool
-	allNotifications []triage.NotificationWithState
-	err              error
-	state            AppState
-	isDark           bool
-	markdownRenderer *glamour.TermRenderer
-	width            int
-	height           int
-	headerHeight     int
-	footerHeight     int
-	bridgeStatus     types.BridgeStatus
-	focusMode        string
-	interpreter      *Interpreter
+	backend             types.TUIBackend
+	traffic             types.TrafficController
+	alerter             api.Alerter
+	ui                  UIController
+	config              *config.Config
+	logger              *slog.Logger
+	userID              string
+	version             string
+	styles              Styles
+	keys                KeyMap
+	help                *help.Model
+	showHelp            bool
+	allNotifications    []triage.NotificationWithState
+	selectionMode       bool
+	selectedIDs         map[string]struct{}
+	batchPending        bool
+	batchUncertain      bool
+	batchRefreshPending bool
+	pendingBatchRequest types.NotificationBatchRequest
+	err                 error
+	state               AppState
+	isDark              bool
+	markdownRenderer    *glamour.TermRenderer
+	width               int
+	height              int
+	headerHeight        int
+	footerHeight        int
+	bridgeStatus        types.BridgeStatus
+	focusMode           string
+	interpreter         *Interpreter
 
 	// Connection Mode
 	ConnectionMode string // "Standalone" or "Connected"
@@ -192,7 +198,8 @@ func NewModel(p ModelParams) (*Model, error) {
 
 	styles := DefaultStyles(true)
 	keys := NewKeyMap(p.Config)
-	delegate := newItemDelegate(styles, keys)
+	selectedIDs := make(map[string]struct{})
+	delegate := newItemDelegate(styles, keys, selectedIDs)
 
 	l := list.New([]list.Item{}, delegate, 0, 0)
 	l.Title = "GitHub Orbit"
@@ -226,6 +233,7 @@ func NewModel(p ModelParams) (*Model, error) {
 		styles:       styles,
 		keys:         keys,
 		help:         &h,
+		selectedIDs:  selectedIDs,
 		state:        StateList,
 		PollInterval: p.Config.Notifications.SyncInterval,
 		// Default intervals
@@ -321,6 +329,14 @@ func (m *Model) submitTask(scope string, timeout time.Duration, priority int, fn
 			return types.ErrMsg{Err: err}
 		}
 		return <-resChan
+	}
+}
+
+func (m *Model) submitBackendTask(scope string, timeout time.Duration, fn types.TaskFunc) tea.Cmd {
+	return func() tea.Msg {
+		ctx, release := m.newTaskContext(scope, timeout)
+		defer release()
+		return fn(ctx)
 	}
 }
 
@@ -427,6 +443,11 @@ type mutationAppliedMsg struct {
 	targetID      string
 	previousIndex int
 	reconcileItem bool
+}
+
+type batchMutationAppliedMsg struct {
+	result types.NotificationBatchResult
+	before []triage.NotificationWithState
 }
 
 type reviewWorkspaceStartedMsg struct {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -542,12 +542,12 @@ func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
 }
 
 func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
-	if !m.batchPending {
-		m.clearSelection()
-		m.batchUncertain = false
-		m.batchRefreshPending = false
-	}
 	m.allNotifications = msg.notifications
+	if m.batchRecovery != nil {
+		m.reconcileBatchRecoveryAfterLoad()
+	} else if !m.batchPending {
+		m.clearSelection()
+	}
 	// Clear inflight on full reload to avoid stale blocks
 	m.inflightEnrichments = make(map[string]time.Time)
 	m.applyFilters()
@@ -619,33 +619,33 @@ func (m *Model) handleMutationApplied(msg mutationAppliedMsg) []Action {
 
 func (m *Model) handleBatchMutationApplied(msg batchMutationAppliedMsg) []Action {
 	m.batchPending = false
-	m.pendingBatchRequest = types.NotificationBatchRequest{}
 	m.err = msg.result.Err
 	m.batchUncertain = msg.result.Status == types.NotificationBatchCommitUnknown
 	m.batchRefreshPending = msg.result.Reconciliation == types.NotificationBatchReconciliationPending
 
 	switch msg.result.Status {
 	case types.NotificationBatchRejected:
+		m.clearBatchRecovery()
 		m.allNotifications = msg.before
 	case types.NotificationBatchCommitted:
 		m.allNotifications = msg.result.Notifications
-		clear(m.selectedIDs)
+		retryIDs := make([]string, 0, len(msg.result.Outcomes))
 		for _, outcome := range msg.result.Outcomes {
 			switch outcome.Status {
 			case types.NotificationRemoteFailed, types.NotificationRemoteCanceled, types.NotificationRemoteNotAttempted:
-				m.selectedIDs[outcome.ID] = struct{}{}
+				retryIDs = append(retryIDs, outcome.ID)
 			}
 		}
-		m.selectionMode = len(m.selectedIDs) > 0
+		if len(retryIDs) > 0 || m.batchRefreshPending {
+			m.setBatchRecovery(msg.result.Request, retryIDs, msg.result.Status, m.batchRefreshPending)
+		} else {
+			m.clearBatchRecovery()
+		}
 	case types.NotificationBatchCommitUnknown:
 		if msg.result.Notifications != nil {
 			m.allNotifications = msg.result.Notifications
 		}
-		m.selectionMode = true
-		clear(m.selectedIDs)
-		for _, id := range msg.result.Request.IDs {
-			m.selectedIDs[id] = struct{}{}
-		}
+		m.setBatchRecovery(msg.result.Request, msg.result.Request.IDs, msg.result.Status, true)
 	}
 	m.applyFilters()
 
@@ -840,6 +840,53 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 func (m *Model) clearSelection() {
 	m.selectionMode = false
 	clear(m.selectedIDs)
+	if !m.batchPending {
+		m.clearBatchRecovery()
+	}
+}
+
+func (m *Model) setBatchRecovery(request types.NotificationBatchRequest, retryIDs []string, status types.NotificationBatchStatus, awaiting bool) {
+	request.IDs = append([]string(nil), request.IDs...)
+	retryIDs = append([]string(nil), retryIDs...)
+	m.pendingBatchRequest = request
+	m.batchRecovery = &batchRecoveryState{
+		request: request, retryIDs: retryIDs, status: status, awaitingAuthoritative: awaiting,
+	}
+	m.restoreBatchRecoverySelection()
+}
+
+func (m *Model) restoreBatchRecoverySelection() {
+	clear(m.selectedIDs)
+	if m.batchRecovery == nil {
+		m.selectionMode = false
+		return
+	}
+	m.pendingBatchRequest = m.batchRecovery.request
+	m.pendingBatchRequest.IDs = append([]string(nil), m.batchRecovery.request.IDs...)
+	for _, id := range m.batchRecovery.retryIDs {
+		m.selectedIDs[id] = struct{}{}
+	}
+	m.selectionMode = len(m.selectedIDs) > 0
+}
+
+func (m *Model) reconcileBatchRecoveryAfterLoad() {
+	if m.batchRecovery.awaitingAuthoritative {
+		m.batchRecovery.awaitingAuthoritative = false
+		m.batchUncertain = false
+		m.batchRefreshPending = false
+	}
+	if m.batchRecovery.status == types.NotificationBatchCommitted && len(m.batchRecovery.retryIDs) == 0 {
+		m.clearBatchRecovery()
+		return
+	}
+	m.restoreBatchRecoverySelection()
+}
+
+func (m *Model) clearBatchRecovery() {
+	m.batchRecovery = nil
+	m.pendingBatchRequest = types.NotificationBatchRequest{}
+	m.batchUncertain = false
+	m.batchRefreshPending = false
 }
 
 func (m *Model) handleSelectionKeys(msg tea.KeyMsg) ([]Action, bool) {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -585,16 +585,25 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 		actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
 	}
 
-	return actions
+	return m.appendBatchReconciliationRetry(actions)
 }
 
 func (m *Model) handleBatchReconciliationLoaded(msg batchReconciliationLoadedMsg) []Action {
 	if m.batchRecovery == nil || msg.generation != m.batchRecovery.generation || !m.batchRecovery.awaitingAuthoritative {
 		return nil
 	}
-	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: msg.notifications})
+	// Apply the correlated snapshot before clearing uncertainty. Reconciling
+	// first also prevents the common load path from scheduling a redundant retry.
+	m.allNotifications = msg.notifications
 	m.reconcileBatchRecoveryAfterLoad()
-	return actions
+	return m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: msg.notifications})
+}
+
+func (m *Model) appendBatchReconciliationRetry(actions []Action) []Action {
+	if m.batchRecovery == nil || !m.batchRecovery.awaitingAuthoritative {
+		return actions
+	}
+	return append(actions, ActionLoadBatchReconciliation{Generation: m.batchRecovery.generation})
 }
 
 func (m *Model) filterSelectedDetailRefreshCandidate(notifications []triage.NotificationWithState) []triage.NotificationWithState {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -101,6 +102,8 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		m.handleBackgroundColor(msg)
 	case notificationsLoadedMsg:
 		return m.handleNotificationsLoaded(msg)
+	case batchReconciliationLoadedMsg:
+		return m.handleBatchReconciliationLoaded(msg)
 	case mutationAppliedMsg:
 		return m.handleMutationApplied(msg)
 	case batchMutationAppliedMsg:
@@ -544,7 +547,7 @@ func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
 func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 	m.allNotifications = msg.notifications
 	if m.batchRecovery != nil {
-		m.reconcileBatchRecoveryAfterLoad()
+		m.restoreBatchRecoverySelection()
 	} else if !m.batchPending {
 		m.clearSelection()
 	}
@@ -582,6 +585,15 @@ func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
 		actions = append(actions, ActionScheduleTick{TickType: TickHeartbeat, Interval: m.heartbeatInterval})
 	}
 
+	return actions
+}
+
+func (m *Model) handleBatchReconciliationLoaded(msg batchReconciliationLoadedMsg) []Action {
+	if m.batchRecovery == nil || msg.generation != m.batchRecovery.generation || !m.batchRecovery.awaitingAuthoritative {
+		return nil
+	}
+	actions := m.handleNotificationsLoaded(notificationsLoadedMsg{notifications: msg.notifications})
+	m.reconcileBatchRecoveryAfterLoad()
 	return actions
 }
 
@@ -667,8 +679,8 @@ func (m *Model) handleBatchMutationApplied(msg batchMutationAppliedMsg) []Action
 		}
 	}
 	actions := []Action{ActionShowToast{Message: toast}}
-	if m.batchUncertain || m.batchRefreshPending {
-		actions = append(actions, ActionLoadNotifications{})
+	if (m.batchUncertain || m.batchRefreshPending) && m.batchRecovery != nil {
+		actions = append(actions, ActionLoadBatchReconciliation{Generation: m.batchRecovery.generation})
 	}
 	return actions
 }
@@ -848,11 +860,28 @@ func (m *Model) clearSelection() {
 func (m *Model) setBatchRecovery(request types.NotificationBatchRequest, retryIDs []string, status types.NotificationBatchStatus, awaiting bool) {
 	request.IDs = append([]string(nil), request.IDs...)
 	retryIDs = append([]string(nil), retryIDs...)
+	m.batchRecoverySeq++
 	m.pendingBatchRequest = request
 	m.batchRecovery = &batchRecoveryState{
 		request: request, retryIDs: retryIDs, status: status, awaitingAuthoritative: awaiting,
+		generation: m.batchRecoverySeq,
 	}
 	m.restoreBatchRecoverySelection()
+}
+
+func (m *Model) syncBatchRecoveryRetryIDs() {
+	if m.batchRecovery == nil {
+		return
+	}
+	retryIDs := make([]string, 0, len(m.selectedIDs))
+	for id := range m.selectedIDs {
+		retryIDs = append(retryIDs, id)
+	}
+	sort.Strings(retryIDs)
+	m.batchRecovery.retryIDs = retryIDs
+	if len(retryIDs) == 0 && m.batchRecovery.status == types.NotificationBatchCommitted && !m.batchRecovery.awaitingAuthoritative {
+		m.clearBatchRecovery()
+	}
 }
 
 func (m *Model) restoreBatchRecoverySelection() {
@@ -920,6 +949,7 @@ func (m *Model) handleSelectionKeys(msg tea.KeyMsg) ([]Action, bool) {
 				m.selectedIDs[notification.GitHubID] = struct{}{}
 			}
 		}
+		m.syncBatchRecoveryRetryIDs()
 		return []Action{}, true
 	case key.Matches(msg, m.keys.BatchRead):
 		return m.notificationBatchAction(types.NotificationBatchRead), true

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -75,9 +76,13 @@ func (m *Model) updateDetailStateMsg(msg tea.Msg) []tea.Cmd {
 
 func (m *Model) updateListStateMsg(msg tea.Msg, oldIndex int) []tea.Cmd {
 	oldPage := m.listView.list.Paginator.Page
+	oldFilter := m.listView.list.FilterValue()
 	var cmd tea.Cmd
 	m.listView.list, cmd = m.listView.list.Update(msg)
 	cmds := []tea.Cmd{cmd}
+	if m.listView.list.FilterValue() != oldFilter {
+		m.clearSelection()
+	}
 
 	// Debounced enrichment logic (after sub-model update ensures index/page is fresh)
 	if m.listView.list.Index() != oldIndex || m.listView.list.Paginator.Page != oldPage {
@@ -98,6 +103,8 @@ func (m *Model) transitionGlobal(msg tea.Msg) []Action {
 		return m.handleNotificationsLoaded(msg)
 	case mutationAppliedMsg:
 		return m.handleMutationApplied(msg)
+	case batchMutationAppliedMsg:
+		return m.handleBatchMutationApplied(msg)
 	case reviewWorkspaceStartedMsg:
 		return m.handleReviewWorkspaceStarted(msg)
 	case syncCompleteMsg:
@@ -528,13 +535,18 @@ func (m *Model) handleBackgroundColor(msg tea.BackgroundColorMsg) {
 	m.styles = DefaultStyles(m.isDark)
 	m.keys = NewKeyMap(m.config)
 	m.listView.list.Styles.Title = m.styles.Title
-	m.listView.delegate = newItemDelegate(m.styles, m.keys)
+	m.listView.delegate = newItemDelegate(m.styles, m.keys, m.selectedIDs)
 	m.listView.list.SetDelegate(m.listView.delegate)
 	m.updateMarkdownRenderer()
 	m.ui.SetStyles(m.styles)
 }
 
 func (m *Model) handleNotificationsLoaded(msg notificationsLoadedMsg) []Action {
+	if !m.batchPending {
+		m.clearSelection()
+		m.batchUncertain = false
+		m.batchRefreshPending = false
+	}
 	m.allNotifications = msg.notifications
 	// Clear inflight on full reload to avoid stale blocks
 	m.inflightEnrichments = make(map[string]time.Time)
@@ -603,6 +615,62 @@ func (m *Model) handleMutationApplied(msg mutationAppliedMsg) []Action {
 		return nil
 	}
 	return []Action{ActionShowToast{Message: msg.toast}}
+}
+
+func (m *Model) handleBatchMutationApplied(msg batchMutationAppliedMsg) []Action {
+	m.batchPending = false
+	m.pendingBatchRequest = types.NotificationBatchRequest{}
+	m.err = msg.result.Err
+	m.batchUncertain = msg.result.Status == types.NotificationBatchCommitUnknown
+	m.batchRefreshPending = msg.result.Reconciliation == types.NotificationBatchReconciliationPending
+
+	switch msg.result.Status {
+	case types.NotificationBatchRejected:
+		m.allNotifications = msg.before
+	case types.NotificationBatchCommitted:
+		m.allNotifications = msg.result.Notifications
+		clear(m.selectedIDs)
+		for _, outcome := range msg.result.Outcomes {
+			switch outcome.Status {
+			case types.NotificationRemoteFailed, types.NotificationRemoteCanceled, types.NotificationRemoteNotAttempted:
+				m.selectedIDs[outcome.ID] = struct{}{}
+			}
+		}
+		m.selectionMode = len(m.selectedIDs) > 0
+	case types.NotificationBatchCommitUnknown:
+		if msg.result.Notifications != nil {
+			m.allNotifications = msg.result.Notifications
+		}
+		m.selectionMode = true
+		clear(m.selectedIDs)
+		for _, id := range msg.result.Request.IDs {
+			m.selectedIDs[id] = struct{}{}
+		}
+	}
+	m.applyFilters()
+
+	toast := msg.result.Toast
+	if toast == "" {
+		switch msg.result.Status {
+		case types.NotificationBatchRejected:
+			toast = "Batch update failed"
+		case types.NotificationBatchCommitUnknown:
+			toast = "Batch outcome unknown; refreshing"
+		default:
+			if m.batchRefreshPending {
+				toast = "Batch committed; refresh pending"
+			} else if len(m.selectedIDs) > 0 {
+				toast = fmt.Sprintf("Batch committed; %d remote updates need retry", len(m.selectedIDs))
+			} else {
+				toast = "Batch update complete"
+			}
+		}
+	}
+	actions := []Action{ActionShowToast{Message: toast}}
+	if m.batchUncertain || m.batchRefreshPending {
+		actions = append(actions, ActionLoadNotifications{})
+	}
+	return actions
 }
 
 func (m *Model) handleReviewWorkspaceStarted(msg reviewWorkspaceStartedMsg) []Action {
@@ -750,6 +818,9 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 	if msg.String() == "ctrl+c" {
 		return []Action{ActionQuit{}}
 	}
+	if actions, handled := m.handleSelectionKeys(msg); handled {
+		return actions
+	}
 
 	if actions := m.handleNavigationKeys(msg); actions != nil {
 		return actions
@@ -764,6 +835,72 @@ func (m *Model) handleListKey(msg tea.KeyMsg) []Action {
 	}
 
 	return m.handlePriorityKeys(msg)
+}
+
+func (m *Model) clearSelection() {
+	m.selectionMode = false
+	clear(m.selectedIDs)
+}
+
+func (m *Model) handleSelectionKeys(msg tea.KeyMsg) ([]Action, bool) {
+	if key.Matches(msg, m.keys.SelectionMode) {
+		if m.batchPending {
+			return []Action{ActionShowToast{Message: "Batch update already in progress"}}, true
+		}
+		if m.selectionMode {
+			m.clearSelection()
+		} else {
+			m.selectionMode = true
+		}
+		return []Action{}, true
+	}
+	if !m.selectionMode {
+		return nil, false
+	}
+	if m.batchPending {
+		return []Action{ActionShowToast{Message: "Batch update already in progress"}}, true
+	}
+
+	switch {
+	case key.Matches(msg, m.keys.Back):
+		m.clearSelection()
+		return []Action{}, true
+	case key.Matches(msg, m.keys.SelectNotification):
+		if notification, ok := m.selectedNotification(); ok {
+			if _, selected := m.selectedIDs[notification.GitHubID]; selected {
+				delete(m.selectedIDs, notification.GitHubID)
+			} else {
+				m.selectedIDs[notification.GitHubID] = struct{}{}
+			}
+		}
+		return []Action{}, true
+	case key.Matches(msg, m.keys.BatchRead):
+		return m.notificationBatchAction(types.NotificationBatchRead), true
+	case key.Matches(msg, m.keys.BatchUnread):
+		return m.notificationBatchAction(types.NotificationBatchUnread), true
+	case key.Matches(msg, m.keys.BatchHandled):
+		return m.notificationBatchAction(types.NotificationBatchHandled), true
+	case key.Matches(msg, m.keys.BatchUnhandled):
+		return m.notificationBatchAction(types.NotificationBatchUnhandled), true
+	case key.Matches(msg, m.keys.NextTab), key.Matches(msg, m.keys.PrevTab),
+		key.Matches(msg, m.keys.Tab1), key.Matches(msg, m.keys.Tab2), key.Matches(msg, m.keys.Tab3),
+		key.Matches(msg, m.keys.FilterPR), key.Matches(msg, m.keys.FilterIssue), key.Matches(msg, m.keys.FilterDiscussion),
+		key.Matches(msg, m.keys.ToggleDetail):
+		m.clearSelection()
+		return nil, false
+	default:
+		// Leave unbound navigation to the Bubbles list while suppressing
+		// scalar actions during selection mode.
+		return nil, true
+	}
+}
+
+func (m *Model) notificationBatchAction(operation types.NotificationBatchOperation) []Action {
+	request, ok := m.selectedBatchRequest(operation)
+	if !ok {
+		return []Action{ActionShowToast{Message: "Select at least one notification"}}
+	}
+	return []Action{ActionApplyNotificationBatch{Request: request}}
 }
 
 func (m *Model) handleNavigationKeys(msg tea.KeyMsg) []Action {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -108,6 +108,17 @@ func (m *Model) renderFooter() string {
 	if m.ui.resourceFilter != "" {
 		filters = m.styles.FilterChip.Render(" " + m.ui.resourceFilter + " ")
 	}
+	if m.selectionMode {
+		selection := fmt.Sprintf(" SELECT %d ", len(m.selectedIDs))
+		if m.batchPending {
+			selection = fmt.Sprintf(" APPLYING %d ", len(m.selectedIDs))
+		} else if m.batchUncertain {
+			selection = fmt.Sprintf(" UNCERTAIN %d ", len(m.selectedIDs))
+		} else if m.batchRefreshPending {
+			selection = fmt.Sprintf(" REFRESH %d ", len(m.selectedIDs))
+		}
+		filters += m.styles.PriorityMed.Render(selection)
+	}
 
 	// 3. Bridge Health Indicator
 	bridge := "[NATIVE]"

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -3,6 +3,9 @@ package types
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/hirakiuc/gh-orbit/internal/models"
@@ -24,6 +27,108 @@ var (
 // ConnectedSyncTimeout bounds connected/native sync requests so stalled MCP calls
 // surface a recoverable error instead of leaving the UI in a permanent syncing state.
 var ConnectedSyncTimeout = 15 * time.Second
+
+const MaxBatchNotifications = 100
+
+// NotificationBatchOperation is an explicit desired state for a notification batch.
+type NotificationBatchOperation string
+
+const (
+	NotificationBatchRead      NotificationBatchOperation = "read"
+	NotificationBatchUnread    NotificationBatchOperation = "unread"
+	NotificationBatchHandled   NotificationBatchOperation = "handled"
+	NotificationBatchUnhandled NotificationBatchOperation = "unhandled"
+)
+
+func (o NotificationBatchOperation) Valid() bool {
+	switch o {
+	case NotificationBatchRead, NotificationBatchUnread, NotificationBatchHandled, NotificationBatchUnhandled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o NotificationBatchOperation) RequiresRemoteRead() bool {
+	return o == NotificationBatchRead
+}
+
+type NotificationBatchRequest struct {
+	Operation NotificationBatchOperation `json:"operation"`
+	IDs       []string                   `json:"ids"`
+}
+
+// NormalizeNotificationBatchRequest validates, deduplicates, and sorts a batch
+// without echoing malformed values in returned errors.
+func NormalizeNotificationBatchRequest(request NotificationBatchRequest) (NotificationBatchRequest, error) {
+	if !request.Operation.Valid() {
+		return NotificationBatchRequest{}, fmt.Errorf("unsupported notification batch operation")
+	}
+	if len(request.IDs) == 0 {
+		return NotificationBatchRequest{}, fmt.Errorf("notification batch IDs are required")
+	}
+
+	seen := make(map[string]struct{}, len(request.IDs))
+	ids := make([]string, 0, len(request.IDs))
+	for index, rawID := range request.IDs {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			return NotificationBatchRequest{}, fmt.Errorf("notification batch ID at position %d is empty", index)
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) > MaxBatchNotifications {
+		return NotificationBatchRequest{}, fmt.Errorf("notification batch has %d distinct IDs; maximum is %d", len(ids), MaxBatchNotifications)
+	}
+	sort.Strings(ids)
+	return NotificationBatchRequest{Operation: request.Operation, IDs: ids}, nil
+}
+
+type NotificationBatchStatus string
+
+const (
+	NotificationBatchRejected      NotificationBatchStatus = "rejected"
+	NotificationBatchCommitted     NotificationBatchStatus = "committed"
+	NotificationBatchCommitUnknown NotificationBatchStatus = "commit_unknown"
+)
+
+type NotificationBatchReconciliation string
+
+const (
+	NotificationBatchAuthoritative         NotificationBatchReconciliation = "authoritative"
+	NotificationBatchReconciliationPending NotificationBatchReconciliation = "pending"
+)
+
+type NotificationRemoteStatus string
+
+const (
+	NotificationRemoteNotRequired  NotificationRemoteStatus = "not_required"
+	NotificationRemoteSucceeded    NotificationRemoteStatus = "succeeded"
+	NotificationRemoteFailed       NotificationRemoteStatus = "failed"
+	NotificationRemoteCanceled     NotificationRemoteStatus = "canceled"
+	NotificationRemoteNotAttempted NotificationRemoteStatus = "not_attempted"
+)
+
+type NotificationBatchItemResult struct {
+	ID        string                   `json:"id"`
+	Status    NotificationRemoteStatus `json:"status"`
+	ErrorCode string                   `json:"error_code,omitempty"`
+	Err       error                    `json:"-"`
+}
+
+type NotificationBatchResult struct {
+	Status         NotificationBatchStatus         `json:"status"`
+	Reconciliation NotificationBatchReconciliation `json:"reconciliation"`
+	Request        NotificationBatchRequest        `json:"request"`
+	Outcomes       []NotificationBatchItemResult   `json:"outcomes"`
+	Notifications  []triage.NotificationWithState  `json:"-"`
+	Toast          string                          `json:"toast,omitempty"`
+	Err            error                           `json:"-"`
+}
 
 // BridgeStatus represents the functional state of the native system bridge.
 type BridgeStatus string
@@ -192,6 +297,7 @@ type PriorityUpdateResult struct {
 type TUIBackend interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
 	Sync(ctx context.Context, force bool) (models.RateLimitInfo, error)
+	ApplyNotificationBatch(ctx context.Context, request NotificationBatchRequest) (NotificationBatchResult, error)
 	SetRead(ctx context.Context, id string, read bool) (ReadUpdateResult, error)
 	SetHandled(ctx context.Context, id string, handled bool) (HandledUpdateResult, error)
 	SetPriority(ctx context.Context, id string, priority int) (PriorityUpdateResult, error)
@@ -210,6 +316,7 @@ type TUIBackend interface {
 // standalone and connected mode.
 type NotificationStore interface {
 	ListNotifications(ctx context.Context) ([]triage.NotificationWithState, error)
+	ApplyNotificationBatchLocally(ctx context.Context, request NotificationBatchRequest) error
 	SetReadLocally(ctx context.Context, id string, isRead bool) error
 	SetHandledLocally(ctx context.Context, id string, isHandled bool) error
 	// MarkReadLocally preserves the deprecated coupled read/handled mutation for legacy MCP clients.

--- a/internal/types/api.go
+++ b/internal/types/api.go
@@ -30,6 +30,8 @@ var ConnectedSyncTimeout = 15 * time.Second
 
 const MaxBatchNotifications = 100
 
+const maxNotificationBatchErrorCodeLength = 64
+
 // NotificationBatchOperation is an explicit desired state for a notification batch.
 type NotificationBatchOperation string
 
@@ -128,6 +130,94 @@ type NotificationBatchResult struct {
 	Notifications  []triage.NotificationWithState  `json:"-"`
 	Toast          string                          `json:"toast,omitempty"`
 	Err            error                           `json:"-"`
+}
+
+// ValidateNotificationBatchResult verifies that a committed result is a
+// complete, self-consistent response for the expected normalized request.
+// Transport adapters must treat validation failures as commit-unknown rather
+// than replaying a mutation whose commit state is no longer knowable.
+func ValidateNotificationBatchResult(expected NotificationBatchRequest, result NotificationBatchResult) error {
+	normalizedExpected, err := NormalizeNotificationBatchRequest(expected)
+	if err != nil {
+		return fmt.Errorf("invalid expected notification batch: %w", err)
+	}
+	normalizedResult, err := NormalizeNotificationBatchRequest(result.Request)
+	if err != nil || !notificationBatchRequestsEqual(result.Request, normalizedResult) {
+		return errors.New("notification batch result request is not normalized")
+	}
+	if !notificationBatchRequestsEqual(normalizedExpected, normalizedResult) {
+		return errors.New("notification batch result request does not match")
+	}
+	if result.Status != NotificationBatchCommitted {
+		return errors.New("notification batch result is not committed")
+	}
+	if result.Reconciliation != NotificationBatchAuthoritative && result.Reconciliation != NotificationBatchReconciliationPending {
+		return errors.New("notification batch result reconciliation is invalid")
+	}
+	if len(result.Outcomes) != len(normalizedExpected.IDs) {
+		return errors.New("notification batch result outcome count does not match")
+	}
+
+	expectedIDs := make(map[string]struct{}, len(normalizedExpected.IDs))
+	for _, id := range normalizedExpected.IDs {
+		expectedIDs[id] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(result.Outcomes))
+	for _, outcome := range result.Outcomes {
+		if _, ok := expectedIDs[outcome.ID]; !ok {
+			return errors.New("notification batch result contains an unknown target")
+		}
+		if _, duplicate := seen[outcome.ID]; duplicate {
+			return errors.New("notification batch result contains a duplicate target")
+		}
+		seen[outcome.ID] = struct{}{}
+		if err := validateNotificationBatchOutcome(normalizedExpected.Operation, outcome); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func notificationBatchRequestsEqual(left, right NotificationBatchRequest) bool {
+	if left.Operation != right.Operation || len(left.IDs) != len(right.IDs) {
+		return false
+	}
+	for index := range left.IDs {
+		if left.IDs[index] != right.IDs[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateNotificationBatchOutcome(operation NotificationBatchOperation, outcome NotificationBatchItemResult) error {
+	if len(outcome.ErrorCode) > maxNotificationBatchErrorCodeLength {
+		return errors.New("notification batch result error code is too long")
+	}
+	if !operation.RequiresRemoteRead() {
+		if outcome.Status != NotificationRemoteNotRequired || outcome.ErrorCode != "" {
+			return errors.New("notification batch result contradicts a local-only operation")
+		}
+		return nil
+	}
+
+	switch outcome.Status {
+	case NotificationRemoteSucceeded, NotificationRemoteNotAttempted:
+		if outcome.ErrorCode != "" {
+			return errors.New("notification batch result has an unexpected error code")
+		}
+	case NotificationRemoteFailed:
+		if outcome.ErrorCode != "remote_failed" {
+			return errors.New("notification batch result has an invalid failure code")
+		}
+	case NotificationRemoteCanceled:
+		if outcome.ErrorCode != "canceled" {
+			return errors.New("notification batch result has an invalid cancellation code")
+		}
+	default:
+		return errors.New("notification batch result has an invalid remote status")
+	}
+	return nil
 }
 
 // BridgeStatus represents the functional state of the native system bridge.

--- a/internal/types/notification_batch_test.go
+++ b/internal/types/notification_batch_test.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeNotificationBatchRequest(t *testing.T) {
+	t.Run("trims deduplicates and sorts", func(t *testing.T) {
+		request, err := NormalizeNotificationBatchRequest(NotificationBatchRequest{
+			Operation: NotificationBatchHandled,
+			IDs:       []string{" b ", "a", "b"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, request.IDs)
+	})
+
+	for _, test := range []struct {
+		name    string
+		request NotificationBatchRequest
+	}{
+		{name: "unsupported operation", request: NotificationBatchRequest{Operation: "toggle", IDs: []string{"1"}}},
+		{name: "empty IDs", request: NotificationBatchRequest{Operation: NotificationBatchRead}},
+		{name: "empty member", request: NotificationBatchRequest{Operation: NotificationBatchRead, IDs: []string{"1", " "}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NormalizeNotificationBatchRequest(test.request)
+			assert.Error(t, err)
+		})
+	}
+
+	t.Run("limit applies after deduplication", func(t *testing.T) {
+		ids := make([]string, 0, MaxBatchNotifications+1)
+		for index := 0; index < MaxBatchNotifications; index++ {
+			ids = append(ids, fmt.Sprintf("%03d", index))
+		}
+		ids = append(ids, "000")
+		_, err := NormalizeNotificationBatchRequest(NotificationBatchRequest{Operation: NotificationBatchRead, IDs: ids})
+		require.NoError(t, err)
+
+		ids[len(ids)-1] = "overflow"
+		_, err = NormalizeNotificationBatchRequest(NotificationBatchRequest{Operation: NotificationBatchRead, IDs: ids})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Related Issue

Fixes #476

## Objective

Make high-volume notification triage practical by supporting ID-stable multiple selection and deterministic batch read, unread, handled, and unhandled operations in the main TUI.

## Changes

- Add configurable selection-mode, membership, and batch-operation keybindings with selected-count and row rendering.
- Add normalized batch contracts, transactional SQLite updates, bounded GitHub read execution, and aggregate partial-failure outcomes.
- Add standalone and MCP parity with strict structured-result validation and engine-owned rate-limit reporting.
- Preserve retry and commit-unknown recovery through generation-correlated, event-driven reconciliation reloads.
- Add deterministic coverage for concurrency, cancellation, queue limits, persistence boundaries, MCP integrity, TUI lifecycle, and recovery ordering.

## Verification Results

- make check
- go test -race -count=1 ./internal/api ./internal/tui ./internal/db ./internal/types ./internal/engine
- git diff --check main...HEAD
- Strategy implementation review: SIGN-OFF

## Checklist

- [x] All checks passed (make check)
- [x] Documentation updated where applicable