### PR TITLE
fix: require Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hirakiuc/gh-orbit
 
-go 1.26
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Summary

- require Go 1.26.6 as the module's minimum toolchain version
- prevent `actions/setup-go` from satisfying the broad Go 1.26 directive with vulnerable Go 1.26.5
- keep the security fix separate from Dependabot PR #488

## Context

The Ubuntu test job for #488 passed build and tests, then failed `govulncheck` because the selected Go 1.26.5 standard library contained five reachable vulnerabilities. Each reported finding is fixed in Go 1.26.6.

Failed job: https://github.com/hirakiuc/gh-orbit/actions/runs/31852437723/job/94930573626?pr=488

After this PR merges, Dependabot PR #488 should be refreshed so its merge commit inherits the secure Go version floor.

## Validation

- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
  - zero reachable vulnerabilities
- `make check`
  - Go formatting, linting, documentation checks, and tests passed
  - native Swift formatting, linting, build, and tests passed
